### PR TITLE
fix: complete game typography audit

### DIFF
--- a/apps/client/app/game/page.tsx
+++ b/apps/client/app/game/page.tsx
@@ -1645,17 +1645,17 @@ export default function GamePage() {
       <div className="scene-root" style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
         <div className="game-frame" style={{ display: 'flex', flexDirection: 'column', background: 'var(--color-bg-dark, #1a1a2e)' }}>
           <div style={{ padding: '12px 16px', borderBottom: '1px solid rgba(255,255,255,0.1)', display: 'flex', alignItems: 'center', gap: 8 }}>
-            <span style={{ color: 'var(--color-accent-gold, #d4a843)', fontWeight: 700, fontSize: 14, letterSpacing: 1 }}>DEV</span>
-            <span style={{ color: '#fff', fontWeight: 600, fontSize: 15 }}>Exercise Tester</span>
+            <span style={{ color: 'var(--color-accent-gold, #d4a843)', fontWeight: 700, fontSize: 'var(--game-text-sm)', letterSpacing: 1 }}>DEV</span>
+            <span style={{ color: '#fff', fontWeight: 600, fontSize: 'var(--game-text-base)' }}>Exercise Tester</span>
           </div>
 
           <div style={{ padding: 16, display: 'flex', flexDirection: 'column', gap: 12 }}>
-            <label style={{ color: '#ccc', fontSize: 13 }}>
+            <label style={{ color: '#ccc', fontSize: 'var(--game-text-sm)' }}>
               Exercise type
               <select
                 value={devExType}
                 onChange={(e) => { setDevExType(e.target.value); setDevExercise(null); setDevLastResult(null); }}
-                style={{ display: 'block', width: '100%', marginTop: 4, padding: '8px 10px', borderRadius: 6, border: '1px solid rgba(255,255,255,0.15)', background: 'rgba(255,255,255,0.08)', color: '#fff', fontSize: 14 }}
+                style={{ display: 'block', width: '100%', minHeight: 44, marginTop: 4, padding: '8px 10px', borderRadius: 6, border: '1px solid rgba(255,255,255,0.15)', background: 'rgba(255,255,255,0.08)', color: '#fff', fontSize: 'var(--game-text-base)' }}
               >
                 {DEV_EX_TYPES.map((t) => (
                   <option key={t} value={t}>{t.replace('_', ' ')}</option>
@@ -1663,12 +1663,12 @@ export default function GamePage() {
               </select>
             </label>
 
-            <label style={{ color: '#ccc', fontSize: 13 }}>
+            <label style={{ color: '#ccc', fontSize: 'var(--game-text-sm)' }}>
               Objective
               <select
                 value={devObjective}
                 onChange={(e) => { setDevObjective(e.target.value); setDevExercise(null); setDevLastResult(null); }}
-                style={{ display: 'block', width: '100%', marginTop: 4, padding: '8px 10px', borderRadius: 6, border: '1px solid rgba(255,255,255,0.15)', background: 'rgba(255,255,255,0.08)', color: '#fff', fontSize: 14 }}
+                style={{ display: 'block', width: '100%', minHeight: 44, marginTop: 4, padding: '8px 10px', borderRadius: 6, border: '1px solid rgba(255,255,255,0.15)', background: 'rgba(255,255,255,0.08)', color: '#fff', fontSize: 'var(--game-text-base)' }}
               >
                 {DEV_OBJECTIVES.map((o) => (
                   <option key={o.id} value={o.id}>{o.label} ({o.id})</option>
@@ -1685,19 +1685,19 @@ export default function GamePage() {
                 setDevExercise(ex);
                 setDevLastResult(null);
               }}
-              style={{ padding: '10px 16px', borderRadius: 8, border: 'none', background: 'var(--color-accent-gold, #d4a843)', color: '#1a1a2e', fontWeight: 700, fontSize: 14, cursor: 'pointer' }}
+              style={{ minHeight: 44, padding: '10px 16px', borderRadius: 8, border: 'none', background: 'var(--color-accent-gold, #d4a843)', color: '#1a1a2e', fontWeight: 700, fontSize: 'var(--game-text-base)', cursor: 'pointer' }}
             >
               Generate {devExType.replace('_', ' ')}
             </button>
 
             {devLastResult && (
-              <div style={{ padding: '8px 12px', borderRadius: 6, background: devLastResult.correct ? 'rgba(76,175,80,0.2)' : 'rgba(244,67,54,0.2)', color: devLastResult.correct ? '#4caf50' : '#f44336', fontSize: 13, fontWeight: 600 }}>
+              <div style={{ padding: '8px 12px', borderRadius: 6, background: devLastResult.correct ? 'rgba(76,175,80,0.2)' : 'rgba(244,67,54,0.2)', color: devLastResult.correct ? '#4caf50' : '#f44336', fontSize: 'var(--game-text-sm)', fontWeight: 600 }}>
                 {devLastResult.correct ? 'Correct' : 'Incorrect'} — {devLastResult.id}
               </div>
             )}
 
             {devExercise && (
-              <div style={{ fontSize: 11, color: '#888', wordBreak: 'break-all', maxHeight: 120, overflow: 'auto', padding: '6px 8px', borderRadius: 4, background: 'rgba(255,255,255,0.03)' }}>
+              <div style={{ fontSize: 'var(--game-text-xs)', color: '#888', wordBreak: 'break-all', maxHeight: 120, overflow: 'auto', padding: '6px 8px', borderRadius: 4, background: 'rgba(255,255,255,0.03)' }}>
                 <strong>Data:</strong> {JSON.stringify(devExercise, null, 0).slice(0, 500)}
               </div>
             )}
@@ -1728,12 +1728,12 @@ export default function GamePage() {
           <div style={{ padding: '10px 14px', display: 'flex', alignItems: 'center', gap: 8, background: 'rgba(0,0,0,0.3)', borderBottom: '1px solid rgba(255,255,255,0.1)' }}>
             <button
               onClick={() => setPhase('city_map')}
-              style={{ background: 'none', border: 'none', color: '#fff', fontSize: 18, cursor: 'pointer', padding: '4px 8px' }}
+              style={{ background: 'none', border: 'none', color: '#fff', fontSize: 18, cursor: 'pointer', width: 44, height: 44, padding: 0 }}
               type="button"
             >
               &larr;
             </button>
-            <span style={{ color: '#fff', fontWeight: 600, fontSize: 15 }}>
+            <span style={{ color: '#fff', fontWeight: 600, fontSize: 'var(--game-text-base)' }}>
               {CITY_NAMES[city]?.local ?? ''} {CITY_NAMES[city]?.en ?? ''} &middot; {t(`loc_${location}`, learnUiLang)}
             </span>
           </div>

--- a/apps/client/app/globals.css
+++ b/apps/client/app/globals.css
@@ -1900,6 +1900,8 @@ button.nav-link:hover {
   backdrop-filter: blur(14px);
   border-radius: 16px;
   color: var(--color-text);
+  font-size: var(--game-text-base);
+  line-height: 1.5;
 }
 
 /* Full radius when inside modal */
@@ -2688,6 +2690,7 @@ button.nav-link:hover {
 /* Translation sub-text inside a bubble — uses a muted but readable dark tone */
 .msg-bubble__translation {
   color: rgba(0, 0, 0, 0.55);
+  font-size: var(--game-text-sm);
 }
 
 /* ── Bubble tails ───────────────────────────────────────────── */
@@ -2725,7 +2728,7 @@ button.nav-link:hover {
 }
 
 .teaching-card__title {
-  font-size: 13px;
+  font-size: var(--game-text-sm);
   font-weight: 600;
   color: var(--msg-npc-text, #1a1a1a);
   margin-bottom: 8px;
@@ -2742,6 +2745,7 @@ button.nav-link:hover {
   flex-direction: column;
   align-items: center;
   gap: 2px;
+  min-height: 44px;
   padding: 6px 4px;
   border-radius: 8px;
   background: rgba(255, 255, 255, 0.6);
@@ -2760,7 +2764,7 @@ button.nav-link:hover {
 }
 
 .teaching-card__roman {
-  font-size: 11px;
+  font-size: var(--game-text-sm);
   color: rgba(0, 0, 0, 0.55);
 }
 
@@ -2768,7 +2772,7 @@ button.nav-link:hover {
 .feedback-bubble {
   padding: 8px 12px;
   border-radius: var(--msg-bubble-radius, 18px);
-  font-size: 14px;
+  font-size: var(--game-text-base);
   line-height: 1.5;
   max-width: 280px;
 }
@@ -3209,14 +3213,18 @@ button.nav-link:hover {
 
 .sentence-builder__tile {
   padding: 6px 12px;
+  min-height: 44px;
   border-radius: 8px;
   background: var(--msg-accent, #f0c040);
   color: var(--msg-accent-text, #1a1a1a);
-  font-size: 14px;
+  font-size: var(--game-text-base);
   font-weight: 500;
   cursor: pointer;
   transition: all 0.15s;
   user-select: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .sentence-builder__tile--placed {
@@ -3231,7 +3239,7 @@ button.nav-link:hover {
 
 /* ── Fill-blank exercise ────────────────────────────────────── */
 .fill-blank__sentence {
-  font-size: 18px;
+  font-size: var(--game-text-lg);
   line-height: 1.6;
   text-align: center;
   margin-bottom: 12px;
@@ -3258,7 +3266,7 @@ button.nav-link:hover {
   padding: 8px;
   border-radius: 8px;
   background: var(--msg-teaching-bg, #fff9e6);
-  font-size: 12px;
+  font-size: var(--game-text-sm);
   color: rgba(0, 0, 0, 0.7);
 }
 
@@ -3280,13 +3288,14 @@ button.nav-link:hover {
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 10px 14px;
+  min-height: 48px;
+  padding: 12px 14px;
   border-radius: 12px;
   border: 1.5px solid rgba(0, 0, 0, 0.12);
   background: transparent;
   cursor: pointer;
   transition: all 0.15s;
-  font-size: 14px;
+  font-size: var(--game-text-base);
 }
 
 .pron-select__option:hover:not(:disabled) {
@@ -3516,20 +3525,20 @@ button.nav-link:hover {
 }
 
 .location-drawer__name-local {
-  font-size: 20px;
+  font-size: var(--game-text-xl);
   font-weight: 700;
   color: #fff;
   letter-spacing: 0.02em;
 }
 
 .location-drawer__name-en {
-  font-size: 12px;
+  font-size: var(--game-text-sm);
   color: rgba(255, 255, 255, 0.45);
   font-weight: 500;
 }
 
 .location-drawer__badge {
-  font-size: 12px;
+  font-size: var(--game-text-sm);
   color: var(--color-accent-gold, #f0c040);
   background: rgba(240, 192, 64, 0.12);
   border: 1px solid rgba(240, 192, 64, 0.2);
@@ -3547,11 +3556,12 @@ button.nav-link:hover {
 /* Base button */
 .location-drawer__btn {
   width: 100%;
-  padding: 10px 14px;
+  min-height: 48px;
+  padding: 12px 14px;
   border-radius: 12px;
   border: none;
   outline: none;
-  font-size: 14px;
+  font-size: var(--game-text-base);
   font-weight: 600;
   cursor: pointer;
   transition: all 0.15s;
@@ -3590,19 +3600,19 @@ button.nav-link:hover {
 }
 
 .location-drawer__btn-label {
-  font-size: 14px;
+  font-size: var(--game-text-base);
   font-weight: 700;
 }
 
 .location-drawer__btn-desc {
-  font-size: 10px;
+  font-size: var(--game-text-sm);
   font-weight: 400;
   opacity: 0.6;
 }
 
 .location-drawer__sp-cost {
   margin-left: 8px;
-  font-size: 11px;
+  font-size: var(--game-text-sm);
   opacity: 0.7;
   font-weight: 500;
 }
@@ -3636,7 +3646,7 @@ button.nav-link:hover {
 }
 
 .location-drawer__hint {
-  font-size: 12px;
+  font-size: var(--game-text-sm);
   color: rgba(255, 255, 255, 0.45);
   text-align: center;
   margin-top: 4px;
@@ -3652,8 +3662,9 @@ button.nav-link:hover {
   display: flex;
   align-items: center;
   width: 100%;
+  min-height: 44px;
   padding: 8px 14px;
-  font-size: 12px;
+  font-size: var(--game-text-sm);
   font-weight: 600;
   color: rgba(255, 255, 255, 0.5);
   cursor: pointer;
@@ -3671,6 +3682,7 @@ button.nav-link:hover {
   display: flex;
   flex-direction: column;
   gap: 2px;
+  min-height: 44px;
   padding: 8px 12px;
   border-radius: 10px;
   background: rgba(255, 255, 255, 0.06);
@@ -3683,7 +3695,7 @@ button.nav-link:hover {
 }
 
 .location-drawer__session-summary {
-  font-size: 13px;
+  font-size: var(--game-text-sm);
   color: rgba(255, 255, 255, 0.8);
   white-space: nowrap;
   overflow: hidden;
@@ -3691,7 +3703,7 @@ button.nav-link:hover {
 }
 
 .location-drawer__session-meta {
-  font-size: 11px;
+  font-size: var(--game-text-xs);
   color: rgba(255, 255, 255, 0.4);
 }
 
@@ -4762,7 +4774,7 @@ button.nav-link:hover {
   color: white;
   padding: 4px 12px;
   border-radius: 8px;
-  font-size: 0.75rem;
+  font-size: var(--game-text-sm);
   white-space: nowrap;
   animation: bc-toast-in 0.2s ease-out, bc-toast-out 0.3s 1.2s ease-in forwards;
   pointer-events: none;
@@ -4806,13 +4818,13 @@ button.nav-link:hover {
 }
 
 .bc-overlay__romanization {
-  font-size: 1rem;
+  font-size: var(--game-text-base);
   color: var(--color-text-muted, #aaa);
   margin-top: 0.5rem;
 }
 
 .bc-overlay__meaning {
-  font-size: 1.5rem;
+  font-size: var(--game-text-xl);
   font-weight: 600;
   color: var(--color-accent-gold, #f0c040);
   margin-top: 0.5rem;

--- a/apps/client/components/city-map/LocationSheet.tsx
+++ b/apps/client/components/city-map/LocationSheet.tsx
@@ -115,7 +115,7 @@ export function LocationSheet({
                   type="button"
                 >
                   {t('past_sessions', lang)} ({locationSessions.length})
-                  <span style={{ marginLeft: 'auto', fontSize: 10, opacity: 0.6 }}>{showPastSessions ? '▲' : '▼'}</span>
+                  <span style={{ marginLeft: 'auto', fontSize: 'var(--game-text-xs)', opacity: 0.6 }}>{showPastSessions ? '▲' : '▼'}</span>
                 </button>
                 {showPastSessions && (
                   <div className="location-drawer__session-list">

--- a/apps/client/components/exercises/BlockCrush.tsx
+++ b/apps/client/components/exercises/BlockCrush.tsx
@@ -895,7 +895,7 @@ export function BlockCrush({ exercise, onResult }: Props) {
           {displayMeaning ? (
             <div className="bc-overlay__meaning">{displayMeaning}</div>
           ) : (
-            <div className="bc-overlay__meaning" style={{ fontSize: '1rem', opacity: 0.6 }}>
+            <div className="bc-overlay__meaning" style={{ fontSize: 'var(--game-text-base)', opacity: 0.6 }}>
               {exercise.components.map((c) => c.piece).join(' + ')} → {exercise.targetChar}
             </div>
           )}

--- a/apps/client/components/exercises/DragDrop.tsx
+++ b/apps/client/components/exercises/DragDrop.tsx
@@ -57,7 +57,7 @@ export function DragDrop({ exercise, onResult }: Props) {
 
   return (
     <div className="exercise-card p-5">
-      <p className="text-lg font-medium mb-2 m-0">{exercise.prompt}</p>
+      <p className="text-[length:var(--game-text-lg)] font-medium mb-2 m-0">{exercise.prompt}</p>
 
       {/* Items (source) */}
       <div className="flex flex-wrap gap-2 mb-4">
@@ -72,7 +72,7 @@ export function DragDrop({ exercise, onResult }: Props) {
               key={item.id}
               onClick={() => handleItemClick(item.id)}
               className={cn(
-                'rounded-lg px-3 py-2 text-ko transition border',
+                'rounded-lg min-h-[44px] px-3 py-2 text-ko text-[length:var(--game-text-base)] transition border',
                 !isPlaced && !isSelected && 'border-white/20 hover:border-white/40',
                 isSelected && 'border-[var(--color-primary)] bg-[var(--color-primary)]/20 scale-105',
                 isPlaced && !submitted && 'border-white/30 opacity-50',
@@ -99,13 +99,13 @@ export function DragDrop({ exercise, onResult }: Props) {
               key={target.id}
               onClick={() => handleTargetClick(target.id)}
               className={cn(
-                'rounded-lg border border-dashed px-3 py-4 text-center transition min-h-[60px]',
+                'rounded-lg border border-dashed px-3 py-4 text-center text-[length:var(--game-text-base)] transition min-h-[60px]',
                 !placedItemData && selectedItem && 'border-[var(--color-primary)]/50 hover:bg-[var(--color-primary)]/5',
                 !placedItemData && !selectedItem && 'border-white/20',
                 placedItemData && 'border-white/30 bg-white/5'
               )}
             >
-              <span className="text-xs text-[var(--color-text-muted)] block">{target.label}</span>
+              <span className="text-[length:var(--game-text-sm)] text-[var(--color-text-muted)] block">{target.label}</span>
               {placedItemData && (
                 <span className="text-ko font-medium">{placedItemData.text}</span>
               )}
@@ -119,7 +119,7 @@ export function DragDrop({ exercise, onResult }: Props) {
           onClick={handleSubmit}
           disabled={Object.keys(mapping).length < exercise.items.length}
           className={cn(
-            'w-full rounded-lg py-3 font-semibold transition',
+            'w-full min-h-[44px] rounded-lg py-3 text-[length:var(--game-text-base)] font-semibold transition',
             Object.keys(mapping).length === exercise.items.length
               ? 'bg-[var(--color-primary)] hover:bg-[var(--color-primary-dark)]'
               : 'bg-white/10 text-[var(--color-text-muted)] cursor-not-allowed'
@@ -130,7 +130,7 @@ export function DragDrop({ exercise, onResult }: Props) {
       ) : (
         <div
           className={cn(
-            'rounded-lg px-4 py-3 text-center font-semibold',
+            'rounded-lg px-4 py-3 text-center text-[length:var(--game-text-base)] font-semibold',
             allCorrect ? 'bg-[var(--color-accent-green)]/20 text-[var(--color-accent-green)]' : 'bg-red-500/20 text-red-400'
           )}
         >

--- a/apps/client/components/exercises/ErrorCorrection.tsx
+++ b/apps/client/components/exercises/ErrorCorrection.tsx
@@ -33,7 +33,7 @@ export function ErrorCorrection({ exercise, onResult }: Props) {
 
   return (
     <div className="exercise-card p-5">
-      <p className="text-lg font-medium mb-4 m-0">{exercise.prompt}</p>
+      <p className="text-[length:var(--game-text-lg)] font-medium mb-4 m-0">{exercise.prompt}</p>
 
       {/* Sentence with tappable words */}
       <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, justifyContent: 'center', marginBottom: 16 }}>
@@ -43,7 +43,7 @@ export function ErrorCorrection({ exercise, onResult }: Props) {
             onClick={() => !submitted && setSelectedWord(idx)}
             disabled={submitted}
             className={cn(
-              'px-3 py-2 rounded-lg text-lg font-medium transition text-ko',
+              'min-h-[44px] px-3 py-2 rounded-lg text-[length:var(--game-text-lg)] font-medium transition text-ko',
               !submitted && selectedWord === idx && 'bg-red-500/30 text-red-300 ring-2 ring-red-400',
               !submitted && selectedWord !== idx && 'bg-white/10 text-[var(--color-text)]',
               submitted && idx === exercise.errorWordIndex && 'bg-red-500/30 text-red-300 line-through',
@@ -58,7 +58,7 @@ export function ErrorCorrection({ exercise, onResult }: Props) {
       {/* Correction options */}
       {selectedWord !== null && (
         <>
-          <p className="text-sm text-[var(--color-text-muted)] mb-2 m-0">{t('replace_with', lang)}</p>
+          <p className="text-[length:var(--game-text-base)] text-[var(--color-text-muted)] mb-2 m-0">{t('replace_with', lang)}</p>
           <div className="pron-select__options">
             {exercise.options.map((opt) => {
               const isThis = selectedCorrection === opt.id;
@@ -85,7 +85,7 @@ export function ErrorCorrection({ exercise, onResult }: Props) {
       )}
 
       {submitted && exercise.explanation && (
-        <p className="mt-3 text-sm text-[var(--color-text-muted)] m-0">{exercise.explanation}</p>
+        <p className="mt-3 text-[length:var(--game-text-base)] text-[var(--color-text-muted)] m-0">{exercise.explanation}</p>
       )}
 
       {!submitted && (
@@ -93,7 +93,7 @@ export function ErrorCorrection({ exercise, onResult }: Props) {
           onClick={handleSubmit}
           disabled={selectedWord === null || !selectedCorrection}
           className={cn(
-            'mt-4 w-full rounded-lg py-3 font-semibold transition',
+            'mt-4 w-full min-h-[44px] rounded-lg py-3 text-[length:var(--game-text-base)] font-semibold transition',
             selectedWord !== null && selectedCorrection
               ? 'bg-[var(--color-accent-gold)] text-[#1a1a2e] hover:brightness-110'
               : 'bg-white/10 text-[var(--color-text-muted)] cursor-not-allowed',
@@ -106,7 +106,7 @@ export function ErrorCorrection({ exercise, onResult }: Props) {
       {submitted && (
         <div
           className={cn(
-            'mt-4 rounded-lg px-4 py-3 text-center text-sm',
+            'mt-4 rounded-lg px-4 py-3 text-center text-[length:var(--game-text-base)]',
             isCorrect
               ? 'bg-[var(--color-accent-green)]/20 text-[var(--color-accent-green)]'
               : 'bg-red-500/20 text-red-400',

--- a/apps/client/components/exercises/FillBlank.tsx
+++ b/apps/client/components/exercises/FillBlank.tsx
@@ -29,7 +29,7 @@ export function FillBlank({ exercise, onResult }: Props) {
 
   return (
     <div className="exercise-card p-5">
-      <p className="text-lg font-medium mb-4 text-ko m-0">{exercise.prompt}</p>
+      <p className="text-[length:var(--game-text-lg)] font-medium mb-4 text-ko m-0">{exercise.prompt}</p>
 
       {/* Sentence with blank */}
       <div className="fill-blank__sentence text-ko">
@@ -53,7 +53,7 @@ export function FillBlank({ exercise, onResult }: Props) {
               key={opt.id}
               onClick={() => !submitted && setSelected(opt.id)}
               className={cn(
-                'rounded-lg px-4 py-3 text-center transition-all border text-ko',
+                'rounded-lg min-h-[44px] px-4 py-3 text-center text-[length:var(--game-text-base)] transition-all border text-ko',
                 !submitted && !isThis && 'border-white/10 hover:border-white/30',
                 !submitted && isThis && 'border-[var(--color-accent-gold)] bg-[var(--color-accent-gold)]/10',
                 showCorrect && 'border-[var(--color-accent-green)] bg-[var(--color-accent-green)]/10',
@@ -76,7 +76,7 @@ export function FillBlank({ exercise, onResult }: Props) {
           onClick={handleSubmit}
           disabled={!selected}
           className={cn(
-            'mt-4 w-full rounded-lg py-3 font-semibold transition',
+            'mt-4 w-full min-h-[44px] rounded-lg py-3 text-[length:var(--game-text-base)] font-semibold transition',
             selected
               ? 'bg-[var(--color-accent-gold)] text-[#1a1a2e] hover:brightness-110'
               : 'bg-white/10 text-[var(--color-text-muted)] cursor-not-allowed',
@@ -89,7 +89,7 @@ export function FillBlank({ exercise, onResult }: Props) {
       {submitted && (
         <div
           className={cn(
-            'mt-4 rounded-lg px-4 py-3 text-center text-sm',
+            'mt-4 rounded-lg px-4 py-3 text-center text-[length:var(--game-text-base)]',
             isCorrect
               ? 'bg-[var(--color-accent-green)]/20 text-[var(--color-accent-green)]'
               : 'bg-red-500/20 text-red-400',

--- a/apps/client/components/exercises/FreeInput.tsx
+++ b/apps/client/components/exercises/FreeInput.tsx
@@ -37,10 +37,10 @@ export function FreeInput({ exercise, onResult }: Props) {
 
   return (
     <div className="exercise-card p-5">
-      <p className="text-lg font-medium mb-4 m-0">{exercise.prompt}</p>
+      <p className="text-[length:var(--game-text-lg)] font-medium mb-4 m-0">{exercise.prompt}</p>
 
       {exercise.hint && (
-        <p className="text-sm text-[var(--color-text-muted)] mb-3 m-0">{exercise.hint}</p>
+        <p className="text-[length:var(--game-text-base)] text-[var(--color-text-muted)] mb-3 m-0">{exercise.hint}</p>
       )}
 
       <input
@@ -50,7 +50,7 @@ export function FreeInput({ exercise, onResult }: Props) {
         onKeyDown={handleKeyDown}
         disabled={submitted}
         placeholder={t('type_answer', lang)}
-        className="w-full rounded-lg px-4 py-3 text-lg text-ko"
+        className="w-full min-h-[44px] rounded-lg px-4 py-3 text-[length:var(--game-text-lg)] text-ko"
         style={{
           background: 'rgba(255,255,255,0.08)',
           border: '2px solid rgba(255,255,255,0.15)',
@@ -62,7 +62,7 @@ export function FreeInput({ exercise, onResult }: Props) {
       />
 
       {submitted && exercise.explanation && (
-        <p className="mt-3 text-sm text-[var(--color-text-muted)] m-0">{exercise.explanation}</p>
+        <p className="mt-3 text-[length:var(--game-text-base)] text-[var(--color-text-muted)] m-0">{exercise.explanation}</p>
       )}
 
       {!submitted && (
@@ -70,7 +70,7 @@ export function FreeInput({ exercise, onResult }: Props) {
           onClick={handleSubmit}
           disabled={!input.trim()}
           className={cn(
-            'mt-4 w-full rounded-lg py-3 font-semibold transition',
+            'mt-4 w-full min-h-[44px] rounded-lg py-3 text-[length:var(--game-text-base)] font-semibold transition',
             input.trim()
               ? 'bg-[var(--color-accent-gold)] text-[#1a1a2e] hover:brightness-110'
               : 'bg-white/10 text-[var(--color-text-muted)] cursor-not-allowed',
@@ -83,7 +83,7 @@ export function FreeInput({ exercise, onResult }: Props) {
       {submitted && (
         <div
           className={cn(
-            'mt-4 rounded-lg px-4 py-3 text-center text-sm',
+            'mt-4 rounded-lg px-4 py-3 text-center text-[length:var(--game-text-base)]',
             isCorrect
               ? 'bg-[var(--color-accent-green)]/20 text-[var(--color-accent-green)]'
               : 'bg-red-500/20 text-red-400',

--- a/apps/client/components/exercises/Matching.tsx
+++ b/apps/client/components/exercises/Matching.tsx
@@ -144,7 +144,7 @@ export function Matching({ exercise, onResult }: Props) {
 
   return (
     <div className="exercise-card p-5">
-      <p className="text-lg font-medium mb-3 m-0">{exercise.prompt}</p>
+      <p className="text-[length:var(--game-text-lg)] font-medium mb-3 m-0">{exercise.prompt}</p>
 
       {/* Word bank — audio mode shows speaker icons, text mode shows text */}
       <div className="flex flex-wrap gap-2 mb-4">
@@ -160,7 +160,7 @@ export function Matching({ exercise, onResult }: Props) {
               disabled={submitted}
               className={cn(
                 'rounded-lg font-medium transition border text-white',
-                isAudioMode ? 'px-4 py-3 flex items-center gap-2' : 'px-3 py-2 text-base',
+                isAudioMode ? 'min-h-[44px] px-4 py-3 flex items-center gap-2 text-[length:var(--game-text-base)]' : 'min-h-[44px] px-3 py-2 text-[length:var(--game-text-base)]',
                 !isPlaced && !isSelected && 'border-white/40 bg-white/8 hover:border-white/60 hover:bg-white/12',
                 isSelected && 'border-[var(--color-primary)] bg-[var(--color-primary)]/20 scale-105',
                 isPlaced && 'opacity-30 border-white/10 bg-transparent cursor-default',
@@ -171,7 +171,7 @@ export function Matching({ exercise, onResult }: Props) {
               {isAudioMode ? (
                 <>
                   <SpeakerIcon active={isThisPlaying} />
-                  {submitted && <span className="text-sm">{pair.right}</span>}
+                  {submitted && <span className="text-[length:var(--game-text-sm)]">{pair.right}</span>}
                 </>
               ) : (
                 pair.right
@@ -209,7 +209,7 @@ export function Matching({ exercise, onResult }: Props) {
                 submitted && 'cursor-default'
               )}
             >
-              <span className="text-ko text-base text-white font-medium min-w-[80px]">
+              <span className="text-ko text-[length:var(--game-text-base)] text-white font-medium min-w-[80px]">
                 {pair.left}
               </span>
               <div className={cn(
@@ -224,22 +224,22 @@ export function Matching({ exercise, onResult }: Props) {
                   isAudioMode ? (
                     <span className={cn('flex items-center gap-2', isWrong && 'text-red-400')}>
                       <SpeakerIcon size={18} active={playing === matchedRightIdx} />
-                      {submitted && <span className="text-sm">{matchedPair?.right}</span>}
+                      {submitted && <span className="text-[length:var(--game-text-sm)]">{matchedPair?.right}</span>}
                     </span>
                   ) : (
                     <span className={cn(
-                      'text-ko font-medium text-white text-base',
+                      'text-ko font-medium text-white text-[length:var(--game-text-base)]',
                       isWrong && 'line-through text-red-400'
                     )}>{matchedPair?.right}</span>
                   )
                 ) : (
-                  <span className="text-xs text-[var(--color-text-muted)]">
+                  <span className="text-[length:var(--game-text-sm)] text-[var(--color-text-muted)]">
                     {isSlotSelected ? t('pick_word', lang) : selectedWord !== null ? t('tap_to_place', lang) : ''}
                   </span>
                 )}
               </div>
               {isWrong && (
-                <span className="text-xs text-[var(--color-accent-green)] whitespace-nowrap flex items-center gap-1">
+                <span className="text-[length:var(--game-text-sm)] text-[var(--color-accent-green)] whitespace-nowrap flex items-center gap-1">
                   {isAudioMode ? (
                     <button
                       type="button"
@@ -254,7 +254,7 @@ export function Matching({ exercise, onResult }: Props) {
                 </span>
               )}
               {isCorrect && (
-                <span className="text-[var(--color-accent-green)] text-sm">✓</span>
+                <span className="text-[var(--color-accent-green)] text-[length:var(--game-text-base)]">✓</span>
               )}
             </div>
           );
@@ -263,7 +263,7 @@ export function Matching({ exercise, onResult }: Props) {
 
       {submitted && (
         <div className={cn(
-          'rounded-lg px-4 py-3 text-center font-semibold mb-3',
+          'rounded-lg px-4 py-3 text-center text-[length:var(--game-text-base)] font-semibold mb-3',
           isAllCorrect
             ? 'bg-[var(--color-accent-green)]/20 text-[var(--color-accent-green)]'
             : 'bg-red-500/20 text-red-400'
@@ -280,7 +280,7 @@ export function Matching({ exercise, onResult }: Props) {
           onClick={handleSubmit}
           disabled={!allFilled}
           className={cn(
-            'w-full rounded-lg py-3 font-semibold transition',
+            'w-full min-h-[44px] rounded-lg py-3 text-[length:var(--game-text-base)] font-semibold transition',
             allFilled
               ? 'bg-[var(--color-primary)] hover:bg-[var(--color-primary-dark)]'
               : 'bg-white/10 text-[var(--color-text-muted)] cursor-not-allowed'

--- a/apps/client/components/exercises/MultipleChoice.tsx
+++ b/apps/client/components/exercises/MultipleChoice.tsx
@@ -50,7 +50,7 @@ export function MultipleChoice({ exercise, onResult }: Props) {
 
   return (
     <div className="exercise-card" style={{ padding: 20 }}>
-      <p style={{ fontSize: 18, fontWeight: 500, marginBottom: 16, margin: '0 0 16px' }}>{exercise.prompt}</p>
+      <p style={{ fontSize: 'var(--game-text-lg)', fontWeight: 500, marginBottom: 16, margin: '0 0 16px' }}>{exercise.prompt}</p>
 
       <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
         {exercise.options.map((opt) => {
@@ -66,8 +66,9 @@ export function MultipleChoice({ exercise, onResult }: Props) {
                 ...getOptionStyle(opt.id),
                 borderRadius: 12,
                 padding: '12px 16px',
+                minHeight: 44,
                 textAlign: 'left',
-                fontSize: 16,
+                fontSize: 'var(--game-text-base)',
                 color: '#fff',
                 display: 'flex',
                 alignItems: 'center',
@@ -78,10 +79,10 @@ export function MultipleChoice({ exercise, onResult }: Props) {
             >
               <span>{opt.text}</span>
               {submitted && isCorrectOption && (
-                <span style={{ color: '#34d399', fontSize: 12, fontWeight: 600 }}>{t('correct', lang)}</span>
+                <span style={{ color: '#34d399', fontSize: 'var(--game-text-sm)', fontWeight: 600 }}>{t('correct', lang)}</span>
               )}
               {showWrong && (
-                <span style={{ color: '#f87171', fontSize: 12, fontWeight: 600 }}>{t('your_pick', lang)}</span>
+                <span style={{ color: '#f87171', fontSize: 'var(--game-text-sm)', fontWeight: 600 }}>{t('your_pick', lang)}</span>
               )}
             </button>
           );
@@ -89,7 +90,7 @@ export function MultipleChoice({ exercise, onResult }: Props) {
       </div>
 
       {submitted && exercise.explanation && (
-        <p style={{ marginTop: 12, fontSize: 13, color: 'rgba(255,255,255,0.55)' }}>{exercise.explanation}</p>
+        <p style={{ marginTop: 12, fontSize: 'var(--game-text-base)', color: 'rgba(255,255,255,0.55)' }}>{exercise.explanation}</p>
       )}
 
       {!submitted && (
@@ -101,8 +102,9 @@ export function MultipleChoice({ exercise, onResult }: Props) {
             width: '100%',
             borderRadius: 12,
             padding: '13px 0',
+            minHeight: 44,
             fontWeight: 600,
-            fontSize: 15,
+            fontSize: 'var(--game-text-base)',
             border: 'none',
             cursor: selected ? 'pointer' : 'not-allowed',
             background: selected ? '#f0c040' : 'rgba(255,255,255,0.08)',
@@ -121,7 +123,7 @@ export function MultipleChoice({ exercise, onResult }: Props) {
             borderRadius: 12,
             padding: '12px 16px',
             textAlign: 'center',
-            fontSize: 14,
+            fontSize: 'var(--game-text-base)',
             fontWeight: 600,
             background: isCorrect ? 'rgba(52, 211, 153, 0.15)' : 'rgba(239, 68, 68, 0.15)',
             color: isCorrect ? '#34d399' : '#f87171',

--- a/apps/client/components/exercises/PatternRecognition.tsx
+++ b/apps/client/components/exercises/PatternRecognition.tsx
@@ -27,7 +27,7 @@ export function PatternRecognition({ exercise, onResult }: Props) {
 
   return (
     <div className="exercise-card p-5">
-      <p className="text-lg font-medium mb-4 text-ko m-0">{exercise.prompt}</p>
+      <p className="text-[length:var(--game-text-lg)] font-medium mb-4 text-ko m-0">{exercise.prompt}</p>
 
       <div className="pron-select__options">
         {exercise.pairs.map((pair, idx) => {
@@ -47,14 +47,14 @@ export function PatternRecognition({ exercise, onResult }: Props) {
               )}
             >
               <span className="text-ko" style={{ fontSize: 24, marginRight: 12 }}>{pair.chars}</span>
-              <span className="text-sm text-[var(--color-text-muted)]">{pair.explanation}</span>
+              <span className="text-[length:var(--game-text-base)] text-[var(--color-text-muted)]">{pair.explanation}</span>
             </button>
           );
         })}
       </div>
 
       {submitted && exercise.explanation && (
-        <p className="mt-3 text-sm text-[var(--color-text-muted)] m-0">{exercise.explanation}</p>
+        <p className="mt-3 text-[length:var(--game-text-base)] text-[var(--color-text-muted)] m-0">{exercise.explanation}</p>
       )}
 
       {!submitted && (
@@ -62,7 +62,7 @@ export function PatternRecognition({ exercise, onResult }: Props) {
           onClick={handleSubmit}
           disabled={selected === null}
           className={cn(
-            'mt-4 w-full rounded-lg py-3 font-semibold transition',
+            'mt-4 w-full min-h-[44px] rounded-lg py-3 text-[length:var(--game-text-base)] font-semibold transition',
             selected !== null
               ? 'bg-[var(--color-accent-gold)] text-[#1a1a2e] hover:brightness-110'
               : 'bg-white/10 text-[var(--color-text-muted)] cursor-not-allowed',
@@ -75,7 +75,7 @@ export function PatternRecognition({ exercise, onResult }: Props) {
       {submitted && (
         <div
           className={cn(
-            'mt-4 rounded-lg px-4 py-3 text-center text-sm',
+            'mt-4 rounded-lg px-4 py-3 text-center text-[length:var(--game-text-base)]',
             isCorrect
               ? 'bg-[var(--color-accent-green)]/20 text-[var(--color-accent-green)]'
               : 'bg-red-500/20 text-red-400',

--- a/apps/client/components/exercises/PronunciationSelect.tsx
+++ b/apps/client/components/exercises/PronunciationSelect.tsx
@@ -92,7 +92,7 @@ export function PronunciationSelect({ exercise, onResult }: Props) {
 
   return (
     <div className="exercise-card p-5">
-      <p className="text-lg font-medium mb-3 m-0">{exercise.prompt}</p>
+      <p className="text-[length:var(--game-text-lg)] font-medium mb-3 m-0">{exercise.prompt}</p>
 
       {/* Target character displayed prominently */}
       <div className="pron-select__target" style={{ cursor: 'default' }}>
@@ -129,14 +129,14 @@ export function PronunciationSelect({ exercise, onResult }: Props) {
                 <span style={{ display: 'flex', alignItems: 'baseline', gap: 8, flex: 1 }}>
                   <span className="text-ko" style={{ fontSize: '1.25rem' }}>{opt.label}</span>
                   {opt.romanization && (
-                    <span style={{ fontSize: 13, opacity: 0.5 }}>{opt.romanization}</span>
+                    <span style={{ fontSize: 'var(--game-text-sm)', opacity: 0.5 }}>{opt.romanization}</span>
                   )}
                   {opt.meaning && (
-                    <span style={{ fontSize: 13, opacity: 0.4, marginLeft: 'auto' }}>{opt.meaning}</span>
+                    <span style={{ fontSize: 'var(--game-text-sm)', opacity: 0.4, marginLeft: 'auto' }}>{opt.meaning}</span>
                   )}
                 </span>
               ) : (
-                <span className="text-ko ml-2" style={{ fontSize: '1rem', opacity: 0.6 }}>
+                <span className="text-ko ml-2" style={{ fontSize: 'var(--game-text-base)', opacity: 0.6 }}>
                   {t('tap_to_play', lang)}
                 </span>
               )}
@@ -146,7 +146,7 @@ export function PronunciationSelect({ exercise, onResult }: Props) {
       </div>
 
       {submitted && exercise.explanation && (
-        <p className="mt-3 text-sm text-[var(--color-text-muted)] m-0">{exercise.explanation}</p>
+        <p className="mt-3 text-[length:var(--game-text-base)] text-[var(--color-text-muted)] m-0">{exercise.explanation}</p>
       )}
 
       {!submitted && (
@@ -154,7 +154,7 @@ export function PronunciationSelect({ exercise, onResult }: Props) {
           onClick={handleSubmit}
           disabled={!selected}
           className={cn(
-            'mt-4 w-full rounded-lg py-3 font-semibold transition',
+            'mt-4 w-full min-h-[44px] rounded-lg py-3 text-[length:var(--game-text-base)] font-semibold transition',
             selected
               ? 'bg-[var(--color-accent-gold)] text-[#1a1a2e] hover:brightness-110'
               : 'bg-white/10 text-[var(--color-text-muted)] cursor-not-allowed',
@@ -167,7 +167,7 @@ export function PronunciationSelect({ exercise, onResult }: Props) {
       {submitted && (
         <div
           className={cn(
-            'mt-4 rounded-lg px-4 py-3 text-center text-sm',
+            'mt-4 rounded-lg px-4 py-3 text-center text-[length:var(--game-text-base)]',
             isCorrect
               ? 'bg-[var(--color-accent-green)]/20 text-[var(--color-accent-green)]'
               : 'bg-red-500/20 text-red-400',

--- a/apps/client/components/exercises/SentenceBuilder.tsx
+++ b/apps/client/components/exercises/SentenceBuilder.tsx
@@ -43,7 +43,7 @@ export function SentenceBuilder({ exercise, onResult }: Props) {
 
   return (
     <div className="exercise-card p-5">
-      <p className="text-lg font-medium mb-4 text-ko m-0">{exercise.prompt}</p>
+      <p className="text-[length:var(--game-text-lg)] font-medium mb-4 text-ko m-0">{exercise.prompt}</p>
 
       {/* Answer area */}
       <div className="sentence-builder__tiles">
@@ -57,7 +57,7 @@ export function SentenceBuilder({ exercise, onResult }: Props) {
           </button>
         ))}
         {placed.length === 0 && (
-          <span className="text-sm text-[var(--color-text-muted)] py-1">{t('tap_tiles', lang)}</span>
+          <span className="text-[length:var(--game-text-base)] text-[var(--color-text-muted)] py-1">{t('tap_tiles', lang)}</span>
         )}
       </div>
 
@@ -79,7 +79,7 @@ export function SentenceBuilder({ exercise, onResult }: Props) {
       </div>
 
       {submitted && exercise.explanation && (
-        <p className="mt-1 text-sm text-[var(--color-text-muted)] m-0">{exercise.explanation}</p>
+        <p className="mt-1 text-[length:var(--game-text-base)] text-[var(--color-text-muted)] m-0">{exercise.explanation}</p>
       )}
 
       {!submitted && (
@@ -87,7 +87,7 @@ export function SentenceBuilder({ exercise, onResult }: Props) {
           onClick={handleSubmit}
           disabled={placed.length === 0}
           className={cn(
-            'mt-2 w-full rounded-lg py-3 font-semibold transition',
+            'mt-2 w-full min-h-[44px] rounded-lg py-3 text-[length:var(--game-text-base)] font-semibold transition',
             placed.length > 0
               ? 'bg-[var(--color-accent-gold)] text-[#1a1a2e] hover:brightness-110'
               : 'bg-white/10 text-[var(--color-text-muted)] cursor-not-allowed',
@@ -100,7 +100,7 @@ export function SentenceBuilder({ exercise, onResult }: Props) {
       {submitted && (
         <div
           className={cn(
-            'mt-4 rounded-lg px-4 py-3 text-center text-sm',
+            'mt-4 rounded-lg px-4 py-3 text-center text-[length:var(--game-text-base)]',
             isCorrect
               ? 'bg-[var(--color-accent-green)]/20 text-[var(--color-accent-green)]'
               : 'bg-red-500/20 text-red-400',

--- a/apps/client/components/exercises/StrokeTracing.tsx
+++ b/apps/client/components/exercises/StrokeTracing.tsx
@@ -669,7 +669,7 @@ export function StrokeTracing({ exercise, onResult }: Props) {
 
   return (
     <div className="exercise-card p-5">
-      <p className="text-lg font-medium mb-3 text-ko m-0">{exercise.prompt}</p>
+      <p className="text-[length:var(--game-text-lg)] font-medium mb-3 text-ko m-0">{exercise.prompt}</p>
 
       {/* Target character + romanization + sound */}
       <div style={{ textAlign: 'center', marginBottom: isDrill ? 8 : 12 }}>
@@ -683,8 +683,8 @@ export function StrokeTracing({ exercise, onResult }: Props) {
               background: 'rgba(255,255,255,0.1)',
               border: 'none',
               borderRadius: '50%',
-              width: 32,
-              height: 32,
+              width: 44,
+              height: 44,
               cursor: 'pointer',
               display: 'flex',
               alignItems: 'center',
@@ -699,12 +699,12 @@ export function StrokeTracing({ exercise, onResult }: Props) {
           </button>
         </div>
         {exercise.romanization && (
-          <div style={{ fontSize: 14, opacity: 0.5, marginTop: 2 }}>
+          <div style={{ fontSize: 'var(--game-text-base)', opacity: 0.5, marginTop: 2 }}>
             {exercise.romanization}
           </div>
         )}
         {exercise.meaning && exercise.meaning !== exercise.romanization && (
-          <div style={{ fontSize: 13, opacity: 0.4, marginTop: 1 }}>
+          <div style={{ fontSize: 'var(--game-text-sm)', opacity: 0.4, marginTop: 1 }}>
             {getMeaning(exercise.meaning, lang, exercise.targetChar)}
           </div>
         )}
@@ -740,19 +740,19 @@ export function StrokeTracing({ exercise, onResult }: Props) {
 
           {/* Freehand hint */}
           {cellGhostOpacity(activeCell) <= 0.01 && !allDone && (
-            <div style={{ textAlign: 'center', fontSize: 13, opacity: 0.5, marginTop: 8 }}>
+            <div style={{ textAlign: 'center', fontSize: 'var(--game-text-sm)', opacity: 0.5, marginTop: 8 }}>
               {t('stroke_freehand', lang)}
             </div>
           )}
 
           {/* Drill progress */}
-          <div style={{ textAlign: 'center', fontSize: 12, opacity: 0.3, marginTop: 8 }}>
+          <div style={{ textAlign: 'center', fontSize: 'var(--game-text-xs)', opacity: 0.3, marginTop: 8 }}>
             {cellStates.filter((c) => c.done).length}/{totalReps}
           </div>
 
           {allDone && (
             <div
-              className="mt-3 rounded-lg px-4 py-3 text-center text-sm bg-[var(--color-accent-green)]/20 text-[var(--color-accent-green)]"
+              className="mt-3 rounded-lg px-4 py-3 text-center text-[length:var(--game-text-base)] bg-[var(--color-accent-green)]/20 text-[var(--color-accent-green)]"
               onClick={() => {
                 const avgScore = cellStates.reduce((a, c) => a + c.score, 0) / cellStates.length;
                 onResult(true, `${totalReps} reps, avg ${Math.round(avgScore * 100)}%`);
@@ -761,11 +761,11 @@ export function StrokeTracing({ exercise, onResult }: Props) {
             >
               {t('stroke_drill_done', lang)}
               {exercise.meaning && (
-                <div className="mt-1 text-sm font-semibold" style={{ color: 'var(--color-accent-gold, #f0c040)' }}>
+                <div className="mt-1 text-[length:var(--game-text-base)] font-semibold" style={{ color: 'var(--color-accent-gold, #f0c040)' }}>
                   {exercise.targetChar} = {getMeaning(exercise.meaning, lang, exercise.targetChar)}
                 </div>
               )}
-              <div className="mt-1 text-xs opacity-70">
+              <div className="mt-1 text-[length:var(--game-text-sm)] opacity-70">
                 {totalReps} reps &middot; avg {Math.round(cellStates.reduce((a, c) => a + c.score, 0) / cellStates.length * 100)}%
               </div>
               <div className="scene-continue-label animate-pulse" style={{ marginTop: 8 }}>
@@ -804,7 +804,7 @@ export function StrokeTracing({ exercise, onResult }: Props) {
             <div style={{ display: 'flex', gap: 8, marginTop: 16 }}>
               <button
                 onClick={handleClear_single}
-                className="flex-1 rounded-lg py-3 font-semibold bg-white/10 text-[var(--color-text-muted)] transition hover:bg-white/20"
+                className="flex-1 min-h-[44px] rounded-lg py-3 text-[length:var(--game-text-base)] font-semibold bg-white/10 text-[var(--color-text-muted)] transition hover:bg-white/20"
               >
                 {t('clear', lang)}
               </button>
@@ -812,7 +812,7 @@ export function StrokeTracing({ exercise, onResult }: Props) {
                 onClick={handleSubmit_single}
                 disabled={!hasDrawn}
                 className={cn(
-                  'flex-1 rounded-lg py-3 font-semibold transition',
+                  'flex-1 min-h-[44px] rounded-lg py-3 text-[length:var(--game-text-base)] font-semibold transition',
                   hasDrawn
                     ? 'bg-[var(--color-accent-gold)] text-[#1a1a2e] hover:brightness-110'
                     : 'bg-white/10 text-[var(--color-text-muted)] cursor-not-allowed',
@@ -826,7 +826,7 @@ export function StrokeTracing({ exercise, onResult }: Props) {
           {submitted && result && (
             <div
               className={cn(
-                'mt-4 rounded-lg px-4 py-3 text-center text-sm',
+                'mt-4 rounded-lg px-4 py-3 text-center text-[length:var(--game-text-base)]',
                 result.correct
                   ? 'bg-[var(--color-accent-green)]/20 text-[var(--color-accent-green)]'
                   : 'bg-red-500/20 text-red-400',
@@ -836,18 +836,18 @@ export function StrokeTracing({ exercise, onResult }: Props) {
                 <>
                   {t('stroke_done', lang)}
                   {exercise.meaning && (
-                    <div className="mt-1 text-sm font-semibold" style={{ color: 'var(--color-accent-gold, #f0c040)' }}>
+                    <div className="mt-1 text-[length:var(--game-text-base)] font-semibold" style={{ color: 'var(--color-accent-gold, #f0c040)' }}>
                       {exercise.targetChar} = {getMeaning(exercise.meaning, lang, exercise.targetChar)}
                     </div>
                   )}
-                  <div className="mt-1 text-xs opacity-70">
+                  <div className="mt-1 text-[length:var(--game-text-sm)] opacity-70">
                     {t('stroke_score', lang)}: {Math.round(result.score * 100)}%
                   </div>
                 </>
               ) : (
                 <>
                   {t('stroke_try_again', lang)}
-                  <div className="mt-1 text-xs opacity-70">
+                  <div className="mt-1 text-[length:var(--game-text-sm)] opacity-70">
                     {t('stroke_score', lang)}: {Math.round(result.score * 100)}%
                   </div>
                 </>
@@ -860,7 +860,7 @@ export function StrokeTracing({ exercise, onResult }: Props) {
       {/* Example words using this character */}
       {exercise.exampleWords && exercise.exampleWords.length > 0 && (
         <div style={{ marginTop: 16 }}>
-          <div style={{ fontSize: 13, opacity: 0.5, marginBottom: 8 }}>
+          <div style={{ fontSize: 'var(--game-text-sm)', opacity: 0.5, marginBottom: 8 }}>
             {t('stroke_examples', lang)}
           </div>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
@@ -875,6 +875,7 @@ export function StrokeTracing({ exercise, onResult }: Props) {
                   background: 'rgba(255,255,255,0.05)',
                   border: '1px solid rgba(255,255,255,0.08)',
                   borderRadius: 8,
+                  minHeight: 44,
                   padding: '8px 12px',
                   cursor: 'pointer',
                   textAlign: 'left',
@@ -884,9 +885,9 @@ export function StrokeTracing({ exercise, onResult }: Props) {
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" style={{ opacity: 0.4, flexShrink: 0 }}>
                   <path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z" />
                 </svg>
-                <span className="text-ko" style={{ fontSize: 18 }}>{ex.word}</span>
-                <span style={{ fontSize: 13, opacity: 0.5 }}>{ex.romanization}</span>
-                <span style={{ fontSize: 13, opacity: 0.4, marginLeft: 'auto' }}>{getMeaning(ex.meaning, lang)}</span>
+                <span className="text-ko" style={{ fontSize: 'var(--game-text-lg)' }}>{ex.word}</span>
+                <span style={{ fontSize: 'var(--game-text-sm)', opacity: 0.5 }}>{ex.romanization}</span>
+                <span style={{ fontSize: 'var(--game-text-sm)', opacity: 0.4, marginLeft: 'auto' }}>{getMeaning(ex.meaning, lang)}</span>
               </button>
             ))}
           </div>

--- a/apps/client/components/learn/FeedbackBubble.tsx
+++ b/apps/client/components/learn/FeedbackBubble.tsx
@@ -16,7 +16,7 @@ export function FeedbackBubble({ positive, message, detail }: FeedbackBubbleProp
       <p className="m-0 font-medium">
         {positive ? '✓' : '✗'} {message}
       </p>
-      {detail && <p className="m-0 mt-1 text-xs" style={{ color: 'rgba(255,255,255,0.85)' }}>{detail}</p>}
+      {detail && <p className="m-0 mt-1 text-[length:var(--game-text-sm)]" style={{ color: 'rgba(255,255,255,0.85)' }}>{detail}</p>}
     </div>
   );
 }

--- a/apps/client/components/learn/TeachingCard.tsx
+++ b/apps/client/components/learn/TeachingCard.tsx
@@ -79,7 +79,7 @@ export function TeachingCard({ title, content, korean, translation, items }: Tea
     <div className="teaching-card">
       {title && <div className="teaching-card__title">{title}</div>}
       {content && !displayItems.length && (
-        <p className="m-0 text-sm text-ko">{content}</p>
+        <p className="m-0 text-[length:var(--game-text-base)] text-ko">{content}</p>
       )}
       {displayItems.length > 0 && (
         <div className="teaching-card__grid">

--- a/apps/client/components/learn/TongBubble.tsx
+++ b/apps/client/components/learn/TongBubble.tsx
@@ -14,7 +14,7 @@ export function TongBubble({ text, translation, expression = 'cheerful' }: TongB
     <div className="msg-bubble msg-bubble--npc bubble-tail-left">
       <p className="m-0 text-ko">{text}</p>
       {translation && (
-        <p className="m-0 mt-1 text-xs msg-bubble__translation">{translation}</p>
+        <p className="m-0 mt-1 text-[length:var(--game-text-sm)] msg-bubble__translation">{translation}</p>
       )}
     </div>
   );

--- a/apps/client/components/scene/Background.tsx
+++ b/apps/client/components/scene/Background.tsx
@@ -24,7 +24,7 @@ export function Background({ imageUrl, ambientDescription, fade = false }: Backg
         />
       ) : ambientDescription ? (
         <div className="absolute inset-0 flex items-center justify-center bg-[var(--color-bg-dark)] p-8">
-          <p className="max-w-xs text-center text-base italic text-[var(--color-text-muted)]">
+          <p className="max-w-xs text-center italic text-[length:var(--game-text-base)] text-[var(--color-text-muted)]">
             {ambientDescription}
           </p>
         </div>

--- a/apps/client/components/shared/KoreanText.tsx
+++ b/apps/client/components/shared/KoreanText.tsx
@@ -634,12 +634,12 @@ export function KoreanText({ text, targetLang = 'ko', onWordTap }: KoreanTextPro
               </div>
             )}
             <div className="rounded-lg bg-[#16213e] border border-[var(--color-accent-gold)]/40 px-3 py-2 shadow-lg text-left min-w-[140px]">
-              <p className="text-sm font-medium text-[var(--color-accent-gold)] m-0">{activeWord}</p>
+              <p className="font-medium text-[length:var(--game-text-base)] text-[var(--color-accent-gold)] m-0">{activeWord}</p>
               {tooltipInfo.romanization && (
-                <p className="text-xs text-[var(--color-text-muted)] m-0">{tooltipInfo.romanization}</p>
+                <p className="text-[length:var(--game-text-sm)] text-[var(--color-text-muted)] m-0">{tooltipInfo.romanization}</p>
               )}
               {tooltipInfo.translation && (
-                <p className="text-xs text-[var(--color-text)] mt-0.5 m-0">{tooltipInfo.translation}</p>
+                <p className="text-[length:var(--game-text-sm)] text-[var(--color-text)] mt-0.5 m-0">{tooltipInfo.translation}</p>
               )}
             </div>
             {/* Arrow on bottom when above (default) */}


### PR DESCRIPTION
## Summary
- finish the remaining `/game` typography audit by moving reader-facing exercise, learn, scene, and location-drawer copy onto the shared `--game-text-*` scale
- raise affected interactive controls to 44px or larger where the typography cleanup touched tappable UI
- leave intentional large glyph/canvas sizing alone and move the actual-device spot check into follow-up issue #42

## How to test
- `npm run demo:smoke`
- `TONG_OPEN_BROWSER=0 ./scripts/run-judge-demo.sh`
- Open `/game?dev_intro=1&demo=TONG-JUDGE-DEMO&qa_trace=1` in a mobile viewport and verify dialogue, Tong whisper, and HUD-expanded states remain readable
- Open `/game?dev=exercise&type=multiple_choice&demo=TONG-JUDGE-DEMO` and verify exercise-card prompt, answers, explanation, and actions use the larger shared scale and 44px touch targets

## Notes
- Functional QA verification comment: https://github.com/erniesg/tong/issues/15#issuecomment-4060162417
- Actual mobile hardware spot-check follow-up: #42
- `npm --prefix apps/client run build` still hits the pre-existing `PageNotFoundError: Cannot find module for page: /_document` during page-data collection

Fixes #15
