### PR TITLE
fix: issue #15 - Font sizes too small across the game (partially fixed)

### DIFF
--- a/apps/client/app/globals.css
+++ b/apps/client/app/globals.css
@@ -13,11 +13,11 @@
   --mint-soft: #d1fae5;
 
   /* Game type scale — single place to tune all in-game font sizes */
-  --game-text-xs: 13px;   /* meta labels, secondary info */
-  --game-text-sm: 14px;   /* HUD scores, subtle labels */
-  --game-text-base: 16px; /* body text, descriptions, prompts */
-  --game-text-lg: 19px;   /* dialogue, whisper body, instructions */
-  --game-text-xl: 22px;   /* headings, speaker names */
+  --game-text-xs: 0.8125rem;   /* meta labels, secondary info */
+  --game-text-sm: 0.875rem;   /* HUD scores, subtle labels */
+  --game-text-base: 1rem; /* body text, descriptions, prompts */
+  --game-text-lg: 1.1875rem;   /* dialogue, whisper body, instructions */
+  --game-text-xl: 1.375rem;   /* headings, speaker names */
 }
 
 * {

--- a/apps/client/app/globals.css
+++ b/apps/client/app/globals.css
@@ -2031,7 +2031,7 @@ button.nav-link:hover {
 }
 
 .vn-choices__prompt {
-  font-size: var(--game-text-base);
+  font-size: 1rem;
   color: rgba(255, 255, 255, 0.7);
   margin-bottom: 0.75rem;
   line-height: 1.4;
@@ -2067,7 +2067,7 @@ button.nav-link:hover {
 }
 
 .vn-choices__text {
-  font-size: var(--game-text-base);
+  font-size: 1rem;
   font-weight: 500;
   line-height: 1.5;
 }
@@ -2075,7 +2075,7 @@ button.nav-link:hover {
 .vn-choices__subtext {
   display: block;
   margin-top: 0.15rem;
-  font-size: var(--game-text-sm);
+  font-size: 0.875rem;
   color: rgba(255, 255, 255, 0.45);
 }
 

--- a/apps/client/app/globals.css
+++ b/apps/client/app/globals.css
@@ -13,11 +13,11 @@
   --mint-soft: #d1fae5;
 
   /* Game type scale — single place to tune all in-game font sizes */
-  --game-text-xs: 12px;   /* meta labels, secondary info */
-  --game-text-sm: 13px;   /* HUD scores, subtle labels */
-  --game-text-base: 15px; /* body text, descriptions, prompts */
-  --game-text-lg: 17px;   /* dialogue, whisper body, instructions */
-  --game-text-xl: 20px;   /* headings, speaker names */
+  --game-text-xs: 13px;   /* meta labels, secondary info */
+  --game-text-sm: 14px;   /* HUD scores, subtle labels */
+  --game-text-base: 16px; /* body text, descriptions, prompts */
+  --game-text-lg: 19px;   /* dialogue, whisper body, instructions */
+  --game-text-xl: 22px;   /* headings, speaker names */
 }
 
 * {
@@ -1875,7 +1875,7 @@ button.nav-link:hover {
 }
 
 .dialogue-translation {
-  font-size: 0.75rem;
+  font-size: var(--game-text-sm);
   color: rgba(255, 255, 255, 0.6);
   margin: 0.25rem 0 0;
   text-shadow: 0 1px 3px rgba(0, 0, 0, 0.8);
@@ -1988,7 +1988,7 @@ button.nav-link:hover {
 
 .exercise-float-continue {
   color: rgba(255,255,255,0.7);
-  font-size: 12px;
+  font-size: var(--game-text-sm);
   text-align: center;
   padding: 8px 16px;
   text-shadow:
@@ -2031,7 +2031,7 @@ button.nav-link:hover {
 }
 
 .vn-choices__prompt {
-  font-size: 0.9rem;
+  font-size: var(--game-text-base);
   color: rgba(255, 255, 255, 0.7);
   margin-bottom: 0.75rem;
   line-height: 1.4;
@@ -2067,7 +2067,7 @@ button.nav-link:hover {
 }
 
 .vn-choices__text {
-  font-size: 0.95rem;
+  font-size: var(--game-text-base);
   font-weight: 500;
   line-height: 1.5;
 }
@@ -2075,7 +2075,7 @@ button.nav-link:hover {
 .vn-choices__subtext {
   display: block;
   margin-top: 0.15rem;
-  font-size: 0.75rem;
+  font-size: var(--game-text-sm);
   color: rgba(255, 255, 255, 0.45);
 }
 
@@ -5910,4 +5910,3 @@ button.nav-link:hover {
     grid-template-columns: 1fr;
   }
 }
-


### PR DESCRIPTION
### Motivation

- Improve mobile readability by addressing the type-scale regressions reported in `erniesg/tong#15` so dialogue, whisper, HUD, and choice text are comfortably legible in gameplay.

### Description

- Bumped the shared game type-scale variables in `apps/client/app/globals.css` to larger defaults (`--game-text-xs: 0.8125rem`, `--game-text-sm: 0.875rem`, `--game-text-base: 1rem`, `--game-text-lg: 1.1875rem`, `--game-text-xl: 1.375rem`).
- Replaced remaining small hard-coded sizes in core game surfaces with the shared scale so the type scale is consistent and tunable from one place.
- Preserved explicit `rem` sizing for VN choice prompt/text/subtext so browser default font size and text-only zoom still scale that interaction proportionally.
- Change is additive and scoped to client UI styling in the `client-shell` lane.

### Testing

- Ran `npm run demo:smoke` after the final VN choice typography follow-up in `d129c06`.
- Captured a fresh browser-backed verification run with the functional QA flow: `functional-qa-validate-issue-20260314T082534Z-erniesg-tong-15`.
- Used the same `iPhone 14` viewport and the same `/game?phase=hangout&demo=TONG-JUDGE-DEMO&qa_trace=1` route on both branches, opening the HUD before capture so the comparison frame is identical.
- Baseline proof frame: local `main` at `1a9a3fa` on `http://localhost:3100`.
- Post-fix proof frame: this PR branch at `d129c06` on `http://localhost:3000`.

### Reviewer Evidence

Matched mobile hangout captures with identical viewport and proof state. `main` is on the left; PR `#33` is on the right.

Full-frame comparison:

![Full-frame before and after comparison](https://runs.tong.berlayar.ai/qa-runs/functional-qa/erniesg-tong-15/functional-qa-validate-issue-20260314T082534Z-erniesg-tong-15/screenshots/comparison-full-frame.png)

Focused comparison of the speaker, dialogue, and continue region:

![Focused dialogue-region comparison](https://runs.tong.berlayar.ai/qa-runs/functional-qa/erniesg-tong-15/functional-qa-validate-issue-20260314T082534Z-erniesg-tong-15/screenshots/comparison-dialogue-focus.png)

Raw captures and bundle:

- Before: [before-hud-open.png](https://runs.tong.berlayar.ai/qa-runs/functional-qa/erniesg-tong-15/functional-qa-validate-issue-20260314T082534Z-erniesg-tong-15/screenshots/before-hud-open.png)
- After: [after-hud-open.png](https://runs.tong.berlayar.ai/qa-runs/functional-qa/erniesg-tong-15/functional-qa-validate-issue-20260314T082534Z-erniesg-tong-15/screenshots/after-hud-open.png)
- QA summary: [summary.md](https://runs.tong.berlayar.ai/qa-runs/functional-qa/erniesg-tong-15/functional-qa-validate-issue-20260314T082534Z-erniesg-tong-15/summary.md)
- Capture metadata: [comparison-capture.json](https://runs.tong.berlayar.ai/qa-runs/functional-qa/erniesg-tong-15/functional-qa-validate-issue-20260314T082534Z-erniesg-tong-15/logs/comparison-capture.json)
- Uploaded manifest: [manifest.json](https://runs.tong.berlayar.ai/qa-runs/functional-qa/erniesg-tong-15/functional-qa-validate-issue-20260314T082534Z-erniesg-tong-15/manifest.json)

Follow-up issue `#34` still tracks automating this comparison-panel workflow so future visual PRs generate these assets by default.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b51011c934832a92c4e2602509ea5d)
