### PR TITLE
fix(qa): honor project execution mode in runtime

### DIFF
--- a/.agents/skills/_functional-qa/scripts/qa_runtime.py
+++ b/.agents/skills/_functional-qa/scripts/qa_runtime.py
@@ -363,6 +363,135 @@ def fetch_issue(target: str) -> dict[str, Any] | None:
     }
 
 
+def fetch_project_overrides() -> dict[str, dict[str, str]]:
+    global PROJECT_OVERRIDE_CACHE
+    if PROJECT_OVERRIDE_CACHE is not None:
+        return PROJECT_OVERRIDE_CACHE
+
+    cfg = project_control_plane()
+    if not cfg:
+        PROJECT_OVERRIDE_CACHE = {}
+        return PROJECT_OVERRIDE_CACHE
+
+    owner_fragment = "user" if cfg.get("owner_type", "user") == "user" else "organization"
+    query = f"""
+    query($owner: String!, $number: Int!, $first: Int!, $after: String) {{
+      {owner_fragment}(login: $owner) {{
+        projectV2(number: $number) {{
+          items(first: $first, after: $after) {{
+            pageInfo {{
+              hasNextPage
+              endCursor
+            }}
+            nodes {{
+              content {{
+                ... on Issue {{
+                  number
+                  repository {{
+                    nameWithOwner
+                  }}
+                }}
+              }}
+              fieldValues(first: 50) {{
+                nodes {{
+                  ... on ProjectV2ItemFieldSingleSelectValue {{
+                    field {{
+                      ... on ProjectV2FieldCommon {{
+                        name
+                      }}
+                    }}
+                    name
+                  }}
+                  ... on ProjectV2ItemFieldTextValue {{
+                    field {{
+                      ... on ProjectV2FieldCommon {{
+                        name
+                      }}
+                    }}
+                    text
+                  }}
+                }}
+              }}
+            }}
+          }}
+        }}
+      }}
+    }}
+    """
+
+    overrides: dict[str, dict[str, str]] = {}
+    cursor: str | None = None
+    while True:
+        command = [
+            "gh",
+            "api",
+            "graphql",
+            "-f",
+            f"query={query}",
+            "-F",
+            f"owner={cfg['owner']}",
+            "-F",
+            f"number={cfg['number']}",
+            "-F",
+            "first=100",
+        ]
+        if cursor:
+            command.extend(["-F", f"after={cursor}"])
+        try:
+            result = run_command(command, allow_failure=True)
+        except FileNotFoundError:
+            PROJECT_OVERRIDE_CACHE = {}
+            return PROJECT_OVERRIDE_CACHE
+        if result.returncode != 0:
+            PROJECT_OVERRIDE_CACHE = {}
+            return PROJECT_OVERRIDE_CACHE
+
+        payload = json.loads(result.stdout)
+        owner_payload = payload["data"].get(owner_fragment)
+        if not owner_payload or not owner_payload.get("projectV2"):
+            break
+
+        items_payload = owner_payload["projectV2"]["items"]
+        for node in items_payload["nodes"]:
+            content = node.get("content")
+            if not content or "number" not in content:
+                continue
+            issue_ref = f"{content['repository']['nameWithOwner']}#{content['number']}"
+            field_map: dict[str, str] = {}
+            for field_node in node.get("fieldValues", {}).get("nodes", []):
+                field_name = field_node.get("field", {}).get("name")
+                if not field_name:
+                    continue
+                value = field_node.get("name") or field_node.get("text")
+                if value:
+                    field_map[field_name] = value
+            overrides[issue_ref] = field_map
+
+        if not items_payload["pageInfo"]["hasNextPage"]:
+            break
+        cursor = items_payload["pageInfo"]["endCursor"]
+
+    PROJECT_OVERRIDE_CACHE = overrides
+    return overrides
+
+
+def project_fields_for_issue(issue_ref: str | None) -> dict[str, str]:
+    if not issue_ref:
+        return {}
+    return fetch_project_overrides().get(issue_ref, {})
+
+
+def project_execution_mode(project_fields: dict[str, str]) -> str | None:
+    cfg = project_control_plane()
+    if not cfg:
+        return None
+    field_name = cfg.get("execution_mode_field")
+    if not field_name:
+        return None
+    value = project_fields.get(field_name)
+    return value or None
+
+
 def collect_issue_notes(issue_ref: str | None) -> list[str]:
     if not issue_ref:
         return []
@@ -395,10 +524,16 @@ def unique_lines(items: list[str]) -> list[str]:
     return list(dict.fromkeys(item for item in items if item))
 
 
-def build_validation_policy(playbook: dict[str, Any] | None, issue_class: str, evidence_plan: dict[str, Any]) -> dict[str, Any]:
+def build_validation_policy(
+    playbook: dict[str, Any] | None,
+    issue_class: str,
+    evidence_plan: dict[str, Any],
+    *,
+    execution_mode_override: str | None = None,
+) -> dict[str, Any]:
     defaults = REPO_ADAPTER.get("validation_defaults", {})
     requirements = (playbook or {}).get("validation_requirements", {})
-    execution_mode = (playbook or {}).get("execution_mode") or defaults.get("execution_mode", "safe-unattended")
+    execution_mode = execution_mode_override or (playbook or {}).get("execution_mode") or defaults.get("execution_mode", "safe-unattended")
 
     requires_direct_issue_evidence = requirements.get("requires_direct_issue_evidence", evidence_plan["requires_ui_capture"])
     ui_acceptance_required = requirements.get("ui_acceptance_required", evidence_plan["requires_ui_capture"])
@@ -411,6 +546,9 @@ def build_validation_policy(playbook: dict[str, Any] | None, issue_class: str, e
         (defaults.get("ui_acceptance_checks", []) if ui_acceptance_required else [])
         + requirements.get("ui_acceptance_checks", [])
     )
+    human_review_required = requirements.get("human_review_required")
+    if human_review_required is None:
+        human_review_required = execution_mode == "needs-human-design-review"
 
     return {
         "issue_class": issue_class,
@@ -422,7 +560,7 @@ def build_validation_policy(playbook: dict[str, Any] | None, issue_class: str, e
         "ui_acceptance_checks": ui_acceptance_checks,
         "required_runtime_modes_for_fixed": requirements.get("required_runtime_modes_for_fixed", []),
         "requires_live_model_for_fixed": requirements.get("requires_live_model_for_fixed", False),
-        "human_review_required": requirements.get("human_review_required", execution_mode == "needs-human-design-review"),
+        "human_review_required": human_review_required,
         "stop_conditions": requirements.get("stop_conditions", []),
     }
 
@@ -1206,6 +1344,7 @@ def init_run(args: argparse.Namespace) -> int:
     (run_dir / "evidence.json").write_text(json.dumps(evidence, indent=2) + "\n", encoding="utf-8")
     (run_dir / "publish.md").write_text("Publish draft will be rendered after finalize-run.\n", encoding="utf-8")
     if issue_payload:
+        issue_payload["project_fields"] = project_fields
         (run_dir / "issue.json").write_text(json.dumps(issue_payload, indent=2) + "\n", encoding="utf-8")
 
     print(str(run_dir))

--- a/.agents/skills/publish-issue-update/SKILL.md
+++ b/.agents/skills/publish-issue-update/SKILL.md
@@ -22,6 +22,8 @@ Use the invocation arguments as either:
 - a run directory under `artifacts/qa-runs/...`
 - a run id that you first resolve to a run directory
 
+The local run directory is the staging source bundle. The reviewer-visible proof surface should be the uploaded `tong-runs` artifacts when that host is configured.
+
 ## Workflow
 
 1. Confirm `publish.md` reflects the current `run.json`, `summary.md`, and `evidence.json`.
@@ -34,7 +36,7 @@ Use the invocation arguments as either:
    python .agents/skills/_functional-qa/scripts/qa_runtime.py publish-github --run-dir <RUN_DIR>
    ```
 
-   By default this now attempts reviewer-proof upload first when the run has screenshots or temporal capture evidence and the uploader scripts are available. If upload succeeds, it publishes `uploaded-comment.md`; otherwise it falls back to `publish.md`.
+   By default this now attempts reviewer-proof upload first when the run has screenshots or temporal capture evidence and the uploader scripts are available. If upload succeeds, it publishes `uploaded-comment.md` with `tong-runs` links; otherwise it falls back to `publish.md`.
 
 4. Use `--dry-run` for a safe preview:
 
@@ -63,7 +65,7 @@ Use the invocation arguments as either:
 
    Use the generated `uploaded-comment.md` when you need clean public links, an inline GIF preview, or an MP4 proof link without committing binaries into git.
 
-   If the uploader is not configured for the current environment, fall back to reviewer-openable git-tracked files on a dedicated branch or PR and use those GitHub blob or raw links in the posted comment. Do not leave reviewer-facing updates pointing only at local artifact paths.
+   If the uploader is not configured for the current environment, fall back to reviewer-openable git-tracked files on a dedicated branch or PR and use those GitHub blob or raw links in the posted comment. Do not leave reviewer-facing updates pointing only at local artifact paths inside `artifacts/qa-runs`.
 
 7. For reviewer-visible UI fixes such as layout, typography, subtitle, translation, tooltip, or focus-style changes, make the published update easy to review:
    - include a full before/after comparison panel

--- a/.agents/skills/validate-issue/SKILL.md
+++ b/.agents/skills/validate-issue/SKILL.md
@@ -100,6 +100,8 @@ If the invocation includes `--verify-fix`, replay the most recent matching valid
 - `logs/`
 - `browser-playbook.md` and `browser/` when the repo adapter generated a browser-backed capture pack
 
+   Treat the run directory under `artifacts/qa-runs/...` as local staging for the current QA tooling, not as the final reviewer-visible proof surface.
+
 9. Finalize the run:
 
    ```bash
@@ -118,7 +120,7 @@ If the invocation includes `--verify-fix`, replay the most recent matching valid
    python .agents/skills/_functional-qa/scripts/qa_runtime.py publish-github --run-dir <RUN_DIR>
    ```
 
-   If the run needs reviewer-facing media links rather than a text-only QA update, continue with `capture-reviewer-proof` before considering the publication complete.
+   If the run needs reviewer-facing media links rather than a text-only QA update, continue with `capture-reviewer-proof` before considering the publication complete. The published proof should land on `tong-runs` when the uploader is configured; the local run bundle remains the staging source.
 
 11. Decide issue closure status deliberately:
 
@@ -128,13 +130,14 @@ If the invocation includes `--verify-fix`, replay the most recent matching valid
 
 ## Output requirements
 
-- Use the artifact bundle under `artifacts/qa-runs/functional-qa/...`.
+- Use the artifact bundle under `artifacts/qa-runs/functional-qa/...` as the required local staging bundle.
 - Make the repro checklist rerunnable.
 - If `--verify-fix` was used, explicitly compare against the previous run before claiming a fix.
 - If a required evidence type is unavailable, lower confidence and say why.
 - For reviewer-visible UI fixes, do not stop at generic screenshots when a comparison view would make the delta materially easier to review.
 - Prefer runtime-emitted cue timestamps over visual guesswork when selecting reviewer-facing frames. Treat video-understanding or OCR as a fallback layer, not the primary source of truth, when deterministic state cues are available.
 - Do not treat a local screenshot or `.webm` path under `artifacts/qa-runs/` as reviewer-visible proof unless the media is also attached or linked where reviewers can open it.
+- For reviewer-facing publication, prefer uploaded `tong-runs` URLs over local artifact paths.
 - Do not call a clip reviewer-ready if it omits the visible input, races through the proof moment, or starts from a semantically confusing state created by a deterministic jump.
 - If the issue execution mode is `validate-and-propose-only` or `needs-human-design-review`, stop after validation evidence and proposal instead of making unattended UX or product changes.
 - If the issue body is not portable enough for remote execution, record that gap in `summary.md` and `evidence.json` before proceeding.

--- a/.agents/skills/work-github-issues/SKILL.md
+++ b/.agents/skills/work-github-issues/SKILL.md
@@ -108,7 +108,8 @@ python .agents/skills/_functional-qa/scripts/codex_cloud_queue.py
 ## Output requirements
 
 - Keep the queue plan under `artifacts/qa-runs/functional-qa/issue-queue/...`.
-- Keep each issue's validation and fix artifacts under `artifacts/qa-runs/functional-qa/...`.
+- Keep each issue's validation and fix artifacts under `artifacts/qa-runs/functional-qa/...` as the local staging source bundle for publication.
+- Treat uploaded `tong-runs` artifacts, not local run paths, as the reviewer-visible proof surface when evidence hosting is configured.
 - Do not claim issues are safe to parallelize without checking shared-zone collisions.
 - Do not skip fix verification before publishing a "fixed" update.
 - Do not upgrade a validation-only or design-review issue into a fix run unless a human explicitly changes the direction.


### PR DESCRIPTION
## Summary
- honor GitHub Project execution mode during `qa_runtime.py init-run`
- persist the project fields in run metadata so published QA evidence reflects the control-plane settings
- clarify in the QA skills that `artifacts/qa-runs` is local staging and `tong-runs` is the reviewer-visible proof surface

## How to test
- python -m py_compile .agents/skills/_functional-qa/scripts/qa_runtime.py
- python .agents/skills/_functional-qa/scripts/issue_router.py plan 66 --json | python -c "import sys,json; data=json.load(sys.stdin); print(data["issues"][0]["validation_policy"]["execution_mode"])"
- python .agents/skills/_functional-qa/scripts/qa_runtime.py init-run validate-issue --target 66 and confirm the generated `run.json` records `validate-and-propose-only`

Refs #66