### PR TITLE
fix: resolve client runtime assets via manifest

### DIFF
--- a/apps/client/app/api/ai/hangout/route.ts
+++ b/apps/client/app/api/ai/hangout/route.ts
@@ -11,6 +11,7 @@ import {
 } from '@/lib/ai/prompts/introduction-hangout';
 import { CHARACTER_MAP, HAEUN, TUTORIAL_VIDEO_CONFIG } from '@/lib/content/characters';
 import { POJANGMACHA } from '@/lib/content/pojangmacha';
+import { runtimeAssetUrl } from '@/lib/runtime-assets';
 import type { Character, RelationshipStage, Relationship } from '@/lib/types/relationship';
 import type { MasterySnapshot } from '@/lib/types/mastery';
 
@@ -102,7 +103,7 @@ const hangoutTools = {
   set_backdrop: tool({
     description: 'Change the scene backdrop. Use to transition between areas within a location (e.g., from outside to inside the stall, from counter to kitchen).',
     parameters: z.object({
-      backdropUrl: z.string().describe('Path to the backdrop image, e.g. /assets/backdrops/seoul/pojangmacha.png'),
+      backdropUrl: z.string().describe('Resolved runtime asset URL for the backdrop image'),
       transition: z.enum(['fade', 'cut']).describe('Transition type: fade (smooth 0.5s) or cut (instant)'),
       ambientDescription: z.string().nullable().describe('Ambient text shown if image fails to load, or null'),
     }),
@@ -261,7 +262,7 @@ export async function POST(req: Request) {
       exercisesDone: (introCtx.exercisesDone as number) ?? 0,
       minExercises: 3,
       introAct: (introCtx.introAct as 1 | 2) ?? 1,
-      backdropUrl: (introCtx.backdropUrl as string) ?? '/assets/backdrops/seoul/pojangmacha.png',
+      backdropUrl: (introCtx.backdropUrl as string) ?? runtimeAssetUrl('city.seoul.location.food-street.backdrop.default'),
       chargePercent: (introCtx.chargePercent as number) ?? 0,
       chargeComplete: (introCtx.chargeComplete as boolean) ?? false,
     };

--- a/apps/client/app/game/GamePageClient.tsx
+++ b/apps/client/app/game/GamePageClient.tsx
@@ -8,9 +8,17 @@ import {
   startOrResumeGame,
   type CityId,
   type LocationId,
+  type ObjectiveNextResponse,
   type ProficiencyLevel,
   type ScoreState,
 } from '@/lib/api';
+import {
+  hasRuntimeAssetKey,
+  resolveCharacterAssetUrl,
+  resolveRuntimeAssetUrl,
+  resolveRuntimeAssetUrls,
+  runtimeAssetUrl,
+} from '@/lib/runtime-assets';
 
 /* ── Inline types — not exported from api.ts ──────────────── */
 interface GameProfile {
@@ -24,12 +32,6 @@ interface HangoutRenderOp {
   text?: string;
   speakerName?: string;
   choices?: string[];
-  [key: string]: unknown;
-}
-
-interface ObjectiveNextResponse {
-  objectiveId: string;
-  title?: string;
   [key: string]: unknown;
 }
 
@@ -114,10 +116,10 @@ const DEFAULT_CITY: CityId = 'seoul';
 const DEFAULT_LOCATION: LocationId = 'food_street';
 const ACTIVE_USER_ID_STORAGE_KEY = 'tong_active_user_id';
 
-const GAME_LOGO_PATH = '/assets/app/logo_transparent.png';
-const TONG_INTRO_PATH = '/assets/tong_intro.webm';
+const GAME_LOGO_PATH = runtimeAssetUrl('app.logo.transparent.default');
+const TONG_INTRO_PATH = runtimeAssetUrl('app.intro.video.default');
 const OPENING_ANIMATION_PATH = TONG_INTRO_PATH;
-const SEOUL_FIRST_SCENE_BACKDROP = '/assets/backdrops/seoul/pojangmacha.png';
+const SEOUL_FIRST_SCENE_BACKDROP = runtimeAssetUrl('city.seoul.location.food-street.backdrop.default');
 
 const MAX_PROFICIENCY_GAUGE_LEVEL: ProficiencyGaugeLevel = 6;
 const REQUESTED_GAUGE_PRESET: Record<CjkLang, ProficiencyGaugeLevel> = {
@@ -134,8 +136,8 @@ const CITY_DEFINITIONS: CityDefinition[] = [
     languageLabel: 'Japanese',
     mapPosition: 'left',
     vibe: 'Shibuya after-hours energy',
-    backdropImage: '/assets/locations/tokyo-static.png',
-    backdropVideo: '/assets/locations/tokyo.mp4',
+    backdropImage: runtimeAssetUrl('city.tokyo.map.static.default'),
+    backdropVideo: runtimeAssetUrl('city.tokyo.map.video.default'),
   },
   {
     id: 'seoul',
@@ -144,8 +146,8 @@ const CITY_DEFINITIONS: CityDefinition[] = [
     languageLabel: 'Korean',
     mapPosition: 'center',
     vibe: 'Hongdae late-night food lane',
-    backdropImage: '/assets/locations/seoul-static.png',
-    backdropVideo: '/assets/locations/seoul.mp4',
+    backdropImage: runtimeAssetUrl('city.seoul.map.static.default'),
+    backdropVideo: runtimeAssetUrl('city.seoul.map.video.default'),
   },
   {
     id: 'shanghai',
@@ -154,8 +156,8 @@ const CITY_DEFINITIONS: CityDefinition[] = [
     languageLabel: 'Chinese',
     mapPosition: 'right',
     vibe: 'Bund neon and river glow',
-    backdropImage: '/assets/locations/shanghai-static.png',
-    backdropVideo: '/assets/locations/shanghai.mp4',
+    backdropImage: runtimeAssetUrl('city.shanghai.map.static.default'),
+    backdropVideo: runtimeAssetUrl('city.shanghai.map.video.default'),
   },
 ];
 
@@ -347,10 +349,13 @@ function getCharacterSpriteUrl(value?: SceneCharacter, expression?: string): str
   if (charKey) {
     const exprFile = expression && EXPRESSION_SPRITES[charKey]?.[expression];
     const file = exprFile || CHARACTER_DEFAULT_SPRITE[charKey] || `${charKey}.png`;
-    return `/assets/characters/${charKey}/${file}`;
+    return resolveCharacterAssetUrl(`${charKey}/${file}`);
   }
 
-  if (value.assetKey) return `/assets/characters/${value.assetKey}`;
+  if (value.assetKey) {
+    if (hasRuntimeAssetKey(value.assetKey)) return runtimeAssetUrl(value.assetKey);
+    return resolveCharacterAssetUrl(value.assetKey);
+  }
   return null;
 }
 
@@ -362,21 +367,25 @@ function getCharacterAvatarPaths(value?: SceneCharacter): string[] {
   const safeId = (value.id || '').toLowerCase().trim();
 
   if (safeId === 'npc_haeun' || safeName === 'haeun') {
-    options.push('/assets/characters/haeun/eye_front_casual.png');
-    options.push('/assets/characters/haeun/haeun.png');
+    options.push(runtimeAssetUrl('character.haeun.portrait.eye-front-casual'));
+    options.push(runtimeAssetUrl('character.haeun.portrait.default'));
   }
 
   if (safeId === 'npc_jin' || safeId === 'npc_ding_man' || safeName === 'jin' || safeName === 'ding') {
-    options.push('/assets/characters/jin/eye_front_casual.png');
-    options.push('/assets/characters/jin/jin.png');
-    options.push('/assets/characters/ding_man/ding_man.png');
+    options.push(runtimeAssetUrl('character.jin.portrait.eye-front-casual'));
+    options.push(runtimeAssetUrl('character.jin.portrait.default'));
+    options.push(runtimeAssetUrl('character.ding-man.portrait.default'));
   }
 
   if (value.assetKey) {
-    options.push(`/assets/characters/${value.assetKey}`);
+    if (hasRuntimeAssetKey(value.assetKey)) {
+      options.push(runtimeAssetUrl(value.assetKey));
+    } else {
+      options.push(resolveCharacterAssetUrl(value.assetKey));
+    }
   }
 
-  return [...new Set(options)];
+  return resolveRuntimeAssetUrls(options);
 }
 
 function getCharacterForCityLocation(city: CityId, location: LocationId): SceneCharacter {

--- a/apps/client/app/game/page.tsx
+++ b/apps/client/app/game/page.tsx
@@ -32,12 +32,17 @@ import { t } from '@/lib/i18n/ui-strings';
 import type { UILang } from '@/lib/i18n/ui-strings';
 import { GameHUD } from '@/components/hud/GameHUD';
 import { ExerciseModal } from '@/components/learn/ExerciseModal';
+import { resolveRuntimeAssetUrl, runtimeAssetUrl } from '@/lib/runtime-assets';
 
 /* ── scene constants ────────────────────────────────────── */
 
+const GAME_LOGO_URL = runtimeAssetUrl('app.logo.transparent.default');
+const GAME_INTRO_VIDEO_URL = runtimeAssetUrl('app.intro.video.default');
+const SEOUL_FOOD_STREET_BACKDROP_URL = runtimeAssetUrl('city.seoul.location.food-street.backdrop.default');
+
 const NPC_SPRITES: Record<string, { name: string; nameLocal: string; nameZh: string; src: string; idleVideo?: string; color: string }> = {
-  haeun: { name: 'Ha-eun', nameLocal: '하은', nameZh: '夏恩', src: '/assets/characters/haeun/haeun.png', color: '#e8485c' },
-  jin: { name: 'Jin', nameLocal: '진', nameZh: '珍', src: '/assets/characters/jin/jin.png', color: '#4a90d9' },
+  haeun: { name: 'Ha-eun', nameLocal: '하은', nameZh: '夏恩', src: runtimeAssetUrl('character.haeun.portrait.default'), color: '#e8485c' },
+  jin: { name: 'Jin', nameLocal: '진', nameZh: '珍', src: runtimeAssetUrl('character.jin.portrait.default'), color: '#4a90d9' },
 };
 
 const NPC_POOL = ['haeun', 'jin'] as const;
@@ -499,7 +504,7 @@ export default function GamePage() {
       exitLine: exitLineRef.current,
       exercisesDone: introExerciseCount,
       introAct,
-      backdropUrl: '/assets/backdrops/seoul/pojangmacha.png',
+      backdropUrl: SEOUL_FOOD_STREET_BACKDROP_URL,
       chargePercent,
       chargeComplete: chargePercent >= 100,
     };
@@ -586,7 +591,7 @@ export default function GamePage() {
         exitLine: exitLineRef.current,
         exercisesDone: 0,
         introAct: 1 as const,
-        backdropUrl: '/assets/backdrops/seoul/pojangmacha.png',
+        backdropUrl: SEOUL_FOOD_STREET_BACKDROP_URL,
         chargePercent: 0,
         chargeComplete: false,
       };
@@ -736,7 +741,7 @@ export default function GamePage() {
       exitLine: exitLineRef.current,
       exercisesDone: fakeExercises,
       introAct: startAct as 1 | 2,
-      backdropUrl: '/assets/backdrops/seoul/pojangmacha.png',
+      backdropUrl: SEOUL_FOOD_STREET_BACKDROP_URL,
     };
 
     const startMsg = `${buildContextBlock(0, npcId, devCity, 'food_street', npcChar, devLang, introCtx)}${startAct === 2 ? 'Act 1 complete. Player already learned basic jamo (ㅎ, ㅏ, ㅇ, ㅡ, ㄴ) and built syllable blocks. Start Act 2 — NPC entrance.' : 'Start the scene.'}`;
@@ -1302,7 +1307,7 @@ export default function GamePage() {
             <video
               ref={openingVideoRef}
               className="tg-opening-vid"
-              src="/assets/tong_intro.webm"
+              src={GAME_INTRO_VIDEO_URL}
               autoPlay
               muted
               playsInline
@@ -1326,7 +1331,7 @@ export default function GamePage() {
         <div className="game-frame">
           <div className="tg-menu">
             <div className="tg-menu-logo">
-              <img className="tg-menu-logo-img" src="/assets/app/logo_transparent.png" alt="Tong" />
+              <img className="tg-menu-logo-img" src={GAME_LOGO_URL} alt="Tong" />
             </div>
             <p className="tg-menu-tagline">
               Live the drama. <span className="tg-menu-tagline-accent">Learn the language.</span>
@@ -1391,14 +1396,14 @@ export default function GamePage() {
               <>
                 <video
                   className="tg-tong-intro-video"
-                  autoPlay
-                  muted
-                  playsInline
-                  preload="auto"
-                  loop
-                >
-                  <source src="/assets/tong_intro.webm" type='video/webm; codecs="vp09.02.10.08.01"' />
-                </video>
+                autoPlay
+                muted
+                playsInline
+                preload="auto"
+                loop
+              >
+                <source src={GAME_INTRO_VIDEO_URL} type='video/webm; codecs="vp09.02.10.08.01"' />
+              </video>
                 <div className="tg-tong-intro-subtitle">
                   <p className="dialogue-speaker" style={{ color: 'var(--color-accent-gold, #f0c040)' }}>Tong</p>
                   <p className="dialogue-text">
@@ -1837,9 +1842,10 @@ export default function GamePage() {
   const npcCity = (npcChar?.cityId ?? city) as CityId;
   const targetLang = getLanguageForCity(npcCity);
   const explainLang = (gameState.explainIn[npcCity] ?? 'en') as UILang;
+  const resolvedDynamicBackdropUrl = resolveRuntimeAssetUrl(dynamicBackdrop?.url);
 
   if (sceneSummary) {
-    const backdropUrl = dynamicBackdrop?.url ?? '/assets/backdrops/seoul/pojangmacha.png';
+    const backdropUrl = resolvedDynamicBackdropUrl || SEOUL_FOOD_STREET_BACKDROP_URL;
     return (
       <UILangProvider value={explainLang}>
         <div className="scene-root" style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
@@ -1900,7 +1906,7 @@ export default function GamePage() {
     <div className="scene-root" style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
       <div className="game-frame">
         <SceneView
-          backgroundUrl={dynamicBackdrop?.url ?? '/assets/backdrops/seoul/pojangmacha.png'}
+          backgroundUrl={resolvedDynamicBackdropUrl || SEOUL_FOOD_STREET_BACKDROP_URL}
           backgroundTransition={dynamicBackdrop?.transition}
           ambientDescription={dynamicBackdrop?.ambientDescription ?? 'A warm pojangmacha (street food tent) on a Seoul side street'}
           cinematic={cinematic}

--- a/apps/client/app/page.tsx
+++ b/apps/client/app/page.tsx
@@ -3,8 +3,10 @@
 import { useState, useEffect, useRef, useCallback, FormEvent, Suspense } from 'react';
 import { useSearchParams } from 'next/navigation';
 import Image from 'next/image';
+import { runtimeAssetUrl } from '@/lib/runtime-assets';
 
 const API_BASE = 'https://tong-api.erniesg.workers.dev';
+const LANDING_LOGO_URL = runtimeAssetUrl('app.logo.trimmed.default');
 
 /* ── Language gauge (mirrors game onboarding) ──────────────── */
 type CjkLang = 'ko' | 'ja' | 'zh';
@@ -213,7 +215,7 @@ function LandingPage() {
       <nav className="landing-nav">
         <a href="/" className="landing-nav-brand">
           <Image
-            src="/assets/app/logo_trimmed.png"
+            src={LANDING_LOGO_URL}
             alt="Tong"
             width={30}
             height={30}
@@ -414,7 +416,7 @@ function LandingPage() {
       <footer className="landing-footer">
         <div className="landing-footer-brand">
           <Image
-            src="/assets/app/logo_trimmed.png"
+            src={LANDING_LOGO_URL}
             alt="Tong"
             width={30}
             height={30}

--- a/apps/client/app/roadmap/page.tsx
+++ b/apps/client/app/roadmap/page.tsx
@@ -11,6 +11,9 @@ import {
   type RoadmapExecution,
   type RoadmapIssue,
 } from '@/lib/content/roadmap';
+import { runtimeAssetUrl } from '@/lib/runtime-assets';
+
+const ROADMAP_LOGO_URL = runtimeAssetUrl('app.logo.trimmed.default');
 
 export const metadata: Metadata = {
   title: 'Tong Roadmap',
@@ -270,7 +273,7 @@ export default function RoadmapPage() {
       <nav className="landing-nav roadmap-nav">
         <Link href="/" className="landing-nav-brand">
           <Image
-            src="/assets/app/logo_trimmed.png"
+            src={ROADMAP_LOGO_URL}
             alt="Tong"
             width={30}
             height={30}

--- a/apps/client/components/city-map/CityMap.tsx
+++ b/apps/client/components/city-map/CityMap.tsx
@@ -8,6 +8,7 @@ import { LocationPin } from './LocationPin';
 import { LocationSheet } from './LocationSheet';
 import { KoreanText } from '@/components/shared/KoreanText';
 import { getLanguageForCity } from '@/lib/content/locations';
+import { runtimeAssetUrl } from '@/lib/runtime-assets';
 
 /* ── Constants ──────────────────────────────────────────────── */
 
@@ -17,6 +18,21 @@ const CITY_META: Record<CityId, { en: string; local: string; hasVideo: boolean }
   tokyo:    { en: 'Tokyo',    local: '東京', hasVideo: true },
   seoul:    { en: 'Seoul',    local: '서울', hasVideo: true },
   shanghai: { en: 'Shanghai', local: '上海', hasVideo: true },
+};
+
+const CITY_MEDIA: Record<CityId, { poster: string; video: string }> = {
+  tokyo: {
+    poster: runtimeAssetUrl('city.tokyo.map.static.default'),
+    video: runtimeAssetUrl('city.tokyo.map.video.default'),
+  },
+  seoul: {
+    poster: runtimeAssetUrl('city.seoul.map.static.default'),
+    video: runtimeAssetUrl('city.seoul.map.video.default'),
+  },
+  shanghai: {
+    poster: runtimeAssetUrl('city.shanghai.map.static.default'),
+    video: runtimeAssetUrl('city.shanghai.map.video.default'),
+  },
 };
 
 /* ── Per-city location configs ────────────────────────────────── */
@@ -218,7 +234,8 @@ export function CityMap({
   /* ── Background ─────────────────────────────────────────── */
 
   const bgStyle = { transform: `translateX(${dragOffset}px)` };
-  const videoSrc = `/assets/locations/${city}.mp4`;
+  const cityMedia = CITY_MEDIA[city];
+  const videoSrc = cityMedia.video;
 
   return (
     <div
@@ -238,7 +255,7 @@ export function CityMap({
             muted
             playsInline
             preload="auto"
-            poster={`/assets/locations/${city}-static.png`}
+            poster={cityMedia.poster}
           >
             <source src={videoSrc} type="video/mp4" />
           </video>
@@ -259,7 +276,7 @@ export function CityMap({
           key={city}
           className={`city-map__bg${comingSoon ? ' city-map__bg--greyscale' : ''}`}
           style={bgStyle}
-          src={`/assets/locations/${city}-static.png`}
+          src={cityMedia.poster}
           alt={meta.en}
         />
       )}

--- a/apps/client/components/scene/TongOverlay.tsx
+++ b/apps/client/components/scene/TongOverlay.tsx
@@ -2,6 +2,7 @@
 
 import { cn } from '@/lib/utils/cn';
 import { KoreanText, type TargetLang } from '@/components/shared/KoreanText';
+import { tongExpressionUrl } from '@/lib/content/tong-expressions';
 
 interface TongOverlayProps {
   message: string;
@@ -23,7 +24,7 @@ export function TongOverlay({ message, translation, visible, targetLang = 'ko', 
       onClick={onDismiss}
     >
       <div className="flex items-start gap-2">
-        <img src="/assets/characters/tong/tong_cheerful.png" alt="Tong" className="tong-whisper__avatar" />
+        <img src={tongExpressionUrl('cheerful')} alt="Tong" className="tong-whisper__avatar" />
         <div className="min-w-0">
           <p className="font-bold tong-whisper__label m-0" style={{ fontSize: 'var(--game-text-sm)' }}>{targetLang === 'zh' ? '小通' : 'Tong'}</p>
           <p className="mt-0.5 text-ko leading-snug tong-whisper__body m-0" style={{ fontSize: 'var(--game-text-lg)' }}><KoreanText text={message} targetLang={targetLang} /></p>

--- a/apps/client/lib/ai/prompts/hangout-orchestrator.ts
+++ b/apps/client/lib/ai/prompts/hangout-orchestrator.ts
@@ -245,7 +245,7 @@ TOOL USAGE GUIDE:
    - Use for sub-location transitions (e.g., from outside to inside, counter to kitchen).
    - transition: "fade" (smooth 0.5s crossfade) or "cut" (instant).
    - Do NOT overuse — 1-2 backdrop changes per hangout at most.
-   - backdropUrl must be a valid path under /assets/backdrops/<city>/.
+   - backdropUrl must be a valid runtime asset URL for the selected city backdrop.
 
 8. play_cinematic(videoUrl, caption?, autoAdvance)
    - Play a short video clip overlaying the scene (establishing shot, character intro, transition).

--- a/apps/client/lib/content/characters.ts
+++ b/apps/client/lib/content/characters.ts
@@ -1,4 +1,5 @@
 import type { Character, RelationshipStage } from '../types/relationship';
+import { runtimeAssetUrl } from '@/lib/runtime-assets';
 
 function stageMap(
   stages: Record<
@@ -263,36 +264,36 @@ export interface TutorialVideoConfig {
 export const TUTORIAL_VIDEO_CONFIG: Record<string, TutorialVideoConfig> = {
   haeun: {
     introVideoUrls: [
-      '/assets/cinematics/haeun/intro_3.mp4',
+      runtimeAssetUrl('cinematic.haeun.intro.3'),
     ],
     exitClips: [
       {
-        video: '/assets/cinematics/haeun/exit_3.mp4',
+        video: runtimeAssetUrl('cinematic.haeun.exit.3'),
         line: '{playerName}...아니, {chineseName}. 나쁘지 않았어.',
         translation: '{playerName}...no, {chineseName}. Not bad.',
       },
       {
-        video: '/assets/cinematics/haeun/exit_4.mp4',
+        video: runtimeAssetUrl('cinematic.haeun.exit.4'),
         line: '흥, {playerName}... 조금은 인정해줄게.',
         translation: 'Hmph, {playerName}... I\'ll give you a little credit.',
       },
     ],
     exitVideoPromptTemplate: `韩国首尔深夜포장마차路边摊。一位年轻韩国女性，长直黑发齐刘海，穿黑色皮夹克、白色露脐上衣、蓝色牛仔裤，戴银色十字架耳环和细链项链，站在热气腾腾的摊位前。她转向镜头，微微挑眉，嘴角不自觉地勾了一下，带着自信的语气说："{exitLine}"。说完她微微侧头，眼神停留一瞬，然后转身走入霓虹灯照亮的夜色中。她的声音特征：女性，约18-22岁，音色明亮有锐度，语速中等偏快，情绪基线自信、带一丝不易察觉的认可。暖黄灯笼光映照侧脸，背景是冒着热气的大锅和绿色烧酒瓶。镜头从近景缓推至中景跟拍她离开的背影。写实风格，韩剧电影质感，浅景深。`,
-    sceneImageUrl: '/assets/characters/haeun/scene.png',
+    sceneImageUrl: runtimeAssetUrl('character.haeun.scene.default'),
   },
   jin: {
     introVideoUrls: [
-      '/assets/cinematics/jin/intro_1.mp4',
-      '/assets/cinematics/jin/intro_2.mp4',
+      runtimeAssetUrl('cinematic.jin.intro.1'),
+      runtimeAssetUrl('cinematic.jin.intro.2'),
     ],
     exitClips: [
       {
-        video: '/assets/cinematics/jin/exit_1.mp4',
+        video: runtimeAssetUrl('cinematic.jin.exit.1'),
         line: '{playerName}, 잘했어! 다음에 또 보자.',
         translation: '{playerName}, you did well! See you next time.',
       },
     ],
     exitVideoPromptTemplate: `韩国首尔深夜포장마차路边摊。一位年轻韩国男性，中棕色微卷短发，穿奶白色针织毛衣，坐在摊位前。他抬头看向镜头，露出温暖的笑容，轻声说："{exitLine}"。说完他微微点头，站起身来拍了拍衣服，慢慢走进夜色中，回头挥了一下手。他的声音特征：男性，约22-26岁，中音域温暖沉稳，语速中等，情绪基线温柔、鼓励。暖黄灯笼光柔和照亮面部，镜头从近景平稳推至中景跟拍他离开。写实风格，韩剧暖心质感。`,
-    sceneImageUrl: '/assets/characters/jin/scene.png',
+    sceneImageUrl: runtimeAssetUrl('character.jin.scene.default'),
   },
 };

--- a/apps/client/lib/content/pojangmacha.ts
+++ b/apps/client/lib/content/pojangmacha.ts
@@ -1,4 +1,5 @@
 import type { Location, VocabularyTarget, GrammarTarget, LearningObjective } from '../types/objectives';
+import { runtimeAssetUrl } from '@/lib/runtime-assets';
 
 const LEVEL_0_OBJECTIVES: LearningObjective[] = [
   {
@@ -285,7 +286,7 @@ export const POJANGMACHA: Location = {
   name: { en: 'Street Food Stall', ko: '포장마차' },
   domain: 'food',
   order: 1,
-  backgroundImageUrl: '/assets/backdrops/seoul/pojangmacha.png',
+  backgroundImageUrl: runtimeAssetUrl('city.seoul.location.food-street.backdrop.default'),
   ambientDescription:
     'A lively 포장마차 tent near Hongdae. Steam rises from bubbling pots of 떡볶이 and 어묵. Orange plastic stools, a handwritten menu board, and the sound of sizzling oil. Ajusshi wipes the counter with a practiced hand. Other trainees drift in and out.',
   levels: [

--- a/apps/client/lib/content/tong-expressions.ts
+++ b/apps/client/lib/content/tong-expressions.ts
@@ -1,3 +1,5 @@
+import { runtimeAssetUrl } from '@/lib/runtime-assets';
+
 export type TongExpression =
   | 'neutral'
   | 'cheerful'
@@ -11,16 +13,16 @@ export type TongExpression =
   | 'thinking';
 
 export const TONG_EXPRESSIONS: Record<TongExpression, string> = {
-  neutral:   '/assets/characters/tong/tong_neutral.png',
-  cheerful:  '/assets/characters/tong/tong_cheerful.png',
-  surprised: '/assets/characters/tong/tong_surprised.png',
-  proud:     '/assets/characters/tong/tong_proud.png',
-  love:      '/assets/characters/tong/tong_love.png',
-  sad:       '/assets/characters/tong/tong_sad.png',
-  crying:    '/assets/characters/tong/tong_crying.png',
-  amazed:    '/assets/characters/tong/tong_amazed.png',
-  excited:   '/assets/characters/tong/tong_excited.png',
-  thinking:  '/assets/characters/tong/tong_thinking.png',
+  neutral: runtimeAssetUrl('character.tong.expression.neutral'),
+  cheerful: runtimeAssetUrl('character.tong.expression.cheerful'),
+  surprised: runtimeAssetUrl('character.tong.expression.surprised'),
+  proud: runtimeAssetUrl('character.tong.expression.proud'),
+  love: runtimeAssetUrl('character.tong.expression.love'),
+  sad: runtimeAssetUrl('character.tong.expression.sad'),
+  crying: runtimeAssetUrl('character.tong.expression.crying'),
+  amazed: runtimeAssetUrl('character.tong.expression.amazed'),
+  excited: runtimeAssetUrl('character.tong.expression.excited'),
+  thinking: runtimeAssetUrl('character.tong.expression.thinking'),
 };
 
 export function tongExpressionUrl(expression: TongExpression = 'cheerful'): string {

--- a/apps/client/lib/hooks/useVideoGeneration.ts
+++ b/apps/client/lib/hooks/useVideoGeneration.ts
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useCallback, useEffect } from 'react';
 import { volcVideoCreate, volcVideoGet } from '@/lib/api';
+import { runtimeAssetUrl } from '@/lib/runtime-assets';
 
 export interface VideoGenState {
   taskId: string | null;
@@ -16,7 +17,7 @@ const TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
 
 /** Mock: ramp progress over durationMs, then succeed with a placeholder URL */
 const MOCK_DURATION_MS = 30_000; // 30s simulated generation
-const MOCK_VIDEO_URL = '/assets/cinematics/haeun/exit_3.mp4';
+const MOCK_VIDEO_URL = runtimeAssetUrl('cinematic.haeun.exit.3');
 
 interface UseVideoGenerationOptions {
   mock?: boolean;

--- a/apps/client/lib/runtime-assets.ts
+++ b/apps/client/lib/runtime-assets.ts
@@ -1,0 +1,107 @@
+import runtimeAssetManifestJson from '../../../assets/manifest/runtime-asset-manifest.json';
+
+interface RuntimeAssetManifestEntry {
+  key: string;
+  uri: string;
+  type: string;
+  usage: string;
+  source: string;
+  status: string;
+}
+
+interface RuntimeAssetManifest {
+  manifestVersion: string;
+  owner: string;
+  keyFormat: string;
+  sourceManifest: string;
+  notes: string;
+  assets: RuntimeAssetManifestEntry[];
+}
+
+const runtimeAssetManifest = runtimeAssetManifestJson as RuntimeAssetManifest;
+const runtimeAssetsByKey = new Map(runtimeAssetManifest.assets.map((asset) => [asset.key, asset] as const));
+const runtimeAssetBaseUrl = normalizeAssetBaseUrl(process.env.NEXT_PUBLIC_TONG_ASSETS_BASE_URL);
+
+function normalizeAssetBaseUrl(baseUrl?: string): string | null {
+  if (!baseUrl) return null;
+
+  const trimmed = baseUrl.trim();
+  if (!trimmed) return null;
+
+  return trimmed.replace(/\/+$/, '');
+}
+
+function isAbsoluteUrl(value: string): boolean {
+  return /^[a-z][a-z0-9+.-]*:\/\//i.test(value);
+}
+
+function joinAssetBase(pathname: string): string {
+  if (!runtimeAssetBaseUrl) return pathname;
+
+  const normalizedPath = pathname.startsWith('/') ? pathname : `/${pathname}`;
+  return `${runtimeAssetBaseUrl}${normalizedPath}`;
+}
+
+export function hasRuntimeAssetKey(key: string): boolean {
+  return runtimeAssetsByKey.has(key);
+}
+
+export function getRuntimeAssetEntry(key: string): RuntimeAssetManifestEntry | null {
+  return runtimeAssetsByKey.get(key) ?? null;
+}
+
+export function resolveRuntimeAssetUrl(ref?: string | null): string {
+  if (!ref) return '';
+
+  const trimmed = ref.trim();
+  if (!trimmed) return '';
+
+  const manifestEntry = runtimeAssetsByKey.get(trimmed);
+  if (manifestEntry) {
+    return resolveRuntimeAssetUrl(manifestEntry.uri);
+  }
+
+  if (isAbsoluteUrl(trimmed)) {
+    return trimmed;
+  }
+
+  if (trimmed.startsWith('/assets/')) {
+    return joinAssetBase(trimmed);
+  }
+
+  if (trimmed.startsWith('assets/')) {
+    return joinAssetBase(trimmed);
+  }
+
+  return trimmed;
+}
+
+export function resolveRuntimeAssetUrls(refs: Array<string | null | undefined>): string[] {
+  const urls = refs
+    .map((ref) => resolveRuntimeAssetUrl(ref))
+    .filter((ref): ref is string => Boolean(ref));
+
+  return [...new Set(urls)];
+}
+
+export function resolveCharacterAssetUrl(pathSegment?: string | null): string {
+  if (!pathSegment) return '';
+  return resolveRuntimeAssetUrl(`assets/characters/${pathSegment}`);
+}
+
+export function runtimeAssetUrl(key: string, fallbackRef?: string): string {
+  const manifestEntry = runtimeAssetsByKey.get(key);
+  if (manifestEntry) {
+    return resolveRuntimeAssetUrl(manifestEntry.uri);
+  }
+
+  if (fallbackRef) {
+    return resolveRuntimeAssetUrl(fallbackRef);
+  }
+
+  throw new Error(`Unknown runtime asset key: ${key}`);
+}
+
+export function getRuntimeAssetManifest(): RuntimeAssetManifest {
+  return runtimeAssetManifest;
+}

--- a/apps/client/next.config.mjs
+++ b/apps/client/next.config.mjs
@@ -2,9 +2,37 @@ import { initOpenNextCloudflareForDev } from '@opennextjs/cloudflare';
 
 initOpenNextCloudflareForDev();
 
+function buildAssetRemotePattern(baseUrl) {
+  if (!baseUrl) return null;
+
+  try {
+    const parsed = new URL(baseUrl);
+    return {
+      protocol: parsed.protocol.replace(':', ''),
+      hostname: parsed.hostname,
+      port: parsed.port,
+      pathname: '/assets/**',
+    };
+  } catch {
+    return null;
+  }
+}
+
+const assetRemotePattern = buildAssetRemotePattern(
+  process.env.NEXT_PUBLIC_TONG_ASSETS_BASE_URL || 'https://assets.tong.berlayar.ai',
+);
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true
+  reactStrictMode: true,
+  experimental: {
+    externalDir: true,
+  },
+  images: assetRemotePattern
+    ? {
+        remotePatterns: [assetRemotePattern],
+      }
+    : undefined,
 };
 
 export default nextConfig;

--- a/docs/handoff-notes.md
+++ b/docs/handoff-notes.md
@@ -65,3 +65,18 @@ Template:
 - Integration risks:
   - Placeholder videos unblock validation but should be replaced by final art/video as the city and cinematic packs land.
 - Next owner: `codex/client-runtime`
+
+## 2026-03-15 (Issue 37 runtime asset resolver)
+- Date: 2026-03-15
+- Branch/worktree: `codex/fix-issue-37-runtime-asset-resolution` (shared root workspace)
+- What changed:
+  - Added `apps/client/lib/runtime-assets.ts` so client/runtime surfaces resolve canonical runtime asset keys through the runtime manifest and `NEXT_PUBLIC_TONG_ASSETS_BASE_URL`.
+  - Rewired active game, city-map, Tong overlay, content config, and shell logo surfaces away from hardcoded runtime file paths.
+  - Tightened `demo:smoke` so runtime source under `apps/client/{app,components,lib}` must use manifest-key resolution and cannot reintroduce direct `/assets/...` literals.
+- Contract changes:
+  - Client runtime now consumes runtime asset manifest keys instead of relying on local public-path assumptions.
+  - Next.js config allows the remote runtime asset host for image optimization and external manifest import.
+- Integration risks:
+  - Any newly added runtime media must land in `assets/manifest/runtime-asset-manifest.json` before client code can reference it via `runtimeAssetUrl(...)`.
+  - Legacy preview HTML and non-runtime scripts still use literal `/assets/...` references and remain outside the runtime smoke gate.
+- Next owner: `codex/runtime-assets`

--- a/scripts/demo_smoke_check.mjs
+++ b/scripts/demo_smoke_check.mjs
@@ -4,10 +4,16 @@ import path from "node:path";
 const root = process.cwd();
 const clientRoot = path.join(root, "apps/client");
 const clientPublicRoot = path.join(clientRoot, "public");
+const runtimeSourceRoots = [
+  path.join(clientRoot, "app"),
+  path.join(clientRoot, "components"),
+  path.join(clientRoot, "lib"),
+];
+const runtimeSourceFileExtensions = new Set([".ts", ".tsx", ".js", ".jsx"]);
 const clientAssetRefPattern = /\/assets\/[A-Za-z0-9_./-]+\.(?:png|jpg|jpeg|webp|svg|mp4|webm)/g;
-const sourceFileExtensions = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".html"]);
+const runtimeAssetKeyCallPattern = /\bruntimeAssetUrl\(\s*['"]([^'"]+)['"]\s*(?:,|\))/g;
 
-function walkFiles(dir, files = []) {
+function walkFiles(dir, files = [], allowedExtensions = runtimeSourceFileExtensions) {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
     const fullPath = path.join(dir, entry.name);
     if (entry.isDirectory()) {
@@ -17,11 +23,11 @@ function walkFiles(dir, files = []) {
       if (fullPath === path.join(clientPublicRoot, "assets")) {
         continue;
       }
-      walkFiles(fullPath, files);
+      walkFiles(fullPath, files, allowedExtensions);
       continue;
     }
 
-    if (sourceFileExtensions.has(path.extname(entry.name))) {
+    if (allowedExtensions.has(path.extname(entry.name))) {
       files.push(fullPath);
     }
   }
@@ -29,14 +35,28 @@ function walkFiles(dir, files = []) {
   return files;
 }
 
-function collectClientAssetRefs() {
-  const refs = new Set();
-  for (const file of walkFiles(clientRoot)) {
-    const contents = fs.readFileSync(file, "utf8");
-    const matches = contents.match(clientAssetRefPattern) ?? [];
-    for (const match of matches) refs.add(match);
+function collectClientRuntimeAssetUsage() {
+  const directRefsByFile = new Map();
+  const manifestKeys = new Set();
+
+  for (const dir of runtimeSourceRoots) {
+    for (const file of walkFiles(dir, [], runtimeSourceFileExtensions)) {
+      const contents = fs.readFileSync(file, "utf8");
+      const directMatches = [...new Set(contents.match(clientAssetRefPattern) ?? [])];
+      if (directMatches.length > 0) {
+        directRefsByFile.set(file, directMatches);
+      }
+
+      for (const match of contents.matchAll(runtimeAssetKeyCallPattern)) {
+        manifestKeys.add(match[1]);
+      }
+    }
   }
-  return [...refs].sort();
+
+  return {
+    directRefsByFile,
+    manifestKeys: [...manifestKeys].sort(),
+  };
 }
 
 function resolveManifestUri(uri) {
@@ -141,7 +161,7 @@ const shanghaiRewardBundle = JSON.parse(
     "utf8"
   )
 );
-const clientAssetRefs = collectClientAssetRefs();
+const clientRuntimeAssetUsage = collectClientRuntimeAssetUsage();
 
 if (!Array.isArray(loop.cities) || loop.cities.length !== 3) {
   console.error("Expected exactly 3 cities in game-loop.json");
@@ -269,7 +289,6 @@ if (runtimeAssetManifest.keyFormat !== "domain.scope.name.variant") {
 const runtimeKeys = runtimeAssetManifest.assets.map((asset) => asset.key);
 const canonicalKeys = (canonicalAssetManifest.assets ?? []).map((asset) => asset.key);
 const runtimeAssetsByKey = new Map(runtimeAssetManifest.assets.map((asset) => [asset.key, asset]));
-const runtimeUris = new Set(runtimeAssetManifest.assets.map((asset) => asset.uri));
 
 if (canonicalAssetManifest.keyFormat !== "domain.scope.name.variant") {
   console.error("Unexpected keyFormat in canonical asset manifest");
@@ -340,15 +359,32 @@ for (const asset of canonicalAssetManifest.assets) {
   }
 }
 
-for (const ref of clientAssetRefs) {
-  if (!runtimeUris.has(ref)) {
-    console.error(`Client asset reference missing from runtime manifest: ${ref}`);
+if (clientRuntimeAssetUsage.directRefsByFile.size > 0) {
+  console.error("Client runtime still contains direct /assets/... references:");
+  for (const [file, refs] of clientRuntimeAssetUsage.directRefsByFile.entries()) {
+    console.error(`- ${path.relative(root, file)}`);
+    for (const ref of refs) {
+      console.error(`  - ${ref}`);
+    }
+  }
+  process.exit(1);
+}
+
+if (clientRuntimeAssetUsage.manifestKeys.length === 0) {
+  console.error("Expected client runtime to resolve at least one asset via runtimeAssetUrl()");
+  process.exit(1);
+}
+
+for (const key of clientRuntimeAssetUsage.manifestKeys) {
+  const runtimeAsset = runtimeAssetsByKey.get(key);
+  if (!runtimeAsset) {
+    console.error(`Client runtime asset key missing from manifest: ${key}`);
     process.exit(1);
   }
 
-  const resolvedPath = resolveManifestUri(ref);
+  const resolvedPath = resolveManifestUri(runtimeAsset.uri);
   if (!fs.existsSync(resolvedPath)) {
-    console.error(`Client asset reference missing on disk: ${ref}`);
+    console.error(`Client runtime asset key ${key} points to missing file: ${runtimeAsset.uri}`);
     process.exit(1);
   }
 }
@@ -390,4 +426,4 @@ console.log("- Player media profile includes youtube + spotify signals");
 console.log("- Demo secret status fixture validated");
 console.log("- Runtime asset manifest keys validated");
 console.log("- Canonical/runtime manifest parity validated");
-console.log(`- Client asset references resolved (${clientAssetRefs.length})`);
+console.log(`- Client runtime manifest keys resolved (${clientRuntimeAssetUsage.manifestKeys.length})`);


### PR DESCRIPTION
## Summary
- add a shared runtime asset resolver that reads the runtime manifest and applies `NEXT_PUBLIC_TONG_ASSETS_BASE_URL`
- switch active client/runtime surfaces off hardcoded runtime file paths and onto manifest-backed keys
- tighten `demo:smoke` so runtime source must use manifest-key resolution instead of direct `/assets/...` literals

Fixes #37
Part of #29

## How to test
- run `npm run demo:smoke`
- run `npm --prefix apps/client run build`
- open `/game` and verify the opening video, map backdrops, Tong avatar, and tutorial media still load via the resolved runtime asset URLs