### PR TITLE
chore: clarify issue closure guidance

### DIFF
--- a/.agents/skills/_functional-qa/templates/codex-cloud-pr-notes.md.tmpl
+++ b/.agents/skills/_functional-qa/templates/codex-cloud-pr-notes.md.tmpl
@@ -18,6 +18,7 @@
 3. Code changes limited to the confirmed issue scope
 4. `--verify-fix` outcome
 5. Evidence summary inline in the PR body or task summary
+6. Issue closure plan: use a closing keyword only if this PR fully resolves the issue; otherwise keep it open and say why
 
 ## Reviewer-Facing Evidence
 

--- a/.agents/skills/_functional-qa/templates/codex-cloud-task.md.tmpl
+++ b/.agents/skills/_functional-qa/templates/codex-cloud-task.md.tmpl
@@ -16,6 +16,7 @@ Requirements:
 - If the issue is ambiguous, use `trace-ui-state` before making a speculative fix.
 - After the code change, re-run validation and verify the fix before claiming success.
 - Summarize evidence inline in the final task output and in the PR body.
+- If the issue is fully resolved by the PR, include a GitHub closing keyword for {{issue_ref}} in the PR body. If the work is partial, explicitly say so and do not close the issue.
 - Reviewer-facing evidence requirement: {{reviewer_evidence_expectation}}
 - If the runtime cannot publish that evidence directly into GitHub after PR creation, return paste-ready markdown with the exact comparison images or links a human should add to the PR.
 - Do not rely on `gh` CLI or shell-level `git push`.

--- a/.agents/skills/publish-issue-update/SKILL.md
+++ b/.agents/skills/publish-issue-update/SKILL.md
@@ -60,6 +60,12 @@ Use the invocation arguments as either:
    - include a focused comparison crop when the changed region is small or text-heavy
    - if automation cannot generate those assets yet, say that explicitly and return paste-ready markdown that points to the raw before/after screenshots instead of pretending the evidence is complete
 
+8. Handle issue closure explicitly after publication:
+
+- if the issue is fully fixed and this PR is the complete resolution, use a PR body closing keyword such as `Fixes #123` or close the issue immediately after merge
+- if the issue is only partially fixed, keep it open and state the remaining scope directly in the issue update
+- do not close umbrella or epic issues from a narrow child PR unless the umbrella itself is truly complete
+
 ## Output requirements
 
 - Never publish a run with a placeholder summary.

--- a/.agents/skills/validate-issue/SKILL.md
+++ b/.agents/skills/validate-issue/SKILL.md
@@ -91,6 +91,12 @@ If the invocation includes `--verify-fix`, replay the most recent matching valid
    python .agents/skills/_functional-qa/scripts/qa_runtime.py publish-github --run-dir <RUN_DIR>
    ```
 
+11. Decide issue closure status deliberately:
+
+- if the verification run shows the issue is fully fixed and no follow-up scope remains, mark the PR or merge plan to close the issue
+- if the work is only partial, keep the issue open and rewrite the issue or publish update so the remaining scope is unambiguous
+- for epic or umbrella issues, prefer landing and closing child issues instead of closing the umbrella from a narrow PR
+
 ## Output requirements
 
 - Use the artifact bundle under `artifacts/qa-runs/functional-qa/...`.

--- a/.agents/skills/work-github-issues/SKILL.md
+++ b/.agents/skills/work-github-issues/SKILL.md
@@ -71,6 +71,12 @@ python .agents/skills/_functional-qa/scripts/codex_cloud_queue.py
    Do not assume shell-level `git push` or `gh` is available inside the cloud task.
    Use GitHub comments for `@codex review` or explicitly manual experiments, not as the default implementation path.
 
+8. Be explicit about issue closure:
+
+- if the PR fully resolves the issue, plan to close it via a GitHub closing keyword in the PR body such as `Fixes #123` or by closing it immediately after merge
+- if the PR is only a partial fix, an audit pass, or work under an umbrella or epic issue, do not close the issue; update the issue title/body or comment so the remaining scope is explicit
+- do not treat merged PRs as sufficient evidence that an issue should close unless the merged scope actually matches the current issue text
+
 ## Output requirements
 
 - Keep the queue plan under `artifacts/qa-runs/functional-qa/issue-queue/...`.


### PR DESCRIPTION
### Motivation

- Make the issue workflow explicit about when a merged PR should close an issue and when it should not.
- Prevent partial fixes and umbrella issues from being treated like complete resolutions.

### Description

- Updated the GitHub-issue workflow skill to require an explicit closure decision instead of assuming merge implies close.
- Updated validation and publish guidance so partial fixes keep the issue open and explain the remaining scope.
- Updated the Codex Cloud task and PR-note templates to require a closing keyword only when a PR fully resolves the issue.
- Left blanket `auto_close_fixed` policy unchanged, because the repo still has legitimate partial-fix and umbrella cases such as `#15` and `#29`.

### Testing

- `python .agents/skills/_functional-qa/scripts/codex_cloud_queue.py plan`
- `python .agents/skills/_functional-qa/scripts/issue_router.py plan 35`
