### PR TITLE
fix: Codex cloud PR handoff and QA issue refs

### DIFF
--- a/.agents/skills/_functional-qa/scripts/qa_runtime.py
+++ b/.agents/skills/_functional-qa/scripts/qa_runtime.py
@@ -86,6 +86,17 @@ def parse_issue_ref(raw: str) -> dict[str, Any]:
             "issue_ref": f"{repo_name_with_owner()}#{issue_number}",
         }
 
+    repo_ref_match = re.fullmatch(r"([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)#(\d+)", cleaned)
+    if repo_ref_match:
+        repo = repo_ref_match.group(1)
+        issue_number = int(repo_ref_match.group(2))
+        return {
+            "kind": "github",
+            "repo": repo,
+            "number": issue_number,
+            "issue_ref": f"{repo}#{issue_number}",
+        }
+
     url_match = re.fullmatch(r"https://github\.com/([^/]+/[^/]+)/issues/(\d+)", cleaned)
     if url_match:
         repo = url_match.group(1)
@@ -115,8 +126,23 @@ def fetch_issue(target: str) -> dict[str, Any] | None:
             "gh",
             "api",
             f"repos/{parsed['repo']}/issues/{parsed['number']}",
-        ]
+        ],
+        allow_failure=True,
     )
+    if result.returncode != 0:
+        return {
+            "repo": parsed["repo"],
+            "number": parsed["number"],
+            "issue_ref": parsed["issue_ref"],
+            "title": target if target != parsed["issue_ref"] else parsed["issue_ref"],
+            "body": "",
+            "html_url": f"https://github.com/{parsed['repo']}/issues/{parsed['number']}",
+            "labels": [],
+            "created_at": None,
+            "updated_at": None,
+            "metadata_resolution": "fallback-no-gh",
+        }
+
     payload = json.loads(result.stdout)
     return {
         "repo": parsed["repo"],
@@ -400,11 +426,27 @@ def summary_is_placeholder(summary_text: str) -> bool:
     return "Replace this scaffold with the actual validation findings." in summary_text
 
 
+def validate_outcome_combination(verdict: str, repro_status: str, fix_status: str) -> None:
+    if verdict == "fixed" and fix_status != "fixed":
+        raise ValueError("`verdict=fixed` requires `fix_status=fixed`.")
+    if fix_status == "fixed" and repro_status != "not-reproduced":
+        raise ValueError("`fix_status=fixed` requires `repro_status=not-reproduced`.")
+    if fix_status == "still-reproduces" and repro_status != "reproduced":
+        raise ValueError("`fix_status=still-reproduces` requires `repro_status=reproduced`.")
+    if verdict == "not-reproduced" and repro_status == "reproduced":
+        raise ValueError("`verdict=not-reproduced` cannot be paired with `repro_status=reproduced`.")
+    if verdict in {"reproduced", "partially-reproduced", "ambiguous", "blocked"} and fix_status == "fixed":
+        raise ValueError(f"`verdict={verdict}` cannot be paired with `fix_status=fixed`.")
+
+
 def init_run(args: argparse.Namespace) -> int:
     issue_payload = fetch_issue(args.target)
     raw_text = args.target
     if issue_payload:
-        raw_text = f"{issue_payload['title']}\n\n{issue_payload['body']}"
+        if issue_payload.get("title") or issue_payload.get("body"):
+            raw_text = f"{issue_payload['title']}\n\n{issue_payload['body']}".strip()
+        else:
+            raw_text = args.target
     classification = classify_issue_text(raw_text)
     override = classification_override(issue_payload["issue_ref"] if issue_payload else None)
     if override:
@@ -488,6 +530,7 @@ def finalize_run(args: argparse.Namespace) -> int:
         raise ValueError(f"Unsupported fix status: {args.fix_status}")
     if args.issue_accuracy not in ISSUE_ACCURACY:
         raise ValueError(f"Unsupported issue accuracy: {args.issue_accuracy}")
+    validate_outcome_combination(verdict, args.repro_status, args.fix_status)
 
     run["functional"]["verdict"] = verdict
     run["functional"]["repro_status"] = args.repro_status

--- a/.agents/skills/_functional-qa/templates/codex-cloud-comment.md.tmpl
+++ b/.agents/skills/_functional-qa/templates/codex-cloud-comment.md.tmpl
@@ -5,12 +5,18 @@ Requirements:
 - Use the functional QA workflow to validate the issue before changing code.
 - Start with `{{initial_skill}}`.
 - Follow with `{{follow_up_skills}}`.
+- Treat this existing PR branch as the only delivery branch.
+- Commit and push all code changes back to this PR branch.
+- Do not create a follow-up PR, alternate branch, or call `make_pr`.
 - Keep the scope to {{issue_ref}} only.
 - Save or update artifacts under `artifacts/qa-runs/functional-qa/...`.
+- When you invoke the QA runtime, keep the target as the exact GitHub issue ref `{{issue_ref}}` so `issue_ref` stays populated even if GitHub CLI access is limited.
 - If the issue is ambiguous, use `trace-ui-state` before making a speculative fix.
 - After the code change, re-run validation and verify the fix before claiming success.
 - Update the GitHub issue and this PR with repro, root cause, fix summary, and verification outcome.
+- Do not cite gitignored artifacts as GitHub blob links unless those files were actually committed to this branch.
 - If blocked by missing assets, missing setup, or local-only context, stop and report the exact blocker.
+- The final deliverable must be a non-empty diff on this PR branch.
 
 Repo guidance:
 - Recommended worktree lane: `{{worktree_id}}` (`{{worktree_branch}}`)

--- a/.agents/skills/_functional-qa/templates/codex-cloud-pr-body.md.tmpl
+++ b/.agents/skills/_functional-qa/templates/codex-cloud-pr-body.md.tmpl
@@ -10,12 +10,15 @@
 ## Scope
 
 Work only on {{issue_ref}} in this PR.
+This PR branch is the delivery branch. Do not create a follow-up PR or alternate delivery branch.
 
 ## Repo workflow
 
 - Start with `{{initial_skill}}`
 - Follow with `{{follow_up_skills}}`
 - Keep artifacts in `artifacts/qa-runs/functional-qa/...`
+- Keep the QA runtime target as the exact GitHub issue ref `{{issue_ref}}`
+- Push commits back to this PR branch only
 
 ## Readiness note
 
@@ -33,6 +36,7 @@ Post the generated task comment from:
 2. Fix only the confirmed issue scope.
 3. Re-run validation, including `--verify-fix` when applicable.
 4. Update the GitHub issue and this PR with evidence and verification outcome.
+5. Ensure the PR has a real code diff before declaring success.
 
 ## Final acceptance
 

--- a/.agents/skills/work-github-issues/SKILL.md
+++ b/.agents/skills/work-github-issues/SKILL.md
@@ -67,6 +67,7 @@ python .agents/skills/_functional-qa/scripts/codex_cloud_queue.py
    ```
 
    Use the generated branch names, PR body files, and `@codex` task comments as the execution handoff.
+   In an existing PR context, the current PR branch is the only delivery branch: push fixes back to it, do not create a follow-up PR, and do not rely on gitignored artifacts as committed evidence.
 
 ## Output requirements
 

--- a/docs/codex-cloud-issue-runbook.md
+++ b/docs/codex-cloud-issue-runbook.md
@@ -95,6 +95,7 @@ This remains local-only until shared asset hosting exists for the looping backdr
    - create a dedicated branch
    - open a draft PR
    - post the generated `@codex` comment
+   - treat that PR branch as the only delivery branch
 4. Let Codex:
    - validate the issue
    - fix the code
@@ -103,6 +104,13 @@ This remains local-only until shared asset hosting exists for the looping backdr
 5. Ask for `@codex review` on the PR if wanted.
 6. Have a human review and merge.
 7. Move to the next batch after the earlier batch stabilizes.
+
+Important delivery rule:
+
+1. The existing draft PR is the delivery vehicle.
+2. Codex must push commits back to that PR branch.
+3. Codex must not create a follow-up PR or alternate delivery branch.
+4. Artifact directories under `artifacts/qa-runs/` are gitignored, so evidence must be summarized in the PR/issue update instead of being cited as committed GitHub blob links unless those files were intentionally checked in.
 
 ## Acceptance policy
 


### PR DESCRIPTION
## Summary
- preserve GitHub issue refs for owner/repo#number targets in functional QA runs
- fall back gracefully when gh issue lookup is unavailable so publish metadata is not dropped
- tighten Codex cloud PR instructions so workers must push back to the current PR branch and stop creating follow-up PRs
- reject inconsistent QA finalize states such as fixed + still reproduces

## How to test
- python -m py_compile .agents/skills/_functional-qa/scripts/qa_runtime.py .agents/skills/_functional-qa/scripts/codex_cloud_queue.py .agents/skills/_functional-qa/scripts/issue_router.py
- python .agents/skills/_functional-qa/scripts/qa_runtime.py init-run validate-issue --target "erniesg/tong#11"
- verify parse_issue_ref("erniesg/tong#11") resolves to a GitHub issue ref and finalize-run rejects fixed+reproduced combinations
