### PR TITLE
fix: stream npc dialogue from partial tool calls

### DIFF
--- a/apps/client/app/api/ai/hangout/route.ts
+++ b/apps/client/app/api/ai/hangout/route.ts
@@ -315,6 +315,7 @@ export async function POST(req: Request) {
       system: systemPrompt,
       messages,
       tools: hangoutTools,
+      toolCallStreaming: true,
       maxSteps: 2,
       temperature: 0.8,
       abortSignal: abortController.signal,

--- a/apps/client/app/game/page.tsx
+++ b/apps/client/app/game/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { useChat } from 'ai/react';
+import type { ToolInvocation, UIMessage } from 'ai';
 import type { CityId, LocationId, ProficiencyLevel, ScoreState, UserProficiency, AppLang } from '@/lib/api';
 import type { SessionMessage, ToolQueueItem, SceneSummary, ExerciseData, BlockCrushCharStep, BlockCrushExercise } from '@/lib/types/hangout';
 import type { CompletedSession } from '@/lib/store/session-store';
@@ -127,8 +128,58 @@ const LOCATION_NAMES: Record<LocationId, string> = {
 
 type Phase = 'opening' | 'menu' | 'tong-intro' | 'hangout' | 'city_map' | 'learn' | 'dev';
 
+type NpcSpeakToolArgs = {
+  characterId?: string;
+  text?: string;
+  translation?: string | null;
+};
+
 
 /* ── helpers ────────────────────────────────────────────── */
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function getNpcSpeakArgs(invocation: ToolInvocation): NpcSpeakToolArgs | null {
+  if (invocation.toolName !== 'npc_speak' || !('args' in invocation) || !isRecord(invocation.args)) {
+    return null;
+  }
+
+  return invocation.args as NpcSpeakToolArgs;
+}
+
+function getLatestNpcSpeakInvocation(messages: UIMessage[]): ToolInvocation | null {
+  for (let messageIndex = messages.length - 1; messageIndex >= 0; messageIndex -= 1) {
+    const toolInvocations = messages[messageIndex]?.toolInvocations;
+    if (!toolInvocations?.length) continue;
+
+    for (let invocationIndex = toolInvocations.length - 1; invocationIndex >= 0; invocationIndex -= 1) {
+      const invocation = toolInvocations[invocationIndex];
+      if (invocation.toolName === 'npc_speak') {
+        return invocation;
+      }
+    }
+  }
+
+  return null;
+}
+
+function buildStreamedNpcMessage(
+  invocation: ToolInvocation,
+  fallbackCharacterId: string,
+): SessionMessage | null {
+  const args = getNpcSpeakArgs(invocation);
+  if (!args) return null;
+
+  return {
+    id: invocation.toolCallId,
+    role: 'npc',
+    characterId: typeof args.characterId === 'string' ? args.characterId : fallbackCharacterId,
+    content: typeof args.text === 'string' ? args.text : '',
+    translation: typeof args.translation === 'string' ? args.translation : undefined,
+  };
+}
 
 /** Build rich context block for API messages using game store data. */
 function buildContextBlock(
@@ -552,7 +603,7 @@ export default function GamePage() {
 
   /* ── useChat integration ──────────────────────────────────── */
 
-  const { append, isLoading: chatLoading } = useChat({
+  const { append, messages, isLoading: chatLoading } = useChat({
     api: '/api/ai/hangout',
     maxSteps: 1,
     onResponse: () => {
@@ -599,6 +650,24 @@ export default function GamePage() {
       traceQA('chat_finish', { role: msg.role, toolCount: msg.toolInvocations?.length ?? 0 });
     },
   });
+
+  const latestNpcSpeakInvocation = getLatestNpcSpeakInvocation(messages);
+  const queuedNpcSpeakId = toolQueue[0]?.toolName === 'npc_speak' ? toolQueue[0].toolCallId : null;
+  const shouldRenderStreamedNpcMessage = latestNpcSpeakInvocation != null && (
+    ((latestNpcSpeakInvocation.state === 'partial-call' || latestNpcSpeakInvocation.state === 'call') && chatLoading)
+    || latestNpcSpeakInvocation.toolCallId === queuedNpcSpeakId
+    || latestNpcSpeakInvocation.toolCallId === currentMessage?.id
+  );
+  const streamedNpcMessage = shouldRenderStreamedNpcMessage && latestNpcSpeakInvocation
+    ? buildStreamedNpcMessage(latestNpcSpeakInvocation, activeNpc)
+    : null;
+  const displayMessage = streamedNpcMessage ?? currentMessage;
+  const dialogueIsStreaming = Boolean(
+    streamedNpcMessage
+    && latestNpcSpeakInvocation
+    && chatLoading
+    && (latestNpcSpeakInvocation.state === 'partial-call' || latestNpcSpeakInvocation.state === 'call')
+  );
 
   /* Auto-start scene when skipping to hangout */
   useEffect(() => {
@@ -1155,6 +1224,8 @@ export default function GamePage() {
     processing: processingRef.current,
     toolQueue: toolQueue.map((item) => ({ toolCallId: item.toolCallId, toolName: item.toolName })),
     currentMessage: currentMessage ? { id: currentMessage.id, role: currentMessage.role, characterId: currentMessage.characterId, contentPreview: currentMessage.content.slice(0, 120) } : null,
+    streamedMessage: streamedNpcMessage ? { id: streamedNpcMessage.id, role: streamedNpcMessage.role, characterId: streamedNpcMessage.characterId, contentPreview: streamedNpcMessage.content.slice(0, 120), isStreaming: dialogueIsStreaming } : null,
+    displayMessage: displayMessage ? { id: displayMessage.id, role: displayMessage.role, characterId: displayMessage.characterId, contentPreview: displayMessage.content.slice(0, 120) } : null,
     tongTip: tongTip ? { messagePreview: tongTip.message.slice(0, 120), hasTranslation: !!tongTip.translation } : null,
     currentExercise: currentExercise ? { id: currentExercise.id, type: currentExercise.type } : null,
     choices: choices ? choices.map((choice) => ({ id: choice.id, text: choice.text })) : null,
@@ -1164,22 +1235,24 @@ export default function GamePage() {
     introExerciseCount,
     introAct,
     npcRevealed,
-  }), [qaRunId, qaTrace, phase, sceneReady, chatLoading, toolQueue, currentMessage, tongTip, currentExercise, choices, choicePrompt, sceneSummary, isIntroHangout, introExerciseCount, introAct, npcRevealed]);
+  }), [qaRunId, qaTrace, phase, sceneReady, chatLoading, toolQueue, currentMessage, streamedNpcMessage, displayMessage, dialogueIsStreaming, tongTip, currentExercise, choices, choicePrompt, sceneSummary, isIntroHangout, introExerciseCount, introAct, npcRevealed]);
 
   useEffect(() => {
     if (!qaTrace) return;
     traceQA('state_snapshot', {
       phase,
       chatLoading,
+      dialogueStreaming: dialogueIsStreaming,
       processing: processingRef.current,
       queueLength: toolQueue.length,
       currentMessageId: currentMessage?.id ?? null,
+      displayMessageId: displayMessage?.id ?? null,
       currentExerciseId: currentExercise?.id ?? null,
       choiceCount: choices?.length ?? 0,
       hasTongTip: !!tongTip,
       hasSceneSummary: !!sceneSummary,
     });
-  }, [qaTrace, traceQA, phase, chatLoading, toolQueue.length, currentMessage?.id, currentExercise?.id, choices?.length, tongTip, sceneSummary]);
+  }, [qaTrace, traceQA, phase, chatLoading, dialogueIsStreaming, toolQueue.length, currentMessage?.id, displayMessage?.id, currentExercise?.id, choices?.length, tongTip, sceneSummary]);
 
   useEffect(() => {
     if (typeof window === 'undefined' || !qaRunId) return;
@@ -1837,12 +1910,13 @@ export default function GamePage() {
           npcColor={npc.color}
           npcSpriteUrl={isIntroHangout && !npcRevealed ? '' : currentExercise ? '' : npc.src}
           npcIdleVideoUrl={isIntroHangout && !npcRevealed ? undefined : npc.idleVideo || undefined}
-          currentMessage={currentMessage}
+          currentMessage={displayMessage}
           currentExercise={currentExercise}
           choices={choices}
           choicePrompt={choicePrompt}
           tongTip={tongTip}
           isStreaming={chatLoading}
+          dialogueIsStreaming={dialogueIsStreaming}
           sceneReady={sceneReady}
           targetLang={targetLang}
           continueLabel={continueLabel}

--- a/apps/client/components/scene/DialogueBox.tsx
+++ b/apps/client/components/scene/DialogueBox.tsx
@@ -30,16 +30,42 @@ export function DialogueBox({
   const [displayedChars, setDisplayedChars] = useState(0);
   const [typewriterDone, setTypewriterDone] = useState(false);
   const timerRef = useRef<ReturnType<typeof setInterval>>(undefined);
+  const previousStreamingRef = useRef(false);
 
   useEffect(() => {
+    const wasStreaming = previousStreamingRef.current;
+    previousStreamingRef.current = Boolean(isStreaming);
+
+    if (timerRef.current) {
+      clearInterval(timerRef.current);
+      timerRef.current = undefined;
+    }
+
+    if (isStreaming) {
+      setDisplayedChars(content.length);
+      setTypewriterDone(false);
+      return;
+    }
+
+    if (wasStreaming) {
+      setDisplayedChars(content.length);
+      setTypewriterDone(true);
+      return;
+    }
+
     setDisplayedChars(0);
-    setTypewriterDone(false);
+    setTypewriterDone(content.length === 0);
+
+    if (!content) {
+      return;
+    }
 
     const timer = setInterval(() => {
       setDisplayedChars((prev) => {
         const next = prev + CHARS_PER_TICK;
         if (next >= content.length) {
           clearInterval(timer);
+          timerRef.current = undefined;
           setTypewriterDone(true);
           return content.length;
         }
@@ -49,11 +75,12 @@ export function DialogueBox({
 
     timerRef.current = timer;
     return () => clearInterval(timer);
-  }, [content]);
+  }, [content, isStreaming]);
 
   const handleClick = (e: React.MouseEvent) => {
     const target = e.target as HTMLElement;
     if (target.closest('.text-ko[data-korean]')) return;
+    if (isStreaming) return;
 
     if (!typewriterDone) {
       if (timerRef.current) clearInterval(timerRef.current);

--- a/apps/client/components/scene/SceneView.tsx
+++ b/apps/client/components/scene/SceneView.tsx
@@ -27,6 +27,7 @@ interface SceneViewProps {
   choicePrompt?: string | null;
   tongTip?: { message: string; translation?: string } | null;
   isStreaming?: boolean;
+  dialogueIsStreaming?: boolean;
   hudContent?: React.ReactNode;
   targetLang?: TargetLang;
   continueLabel?: string;
@@ -62,6 +63,7 @@ export function SceneView({
   choicePrompt,
   tongTip = null,
   isStreaming = false,
+  dialogueIsStreaming = false,
   hudContent,
   targetLang = 'ko',
   continueLabel = 'Tap to continue',
@@ -162,7 +164,7 @@ export function SceneView({
           speakerColor={getSpeakerColor(currentMessage)}
           content={currentMessage.content}
           translation={currentMessage.translation}
-          isStreaming={isStreaming}
+          isStreaming={dialogueIsStreaming}
           targetLang={targetLang}
           continueLabel={continueLabel}
           onContinue={onContinue}


### PR DESCRIPTION
Fixes #19

## Summary
- enable `toolCallStreaming` on the hangout route so partial tool-call args reach the client
- render partial `npc_speak` tool invocations from `useChat().messages` as the active dialogue message while the stream is in flight
- keep the existing tool queue for blocking actions, but stop fake-local typewriting for streamed dialogue content

## Validation
- `npm --prefix apps/client run build`
- live-model verification on `next start -p 3003` with repo `.env`
- first response frame: `+2155ms`
- `npc_speak` partial stream start: `+4456ms`
- first text delta: `+4675ms`
- first visible dialogue characters: `+4785ms`
- completed `npc_speak` payload: `+5314ms`
- stream complete: `+5349ms`
- visible dialogue now appears about `529ms` before the completed tool payload and about `564ms` before stream completion, while `chatLoading=true`

Reviewer proof:
- GIF preview: https://runs.tong.berlayar.ai/qa-runs/functional-qa/erniesg-tong-19/functional-qa-validate-issue-20260314T132143Z-erniesg-tong-19/previews/issue19-fixed-stream-proof.preview.gif?v=20260314T133105340Z
- Screen recording: https://runs.tong.berlayar.ai/qa-runs/functional-qa/erniesg-tong-19/functional-qa-validate-issue-20260314T132143Z-erniesg-tong-19/video/issue19-fixed-stream-proof.webm?v=20260314T133105340Z
- Dialogue screenshot: https://runs.tong.berlayar.ai/qa-runs/functional-qa/erniesg-tong-19/functional-qa-validate-issue-20260314T132143Z-erniesg-tong-19/screenshots/03-first-dialogue-frame.png?v=20260314T133105340Z
- QA summary: https://runs.tong.berlayar.ai/qa-runs/functional-qa/erniesg-tong-19/functional-qa-validate-issue-20260314T132143Z-erniesg-tong-19/summary.md?v=20260314T133105340Z
- Uploaded manifest: https://runs.tong.berlayar.ai/qa-runs/functional-qa/erniesg-tong-19/functional-qa-validate-issue-20260314T132143Z-erniesg-tong-19/manifest.json?v=20260314T133105340Z

## How To Test
1. Start the client with the repo `.env` loaded and open `/game?dev_intro=1&dev_act=2&demo=TONG-JUDGE-DEMO`.
2. Trigger the first NPC reply.
3. Confirm the dialogue box becomes visible while loading is still active and the visible text grows before the final `npc_speak` payload lands.
