### PR TITLE
chore: reprioritize issue queue after #15 partial fix

### DIFF
--- a/.agents/skills/_functional-qa/config/codex-cloud.json
+++ b/.agents/skills/_functional-qa/config/codex-cloud.json
@@ -48,8 +48,8 @@
   "current_batches": [
     {
       "id": "batch-1",
-      "description": "First cloud wave: prioritized fixes for readability, Block Crush transition polish, and streaming behavior.",
-      "issues": ["#15", "#18", "#19"]
+      "description": "First cloud wave: Block Crush transition polish and dialogue streaming after the initial readability pass landed.",
+      "issues": ["#18", "#19"]
     },
     {
       "id": "batch-parallel",
@@ -63,8 +63,8 @@
     },
     {
       "id": "batch-3",
-      "description": "Reserved for future cleanup after the focused fixes land.",
-      "issues": []
+      "description": "Later follow-up cleanup after the focused fixes land, including residual readability audit work.",
+      "issues": ["#15"]
     },
     {
       "id": "batch-local",
@@ -99,11 +99,11 @@
     },
     {
       "match": "#15",
-      "cloud_mode": "cloud-ready",
-      "batch": "batch-1",
+      "cloud_mode": "cloud-ready-with-local-proof",
+      "batch": "batch-3",
       "depends_on": [],
-      "needs_final_local_acceptance": false,
-      "reason": "Type-scale cleanup is now intentionally prioritized as the first readability pass."
+      "needs_final_local_acceptance": true,
+      "reason": "PR #33 landed the first readability pass on March 14, 2026, so the remaining scope is a lower-priority audit and mobile-device follow-up rather than the next blocking fix."
     },
     {
       "match": "#17",
@@ -117,9 +117,9 @@
       "match": "#18",
       "cloud_mode": "cloud-ready",
       "batch": "batch-1",
-      "depends_on": ["#15"],
+      "depends_on": [],
       "needs_final_local_acceptance": false,
-      "reason": "This Block Crush transition bug stays in the priority wave, but it should follow the shared-style pass on #15 to reduce client-shell churn."
+      "reason": "The shared readability pass from #15 already landed in PR #33, so this transition bug is now the next client-shell fix in the priority wave."
     },
     {
       "match": "#34",

--- a/docs/codex-cloud-issue-runbook.md
+++ b/docs/codex-cloud-issue-runbook.md
@@ -55,12 +55,11 @@ The generator emits these as suggestions; it does not modify GitHub labels direc
 
 ### Batch 1
 
-- `#15` type-scale cleanup
 - `#18` Block Crush review flash
 - `#19` fake streaming after loading
 
-These are the first cloud wave because they are the explicitly prioritized fixes for readability, Block Crush transition polish, and streaming behavior.
-Run them serially in the listed order. They all sit in the `client-shell` lane, and `#15` touches shared `apps/client/app/globals.css`.
+These are the first cloud wave because they are the next unresolved `client-shell` bugs after the initial readability pass for `#15` landed in PR `#33` on March 14, 2026.
+Run them serially in the listed order. They both sit in the `client-shell` lane, and `#19` should follow `#18` so the queue stays serialized through the transition and streaming work.
 
 ### Batch parallel
 
@@ -81,9 +80,9 @@ These should follow Batch 1 because they are the remaining onboarding and gamepl
 
 ### Batch 3
 
-- no current issue is assigned here
+- `#15` residual readability audit and mobile-device follow-up
 
-Keep this batch available for future cleanup work if more cross-cutting polish issues are opened later.
+Keep this batch for lower-priority cleanup work after the focused bug-fix waves land. `#15` stays open because PR `#33` only completed the first readability pass; the remaining audit scope should not block `#18` or `#19`.
 
 ### Local-only for now
 


### PR DESCRIPTION
## Summary
- move `#18` and `#19` to the front of the Codex cloud queue now that the first readability pass for `#15` landed in `#33`
- keep `#15` open as a later readability audit with final local/mobile proof instead of treating it as the next blocking client-shell item
- update the cloud runbook text to match the new ordering and rationale

## How To Test
1. Run `python .agents/skills/_functional-qa/scripts/codex_cloud_queue.py plan 15 18 19` and confirm `cloud-plan.md` lists batch 1 as `#18`, then `#19`, with `#15` in batch 3.
2. Run `python .agents/skills/_functional-qa/scripts/codex_cloud_queue.py plan` and confirm the open-issues plan starts batch 1 with `#18` and `#19`.
3. Run `python .agents/skills/_functional-qa/scripts/issue_router.py plan 15 18 19` and confirm `#15` still routes as a separate shared-style audit while `#18` and `#19` stay in the `client-shell` lane.
