### PR TITLE
feat: define durable session, checkpoint, and scenario-seed contracts

### DIFF
--- a/apps/server/src/index.mjs
+++ b/apps/server/src/index.mjs
@@ -822,7 +822,7 @@ function buildPersonalizedObjective({
   };
 }
 
-function buildGameStartResponse(userId, incomingProfile) {
+function buildGameStartResponse(userId, incomingProfile, sessionId) {
   const profile = incomingProfile || getProfile(userId) || FIXTURES.gameStart.profile;
   const dominantClusterId = getDominantClusterId(ensureIngestionForUser(userId));
   const city = CLUSTER_CITY_MAP[dominantClusterId] || FIXTURES.gameStart.city || 'seoul';
@@ -835,16 +835,198 @@ function buildGameStartResponse(userId, incomingProfile) {
     city,
     location,
   });
+  const nowIso = new Date().toISOString();
+  const sceneId = `${location}_hangout_intro`;
+  const sceneSessionId = `scene_${sessionId}_001`;
+  const actions = [
+    'Start hangout validation',
+    'Review personalized learn targets',
+    `Practice ${weakestLang.toUpperCase()} objective ${objective.objectiveId}`,
+  ];
+  const activeObjective = {
+    objectiveId: objective.objectiveId,
+    lang: weakestLang,
+    mode: 'hangout',
+    cityId: city,
+    locationId: location,
+    objectiveCategory: objective.objectiveGraph?.objectiveCategory,
+    objectiveNodeId: objective.objectiveGraph?.objectiveNodeId,
+    targetNodeIds: cloneJson(objective.objectiveGraph?.targetNodeIds || []),
+    summary: `Resume ${weakestLang.toUpperCase()} practice at ${location.replace(/_/g, ' ')}.`,
+  };
+  const progression = {
+    ...(cloneJson(FIXTURES.gameStart.progression || {})),
+    xp: FIXTURES.gameStart.progression?.xp ?? 110,
+    sp: FIXTURES.gameStart.progression?.sp ?? 45,
+    rp: FIXTURES.gameStart.progression?.rp ?? 12,
+    currentMasteryLevel: FIXTURES.gameStart.progression?.currentMasteryLevel ?? 1,
+  };
+  const missionGate = {
+    readiness: 0.34,
+    validatedHangouts: 0,
+    missionAssessmentUnlocked: false,
+    masteryTier: progression.currentMasteryLevel,
+  };
+  const unlocks = {
+    locationIds: [location],
+    missionIds: [],
+    rewardIds: [],
+  };
+  const checkpoint = {
+    checkpointId: `ckpt_${sessionId}_intro`,
+    gameSessionId: sessionId,
+    sceneSessionId,
+    kind: 'player_resume',
+    route: {
+      pathname: '/game',
+      query: {
+        city,
+        location,
+        mode: 'hangout',
+        resume: '1',
+      },
+    },
+    cityId: city,
+    locationId: location,
+    mode: 'hangout',
+    objective: cloneJson(activeObjective),
+    phase: 'intro',
+    turn: 1,
+    progressionDelta: {
+      xp: 0,
+      sp: 0,
+      rp: 0,
+      objectiveProgressDelta: 0,
+      validatedHangoutsDelta: 0,
+    },
+    rewards: [],
+    missionGate: cloneJson(missionGate),
+    unlocks: cloneJson(unlocks),
+    rng: {
+      seed: `${sessionId}_intro`,
+      version: 1,
+    },
+    createdAtIso: nowIso,
+  };
+  const availableScenarioSeeds = [
+    {
+      seedId: 'review_ready',
+      label: 'Review-ready food street checkpoint',
+      source: 'qa',
+      qaOnly: true,
+      route: {
+        pathname: '/game',
+        query: {
+          city,
+          location,
+          mode: 'hangout',
+          qa_trace: '1',
+          scenarioSeed: 'review_ready',
+        },
+      },
+      cityId: city,
+      locationId: location,
+      mode: 'hangout',
+      objective: cloneJson(activeObjective),
+      phase: 'review',
+      turn: 4,
+      activeExercise: {
+        exerciseId: 'block_crush_food_003',
+        exerciseType: 'block_crush',
+        stepIndex: 2,
+        prompt: 'Hold before the final review decision.',
+        payloadVersion: 1,
+        state: {
+          targetChar: weakestLang === 'ko' ? '뉴' : weakestLang === 'ja' ? '食' : '单',
+          remainingLives: 2,
+          boardPieces: weakestLang === 'ko' ? ['ㅁ', 'ㅠ'] : weakestLang === 'ja' ? ['し', 'ょ'] : ['订', '单'],
+          requiredMatches: 1,
+        },
+      },
+      progressionDelta: {
+        xp: 8,
+        sp: 2,
+        rp: 1,
+        objectiveProgressDelta: 0.25,
+        validatedHangoutsDelta: 0,
+      },
+      rewards: [],
+      rng: {
+        seed: 'review_ready_seed_v1',
+        version: 1,
+      },
+      notes: 'Use for QA/demo capture only; do not expose as player-facing resume.',
+    },
+  ];
 
   return {
     ...cloneJson(FIXTURES.gameStart),
+    sessionId,
     city,
-    sceneId: `${location}_hangout_intro`,
-    actions: [
-      'Start hangout validation',
-      'Review personalized learn targets',
-      `Practice ${weakestLang.toUpperCase()} objective ${objective.objectiveId}`,
-    ],
+    location,
+    mode: 'hangout',
+    sceneId,
+    tongPrompt: FIXTURES.gameStart.tongPrompt || 'tong.system.food_street_intro.v1',
+    profile: cloneJson(profile),
+    progression,
+    actions,
+    resumeSource: 'new_session',
+    gameSession: {
+      sessionId,
+      userId,
+      status: 'active',
+      profile: cloneJson(profile),
+      cityId: city,
+      locationId: location,
+      currentMode: 'hangout',
+      activeSceneId: sceneId,
+      activeSceneSessionId: sceneSessionId,
+      activeObjective,
+      progression: cloneJson(progression),
+      missionGate: cloneJson(missionGate),
+      unlocks: cloneJson(unlocks),
+      rewards: [],
+      availableActions: actions,
+      resumeSource: 'new_session',
+      activeCheckpointId: checkpoint.checkpointId,
+      startedAtIso: nowIso,
+      updatedAtIso: nowIso,
+    },
+    sceneSession: {
+      sceneSessionId,
+      gameSessionId: sessionId,
+      sceneId,
+      cityId: city,
+      locationId: location,
+      mode: 'hangout',
+      objective: cloneJson(activeObjective),
+      phase: 'intro',
+      turn: 1,
+      route: {
+        pathname: '/game',
+        query: {
+          city,
+          location,
+          mode: 'hangout',
+        },
+      },
+      progressionDelta: {
+        xp: 0,
+        sp: 0,
+        rp: 0,
+        objectiveProgressDelta: 0,
+        validatedHangoutsDelta: 0,
+      },
+      checkpointable: true,
+      uiPolicy: {
+        immersiveFirstPerson: true,
+        allowOnlyDialogueAndHints: true,
+      },
+      startedAtIso: nowIso,
+      updatedAtIso: nowIso,
+    },
+    activeCheckpoint: checkpoint,
+    availableScenarioSeeds,
   };
 }
 
@@ -1673,11 +1855,16 @@ const server = http.createServer(async (req, res) => {
         state.profiles.set(userId, { userId, profile: body.profile });
       }
       const sessionId = `sess_${Math.random().toString(36).slice(2, 10)}`;
-      const response = { ...buildGameStartResponse(userId, body.profile), sessionId };
+      const response = buildGameStartResponse(userId, body.profile, sessionId);
       state.sessions.set(sessionId, {
         userId,
-        turn: 1,
-        score: { xp: 0, sp: 0, rp: 0 },
+        city: response.city,
+        location: response.location,
+        sceneId: response.sceneId,
+        objectiveId: response.gameSession.activeObjective.objectiveId,
+        checkpointId: response.activeCheckpoint?.checkpointId,
+        turn: response.sceneSession.turn,
+        score: { xp: response.progression.xp, sp: response.progression.sp, rp: response.progression.rp },
       });
       jsonResponse(res, 200, response);
       return;

--- a/docs/handoff-notes.md
+++ b/docs/handoff-notes.md
@@ -80,3 +80,17 @@ Template:
   - Any newly added runtime media must land in `assets/manifest/runtime-asset-manifest.json` before client code can reference it via `runtimeAssetUrl(...)`.
   - Legacy preview HTML and non-runtime scripts still use literal `/assets/...` references and remain outside the runtime smoke gate.
 - Next owner: `codex/runtime-assets`
+
+## 2026-03-15 (Issue 48 session/checkpoint contracts)
+- Date: 2026-03-15
+- Branch/worktree: `codex/issue-48-session-contracts` (shared root workspace)
+- What changed:
+  - Crossing into `packages/contracts/**` and the mock server to add the additive `GameSession`, `SceneSession`, `Checkpoint`, and `ScenarioSeed` contract model behind `POST /api/v1/game/start-or-resume`.
+  - Extending fixture and smoke coverage so progression/resume follow-up work can build on a single durable payload shape instead of the older bootstrap-only response.
+- Contract changes:
+  - `start-or-resume` keeps the legacy top-level compatibility fields, but now also carries nested durable session/checkpoint/seed objects.
+  - Added dedicated resume fixture samples for `game.session`, `scene.session`, `checkpoint`, and `scenario seed`.
+- Integration risks:
+  - Follow-up server/client branches should consume the nested contract objects rather than re-inventing ad hoc resume payloads.
+  - This change touches the shared contracts zone; dependent progression branches should rebase before landing resume/checkpoint work.
+- Next owner: `codex/server-api`

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -10,6 +10,8 @@ Keep this package stable:
 Typed contracts:
 - `types.ts` defines TypeScript request/response models for Tong demo endpoints.
 - `index.ts` re-exports typed contracts for app usage.
+- `fixtures/game.start-or-resume.sample.json` now includes the additive nested session model used for player resume and QA seed routing.
+- `fixtures/game.session.sample.json`, `fixtures/scene.session.sample.json`, `fixtures/checkpoint.player-resume.sample.json`, and `fixtures/scenario.seed.review-ready.sample.json` are the canonical samples for progression/resume work.
 
 Curriculum graph fixtures:
 - `fixtures/curriculum.graph.food-street.sample.json` is the canonical typed curriculum-graph sample.

--- a/packages/contracts/api-contract.md
+++ b/packages/contracts/api-contract.md
@@ -390,11 +390,86 @@ Response:
 {
   "sessionId": "sess_123",
   "city": "seoul",
+  "location": "food_street",
   "sceneId": "intro_001",
+  "mode": "hangout",
   "tongPrompt": "in-character system prompt token or id",
-  "actions": ["Train vocals", "Attend language class", "Meet cast member"]
+  "profile": {
+    "nativeLanguage": "en",
+    "targetLanguages": ["ko", "ja", "zh"],
+    "proficiency": {
+      "ko": "beginner",
+      "ja": "none",
+      "zh": "advanced"
+    }
+  },
+  "progression": {
+    "xp": 110,
+    "sp": 45,
+    "rp": 12,
+    "currentMasteryLevel": 1
+  },
+  "actions": ["Start hangout validation", "Review personalized learn targets"],
+  "resumeSource": "new_session",
+  "gameSession": {
+    "sessionId": "sess_123",
+    "status": "active",
+    "cityId": "seoul",
+    "locationId": "food_street",
+    "currentMode": "hangout",
+    "activeSceneId": "food_street_hangout_intro",
+    "activeSceneSessionId": "scene_sess_123_001",
+    "activeCheckpointId": "ckpt_sess_123_intro"
+  },
+  "sceneSession": {
+    "sceneSessionId": "scene_sess_123_001",
+    "gameSessionId": "sess_123",
+    "sceneId": "food_street_hangout_intro",
+    "phase": "intro",
+    "turn": 1,
+    "checkpointable": true
+  },
+  "activeCheckpoint": {
+    "checkpointId": "ckpt_sess_123_intro",
+    "kind": "player_resume",
+    "phase": "intro",
+    "turn": 1,
+    "route": {
+      "pathname": "/game",
+      "query": {
+        "city": "seoul",
+        "location": "food_street",
+        "mode": "hangout",
+        "resume": "1"
+      }
+    },
+    "rng": {
+      "seed": "sess_123_intro",
+      "version": 1
+    }
+  },
+  "availableScenarioSeeds": [
+    {
+      "seedId": "review_ready",
+      "qaOnly": true,
+      "phase": "review",
+      "turn": 4
+    }
+  ]
 }
 ```
+
+Contract notes:
+- The legacy top-level `sessionId`, `city`, `sceneId`, `tongPrompt`, and `actions` fields remain for compatibility with current clients.
+- `gameSession` is the durable player session envelope for progression, unlocks, and the active objective.
+- `sceneSession` is the currently mounted scene/runtime slice that can advance independently of broader session metadata.
+- `activeCheckpoint` is the player-facing resume payload and must stay safe to restore on the real `/game` route.
+- `availableScenarioSeeds` are QA/demo-only deterministic setup entries and must stay separate from player resume checkpoints.
+- Dedicated samples live at:
+  - `packages/contracts/fixtures/game.session.sample.json`
+  - `packages/contracts/fixtures/scene.session.sample.json`
+  - `packages/contracts/fixtures/checkpoint.player-resume.sample.json`
+  - `packages/contracts/fixtures/scenario.seed.review-ready.sample.json`
 
 ## GET `/api/v1/objectives/next`
 Query:

--- a/packages/contracts/fixtures/checkpoint.player-resume.sample.json
+++ b/packages/contracts/fixtures/checkpoint.player-resume.sample.json
@@ -1,0 +1,68 @@
+{
+  "checkpointId": "ckpt_food_street_turn_03",
+  "gameSessionId": "sess_demo_001",
+  "sceneSessionId": "scene_sess_demo_001_001",
+  "kind": "player_resume",
+  "route": {
+    "pathname": "/game",
+    "query": {
+      "city": "seoul",
+      "location": "food_street",
+      "mode": "hangout",
+      "resume": "1"
+    }
+  },
+  "cityId": "seoul",
+  "locationId": "food_street",
+  "mode": "hangout",
+  "objective": {
+    "objectiveId": "ko_food_l2_001",
+    "lang": "ko",
+    "mode": "hangout",
+    "cityId": "seoul",
+    "locationId": "food_street",
+    "objectiveCategory": "vocabulary",
+    "objectiveNodeId": "objective:ko_food_l2_001",
+    "targetNodeIds": ["target:메뉴", "target:주문", "target:맵다"],
+    "summary": "Resume mid-ordering exercise at the last safe player-visible state."
+  },
+  "phase": "exercise",
+  "turn": 3,
+  "activeExercise": {
+    "exerciseId": "block_crush_food_003",
+    "exerciseType": "block_crush",
+    "stepIndex": 2,
+    "prompt": "Assemble 메뉴 before the final piece drops.",
+    "payloadVersion": 1,
+    "state": {
+      "targetChar": "뉴",
+      "remainingLives": 2,
+      "boardPieces": ["ㅁ", "ㅠ"],
+      "requiredMatches": 1
+    }
+  },
+  "progressionDelta": {
+    "xp": 8,
+    "sp": 2,
+    "rp": 1,
+    "objectiveProgressDelta": 0.25,
+    "validatedHangoutsDelta": 0
+  },
+  "rewards": [],
+  "missionGate": {
+    "readiness": 0.67,
+    "validatedHangouts": 1,
+    "missionAssessmentUnlocked": false,
+    "masteryTier": 1
+  },
+  "unlocks": {
+    "locationIds": ["food_street"],
+    "missionIds": ["ko_food_street_gate_01"],
+    "rewardIds": []
+  },
+  "rng": {
+    "seed": "sess_demo_001_turn_03",
+    "version": 2
+  },
+  "createdAtIso": "2026-03-15T04:58:00.000Z"
+}

--- a/packages/contracts/fixtures/game.session.sample.json
+++ b/packages/contracts/fixtures/game.session.sample.json
@@ -1,0 +1,57 @@
+{
+  "sessionId": "sess_demo_001",
+  "userId": "demo-user-1",
+  "status": "active",
+  "profile": {
+    "nativeLanguage": "en",
+    "targetLanguages": ["ko", "ja", "zh"],
+    "proficiency": {
+      "ko": "beginner",
+      "ja": "none",
+      "zh": "advanced"
+    }
+  },
+  "cityId": "seoul",
+  "locationId": "food_street",
+  "currentMode": "hangout",
+  "activeSceneId": "food_street_hangout_intro",
+  "activeSceneSessionId": "scene_sess_demo_001_001",
+  "activeObjective": {
+    "objectiveId": "ko_food_l2_001",
+    "lang": "ko",
+    "mode": "hangout",
+    "cityId": "seoul",
+    "locationId": "food_street",
+    "objectiveCategory": "vocabulary",
+    "objectiveNodeId": "objective:ko_food_l2_001",
+    "targetNodeIds": ["target:메뉴", "target:주문", "target:맵다"],
+    "summary": "Order street food politely in Korean."
+  },
+  "progression": {
+    "xp": 110,
+    "sp": 45,
+    "rp": 12,
+    "currentMasteryLevel": 1
+  },
+  "missionGate": {
+    "readiness": 0.34,
+    "validatedHangouts": 0,
+    "missionAssessmentUnlocked": false,
+    "masteryTier": 1
+  },
+  "unlocks": {
+    "locationIds": ["food_street"],
+    "missionIds": [],
+    "rewardIds": []
+  },
+  "rewards": [],
+  "availableActions": [
+    "Start hangout validation",
+    "Review personalized learn targets",
+    "Practice KO objective ko_food_l2_001"
+  ],
+  "resumeSource": "new_session",
+  "activeCheckpointId": "ckpt_sess_demo_001_intro",
+  "startedAtIso": "2026-03-15T04:55:00.000Z",
+  "updatedAtIso": "2026-03-15T04:55:00.000Z"
+}

--- a/packages/contracts/fixtures/game.start-or-resume.sample.json
+++ b/packages/contracts/fixtures/game.start-or-resume.sample.json
@@ -1,7 +1,10 @@
 {
   "sessionId": "sess_demo_001",
   "city": "seoul",
+  "location": "food_street",
   "sceneId": "food_street_hangout_intro",
+  "mode": "hangout",
+  "tongPrompt": "tong.system.food_street_intro.v1",
   "profile": {
     "nativeLanguage": "en",
     "targetLanguages": ["ko", "ja", "zh"],
@@ -16,5 +19,226 @@
     "sp": 45,
     "rp": 12,
     "currentMasteryLevel": 1
-  }
+  },
+  "actions": [
+    "Start hangout validation",
+    "Review personalized learn targets",
+    "Practice KO objective ko_food_l2_001"
+  ],
+  "resumeSource": "new_session",
+  "gameSession": {
+    "sessionId": "sess_demo_001",
+    "userId": "demo-user-1",
+    "status": "active",
+    "profile": {
+      "nativeLanguage": "en",
+      "targetLanguages": ["ko", "ja", "zh"],
+      "proficiency": {
+        "ko": "beginner",
+        "ja": "none",
+        "zh": "advanced"
+      }
+    },
+    "cityId": "seoul",
+    "locationId": "food_street",
+    "currentMode": "hangout",
+    "activeSceneId": "food_street_hangout_intro",
+    "activeSceneSessionId": "scene_sess_demo_001_001",
+    "activeObjective": {
+      "objectiveId": "ko_food_l2_001",
+      "lang": "ko",
+      "mode": "hangout",
+      "cityId": "seoul",
+      "locationId": "food_street",
+      "objectiveCategory": "vocabulary",
+      "objectiveNodeId": "objective:ko_food_l2_001",
+      "targetNodeIds": ["target:메뉴", "target:주문", "target:맵다"],
+      "summary": "Order street food politely in Korean."
+    },
+    "progression": {
+      "xp": 110,
+      "sp": 45,
+      "rp": 12,
+      "currentMasteryLevel": 1
+    },
+    "missionGate": {
+      "readiness": 0.34,
+      "validatedHangouts": 0,
+      "missionAssessmentUnlocked": false,
+      "masteryTier": 1
+    },
+    "unlocks": {
+      "locationIds": ["food_street"],
+      "missionIds": [],
+      "rewardIds": []
+    },
+    "rewards": [],
+    "availableActions": [
+      "Start hangout validation",
+      "Review personalized learn targets",
+      "Practice KO objective ko_food_l2_001"
+    ],
+    "resumeSource": "new_session",
+    "activeCheckpointId": "ckpt_sess_demo_001_intro",
+    "startedAtIso": "2026-03-15T04:55:00.000Z",
+    "updatedAtIso": "2026-03-15T04:55:00.000Z"
+  },
+  "sceneSession": {
+    "sceneSessionId": "scene_sess_demo_001_001",
+    "gameSessionId": "sess_demo_001",
+    "sceneId": "food_street_hangout_intro",
+    "cityId": "seoul",
+    "locationId": "food_street",
+    "mode": "hangout",
+    "objective": {
+      "objectiveId": "ko_food_l2_001",
+      "lang": "ko",
+      "mode": "hangout",
+      "cityId": "seoul",
+      "locationId": "food_street",
+      "objectiveCategory": "vocabulary",
+      "objectiveNodeId": "objective:ko_food_l2_001",
+      "targetNodeIds": ["target:메뉴", "target:주문", "target:맵다"],
+      "summary": "Order street food politely in Korean."
+    },
+    "phase": "intro",
+    "turn": 1,
+    "route": {
+      "pathname": "/game",
+      "query": {
+        "city": "seoul",
+        "location": "food_street",
+        "mode": "hangout"
+      }
+    },
+    "progressionDelta": {
+      "xp": 0,
+      "sp": 0,
+      "rp": 0,
+      "objectiveProgressDelta": 0,
+      "validatedHangoutsDelta": 0
+    },
+    "checkpointable": true,
+    "uiPolicy": {
+      "immersiveFirstPerson": true,
+      "allowOnlyDialogueAndHints": true
+    },
+    "startedAtIso": "2026-03-15T04:55:00.000Z",
+    "updatedAtIso": "2026-03-15T04:55:00.000Z"
+  },
+  "activeCheckpoint": {
+    "checkpointId": "ckpt_sess_demo_001_intro",
+    "gameSessionId": "sess_demo_001",
+    "sceneSessionId": "scene_sess_demo_001_001",
+    "kind": "player_resume",
+    "route": {
+      "pathname": "/game",
+      "query": {
+        "city": "seoul",
+        "location": "food_street",
+        "mode": "hangout",
+        "resume": "1"
+      }
+    },
+    "cityId": "seoul",
+    "locationId": "food_street",
+    "mode": "hangout",
+    "objective": {
+      "objectiveId": "ko_food_l2_001",
+      "lang": "ko",
+      "mode": "hangout",
+      "cityId": "seoul",
+      "locationId": "food_street",
+      "objectiveCategory": "vocabulary",
+      "objectiveNodeId": "objective:ko_food_l2_001",
+      "targetNodeIds": ["target:메뉴", "target:주문", "target:맵다"],
+      "summary": "Resume from the current safe intro boundary."
+    },
+    "phase": "intro",
+    "turn": 1,
+    "progressionDelta": {
+      "xp": 0,
+      "sp": 0,
+      "rp": 0,
+      "objectiveProgressDelta": 0,
+      "validatedHangoutsDelta": 0
+    },
+    "rewards": [],
+    "missionGate": {
+      "readiness": 0.34,
+      "validatedHangouts": 0,
+      "missionAssessmentUnlocked": false,
+      "masteryTier": 1
+    },
+    "unlocks": {
+      "locationIds": ["food_street"],
+      "missionIds": [],
+      "rewardIds": []
+    },
+    "rng": {
+      "seed": "sess_demo_001_intro",
+      "version": 1
+    },
+    "createdAtIso": "2026-03-15T04:55:00.000Z"
+  },
+  "availableScenarioSeeds": [
+    {
+      "seedId": "review_ready",
+      "label": "Review-ready food street checkpoint",
+      "source": "qa",
+      "qaOnly": true,
+      "route": {
+        "pathname": "/game",
+        "query": {
+          "city": "seoul",
+          "location": "food_street",
+          "mode": "hangout",
+          "qa_trace": "1",
+          "scenarioSeed": "review_ready"
+        }
+      },
+      "cityId": "seoul",
+      "locationId": "food_street",
+      "mode": "hangout",
+      "objective": {
+        "objectiveId": "ko_food_l2_001",
+        "lang": "ko",
+        "mode": "hangout",
+        "cityId": "seoul",
+        "locationId": "food_street",
+        "objectiveCategory": "vocabulary",
+        "objectiveNodeId": "objective:ko_food_l2_001",
+        "targetNodeIds": ["target:메뉴", "target:주문", "target:맵다"],
+        "summary": "QA-only seed for deterministic review and proof capture."
+      },
+      "phase": "review",
+      "turn": 4,
+      "activeExercise": {
+        "exerciseId": "block_crush_food_003",
+        "exerciseType": "block_crush",
+        "stepIndex": 2,
+        "prompt": "Hold before the final review decision.",
+        "payloadVersion": 1,
+        "state": {
+          "targetChar": "뉴",
+          "remainingLives": 2,
+          "boardPieces": ["ㅁ", "ㅠ"],
+          "requiredMatches": 1
+        }
+      },
+      "progressionDelta": {
+        "xp": 8,
+        "sp": 2,
+        "rp": 1,
+        "objectiveProgressDelta": 0.25,
+        "validatedHangoutsDelta": 0
+      },
+      "rewards": [],
+      "rng": {
+        "seed": "review_ready_seed_v1",
+        "version": 1
+      },
+      "notes": "Use for QA/demo capture only; do not expose as player-facing resume."
+    }
+  ]
 }

--- a/packages/contracts/fixtures/scenario.seed.review-ready.sample.json
+++ b/packages/contracts/fixtures/scenario.seed.review-ready.sample.json
@@ -1,0 +1,58 @@
+{
+  "seedId": "review_ready",
+  "label": "Review-ready food street checkpoint",
+  "source": "qa",
+  "qaOnly": true,
+  "route": {
+    "pathname": "/game",
+    "query": {
+      "city": "seoul",
+      "location": "food_street",
+      "mode": "hangout",
+      "qa_trace": "1",
+      "scenarioSeed": "review_ready"
+    }
+  },
+  "cityId": "seoul",
+  "locationId": "food_street",
+  "mode": "hangout",
+  "objective": {
+    "objectiveId": "ko_food_l2_001",
+    "lang": "ko",
+    "mode": "hangout",
+    "cityId": "seoul",
+    "locationId": "food_street",
+    "objectiveCategory": "vocabulary",
+    "objectiveNodeId": "objective:ko_food_l2_001",
+    "targetNodeIds": ["target:메뉴", "target:주문", "target:맵다"],
+    "summary": "QA-only seed for deterministic review and proof capture."
+  },
+  "phase": "review",
+  "turn": 4,
+  "activeExercise": {
+    "exerciseId": "block_crush_food_003",
+    "exerciseType": "block_crush",
+    "stepIndex": 2,
+    "prompt": "Hold before the final review decision.",
+    "payloadVersion": 1,
+    "state": {
+      "targetChar": "뉴",
+      "remainingLives": 2,
+      "boardPieces": ["ㅁ", "ㅠ"],
+      "requiredMatches": 1
+    }
+  },
+  "progressionDelta": {
+    "xp": 8,
+    "sp": 2,
+    "rp": 1,
+    "objectiveProgressDelta": 0.25,
+    "validatedHangoutsDelta": 0
+  },
+  "rewards": [],
+  "rng": {
+    "seed": "review_ready_seed_v1",
+    "version": 1
+  },
+  "notes": "Use for QA/demo capture only; do not expose as player-facing resume."
+}

--- a/packages/contracts/fixtures/scene.session.sample.json
+++ b/packages/contracts/fixtures/scene.session.sample.json
@@ -1,0 +1,43 @@
+{
+  "sceneSessionId": "scene_sess_demo_001_001",
+  "gameSessionId": "sess_demo_001",
+  "sceneId": "food_street_hangout_intro",
+  "cityId": "seoul",
+  "locationId": "food_street",
+  "mode": "hangout",
+  "objective": {
+    "objectiveId": "ko_food_l2_001",
+    "lang": "ko",
+    "mode": "hangout",
+    "cityId": "seoul",
+    "locationId": "food_street",
+    "objectiveCategory": "vocabulary",
+    "objectiveNodeId": "objective:ko_food_l2_001",
+    "targetNodeIds": ["target:메뉴", "target:주문", "target:맵다"],
+    "summary": "Order street food politely in Korean."
+  },
+  "phase": "intro",
+  "turn": 1,
+  "route": {
+    "pathname": "/game",
+    "query": {
+      "city": "seoul",
+      "location": "food_street",
+      "mode": "hangout"
+    }
+  },
+  "progressionDelta": {
+    "xp": 0,
+    "sp": 0,
+    "rp": 0,
+    "objectiveProgressDelta": 0,
+    "validatedHangoutsDelta": 0
+  },
+  "checkpointable": true,
+  "uiPolicy": {
+    "immersiveFirstPerson": true,
+    "allowOnlyDialogueAndHints": true
+  },
+  "startedAtIso": "2026-03-15T04:55:00.000Z",
+  "updatedAtIso": "2026-03-15T04:55:00.000Z"
+}

--- a/packages/contracts/types.ts
+++ b/packages/contracts/types.ts
@@ -119,27 +119,206 @@ export interface PlayerMediaProfileResponse {
   };
 }
 
+export interface PlayerLanguageProfile {
+  nativeLanguage: AppLanguage;
+  targetLanguages: TargetLanguage[];
+  proficiency: Record<TargetLanguage, 'none' | 'beginner' | 'intermediate' | 'advanced'>;
+}
+
+export interface HangoutScore {
+  xp: number;
+  sp: number;
+  rp: number;
+}
+
+export type SessionMode = 'hangout' | 'learn';
+export type ResumeSource = 'new_session' | 'checkpoint' | 'scenario_seed';
+export type GameSessionStatus = 'active' | 'paused' | 'completed';
+export type ScenePhase = 'intro' | 'dialogue' | 'exercise' | 'review' | 'mission' | 'reward';
+export type ScenarioSeedSource = 'qa' | 'demo' | 'dev';
+
+export interface ObjectiveDescriptor {
+  objectiveId: string;
+  lang: TargetLanguage;
+  mode: SessionMode;
+  cityId: GraphCityId;
+  locationId: GraphLocationId;
+  objectiveCategory?: ObjectiveCategory;
+  objectiveNodeId?: string;
+  targetNodeIds?: string[];
+  summary?: string;
+}
+
+export interface RouteStateDescriptor {
+  pathname: string;
+  query?: Record<string, string>;
+}
+
+export interface ExerciseCheckpointState {
+  exerciseId: string;
+  exerciseType: string;
+  stepIndex?: number;
+  prompt?: string;
+  payloadVersion: number;
+  state: Record<string, unknown>;
+}
+
+export interface RewardGrant {
+  rewardId: string;
+  rewardType:
+    | 'xp_bonus'
+    | 'sp_bonus'
+    | 'rp_bonus'
+    | 'mission_unlock'
+    | 'video_call'
+    | 'polaroid_memory'
+    | 'collectible'
+    | 'cosmetic';
+  grantedAtIso: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface MissionGateSnapshot {
+  readiness: number;
+  validatedHangouts: number;
+  missionAssessmentUnlocked: boolean;
+  masteryTier: number;
+}
+
+export interface UnlockSnapshot {
+  locationIds: GraphLocationId[];
+  missionIds: string[];
+  rewardIds: string[];
+}
+
+export interface RngStateSnapshot {
+  seed: string;
+  version: number;
+}
+
+export interface CheckpointProgressionDelta extends HangoutScore {
+  objectiveProgressDelta?: number;
+  validatedHangoutsDelta?: number;
+}
+
+export interface Checkpoint {
+  checkpointId: string;
+  gameSessionId: string;
+  sceneSessionId: string;
+  kind: 'player_resume';
+  route: RouteStateDescriptor;
+  cityId: GraphCityId;
+  locationId: GraphLocationId;
+  mode: SessionMode;
+  objective: ObjectiveDescriptor;
+  phase: ScenePhase | string;
+  turn: number;
+  activeExercise?: ExerciseCheckpointState;
+  progressionDelta: CheckpointProgressionDelta;
+  rewards: RewardGrant[];
+  missionGate: MissionGateSnapshot;
+  unlocks: UnlockSnapshot;
+  rng: RngStateSnapshot;
+  createdAtIso: string;
+}
+
+export interface ScenarioSeed {
+  seedId: string;
+  label: string;
+  source: ScenarioSeedSource;
+  qaOnly: true;
+  route: RouteStateDescriptor;
+  cityId: GraphCityId;
+  locationId: GraphLocationId;
+  mode: SessionMode;
+  objective: ObjectiveDescriptor;
+  phase: ScenePhase | string;
+  turn: number;
+  activeExercise?: ExerciseCheckpointState;
+  progressionDelta?: CheckpointProgressionDelta;
+  rewards?: RewardGrant[];
+  rng: RngStateSnapshot;
+  notes?: string;
+}
+
+export interface GameSessionProgression extends HangoutScore {
+  currentMasteryLevel: number;
+}
+
+export interface GameSession {
+  sessionId: string;
+  userId: string;
+  status: GameSessionStatus;
+  profile: PlayerLanguageProfile;
+  cityId: GraphCityId;
+  locationId: GraphLocationId;
+  currentMode: SessionMode;
+  activeSceneId: string;
+  activeSceneSessionId: string;
+  activeObjective: ObjectiveDescriptor;
+  progression: GameSessionProgression;
+  missionGate: MissionGateSnapshot;
+  unlocks: UnlockSnapshot;
+  rewards: RewardGrant[];
+  availableActions: string[];
+  resumeSource: ResumeSource;
+  activeCheckpointId?: string;
+  startedAtIso: string;
+  updatedAtIso: string;
+}
+
+export interface SceneSession {
+  sceneSessionId: string;
+  gameSessionId: string;
+  sceneId: string;
+  cityId: GraphCityId;
+  locationId: GraphLocationId;
+  mode: SessionMode;
+  objective: ObjectiveDescriptor;
+  phase: ScenePhase | string;
+  turn: number;
+  route: RouteStateDescriptor;
+  activeExercise?: ExerciseCheckpointState;
+  progressionDelta: CheckpointProgressionDelta;
+  checkpointable: boolean;
+  uiPolicy?: {
+    immersiveFirstPerson: boolean;
+    allowOnlyDialogueAndHints: boolean;
+  };
+  startedAtIso: string;
+  updatedAtIso: string;
+}
+
 export interface StartOrResumeGameRequest {
   userId: string;
-  profile: {
-    nativeLanguage: AppLanguage;
-    targetLanguages: TargetLanguage[];
-    proficiency: Record<TargetLanguage, 'none' | 'beginner' | 'intermediate' | 'advanced'>;
-  };
+  city?: GraphCityId;
+  profile: PlayerLanguageProfile;
+  resumeCheckpointId?: string;
+  scenarioSeedId?: string;
+  preferRomance?: boolean;
 }
 
 export interface StartOrResumeGameResponse {
   sessionId: string;
-  city: 'seoul' | 'tokyo' | 'shanghai';
+  city: GraphCityId;
+  location: GraphLocationId;
   sceneId: string;
+  mode: SessionMode;
   tongPrompt: string;
+  profile: PlayerLanguageProfile;
+  progression: GameSessionProgression;
   actions: string[];
+  resumeSource: ResumeSource;
+  gameSession: GameSession;
+  sceneSession: SceneSession;
+  activeCheckpoint: Checkpoint | null;
+  availableScenarioSeeds: ScenarioSeed[];
 }
 
 export interface ObjectiveNextResponse {
   objectiveId: string;
   level: number;
-  mode: 'hangout' | 'learn';
+  mode: SessionMode;
   lang: TargetLanguage;
   objectiveGraph: {
     objectiveNodeId: string;
@@ -168,15 +347,9 @@ export interface ObjectiveNextResponse {
   };
 }
 
-export interface HangoutScore {
-  xp: number;
-  sp: number;
-  rp: number;
-}
-
 export interface HangoutStartResponse {
   sceneSessionId: string;
-  mode: 'hangout';
+  mode: SessionMode;
   uiPolicy: {
     immersiveFirstPerson: boolean;
     allowOnlyDialogueAndHints: boolean;

--- a/scripts/demo_smoke_check.mjs
+++ b/scripts/demo_smoke_check.mjs
@@ -76,6 +76,10 @@ const requiredFiles = [
   "packages/contracts/fixtures/vocab.insights.sample.json",
   "packages/contracts/fixtures/player.media-profile.sample.json",
   "packages/contracts/fixtures/game.start-or-resume.sample.json",
+  "packages/contracts/fixtures/game.session.sample.json",
+  "packages/contracts/fixtures/scene.session.sample.json",
+  "packages/contracts/fixtures/checkpoint.player-resume.sample.json",
+  "packages/contracts/fixtures/scenario.seed.review-ready.sample.json",
   "packages/contracts/fixtures/objectives.next.sample.json",
   "packages/contracts/fixtures/learn.sessions.sample.json",
   "packages/contracts/fixtures/scene.food-hangout.sample.json",
@@ -136,6 +140,36 @@ const mediaEvents = JSON.parse(
     "utf8"
   )
 );
+const gameStart = JSON.parse(
+  fs.readFileSync(
+    path.join(root, "packages/contracts/fixtures/game.start-or-resume.sample.json"),
+    "utf8"
+  )
+);
+const gameSession = JSON.parse(
+  fs.readFileSync(
+    path.join(root, "packages/contracts/fixtures/game.session.sample.json"),
+    "utf8"
+  )
+);
+const sceneSession = JSON.parse(
+  fs.readFileSync(
+    path.join(root, "packages/contracts/fixtures/scene.session.sample.json"),
+    "utf8"
+  )
+);
+const playerCheckpoint = JSON.parse(
+  fs.readFileSync(
+    path.join(root, "packages/contracts/fixtures/checkpoint.player-resume.sample.json"),
+    "utf8"
+  )
+);
+const scenarioSeed = JSON.parse(
+  fs.readFileSync(
+    path.join(root, "packages/contracts/fixtures/scenario.seed.review-ready.sample.json"),
+    "utf8"
+  )
+);
 
 const runtimeAssetManifest = JSON.parse(
   fs.readFileSync(
@@ -162,6 +196,84 @@ const shanghaiRewardBundle = JSON.parse(
   )
 );
 const clientRuntimeAssetUsage = collectClientRuntimeAssetUsage();
+
+function assertRouteState(route, label) {
+  if (!route || typeof route.pathname !== "string" || route.pathname.length === 0) {
+    console.error(`${label} missing route.pathname`);
+    process.exit(1);
+  }
+  if (route.query !== undefined && (typeof route.query !== "object" || Array.isArray(route.query))) {
+    console.error(`${label} route.query must be an object when present`);
+    process.exit(1);
+  }
+}
+
+function assertObjectiveDescriptor(objective, label) {
+  if (!objective || typeof objective.objectiveId !== "string" || objective.objectiveId.length === 0) {
+    console.error(`${label} missing objectiveId`);
+    process.exit(1);
+  }
+  if (!["ko", "ja", "zh"].includes(objective.lang)) {
+    console.error(`${label} has invalid lang`);
+    process.exit(1);
+  }
+  if (!["hangout", "learn"].includes(objective.mode)) {
+    console.error(`${label} has invalid mode`);
+    process.exit(1);
+  }
+  if (!["seoul", "tokyo", "shanghai"].includes(objective.cityId)) {
+    console.error(`${label} has invalid cityId`);
+    process.exit(1);
+  }
+  if (objective.targetNodeIds !== undefined && !Array.isArray(objective.targetNodeIds)) {
+    console.error(`${label} targetNodeIds must be an array when present`);
+    process.exit(1);
+  }
+}
+
+function assertMissionGate(gate, label) {
+  if (!gate || typeof gate.readiness !== "number") {
+    console.error(`${label} missing readiness`);
+    process.exit(1);
+  }
+  if (typeof gate.validatedHangouts !== "number") {
+    console.error(`${label} missing validatedHangouts`);
+    process.exit(1);
+  }
+  if (typeof gate.missionAssessmentUnlocked !== "boolean") {
+    console.error(`${label} missing missionAssessmentUnlocked`);
+    process.exit(1);
+  }
+  if (typeof gate.masteryTier !== "number") {
+    console.error(`${label} missing masteryTier`);
+    process.exit(1);
+  }
+}
+
+function assertUnlockSnapshot(unlocks, label) {
+  if (!unlocks || !Array.isArray(unlocks.locationIds) || !Array.isArray(unlocks.missionIds) || !Array.isArray(unlocks.rewardIds)) {
+    console.error(`${label} unlock snapshot is incomplete`);
+    process.exit(1);
+  }
+}
+
+function assertRngState(rng, label) {
+  if (!rng || typeof rng.seed !== "string" || rng.seed.length === 0) {
+    console.error(`${label} missing rng.seed`);
+    process.exit(1);
+  }
+  if (!Number.isInteger(rng.version) || rng.version < 1) {
+    console.error(`${label} missing valid rng.version`);
+    process.exit(1);
+  }
+}
+
+function assertProgressionDelta(delta, label) {
+  if (!delta || typeof delta.xp !== "number" || typeof delta.sp !== "number" || typeof delta.rp !== "number") {
+    console.error(`${label} missing xp/sp/rp`);
+    process.exit(1);
+  }
+}
 
 if (!Array.isArray(loop.cities) || loop.cities.length !== 3) {
   console.error("Expected exactly 3 cities in game-loop.json");
@@ -267,6 +379,140 @@ if (!playerMediaProfile.learningSignals || !Array.isArray(playerMediaProfile.lea
 
 if (!Array.isArray(mediaEvents.events) || mediaEvents.events.length === 0) {
   console.error("Expected non-empty events array in media.events.sample.json");
+  process.exit(1);
+}
+
+if (typeof gameStart.sessionId !== "string" || gameStart.sessionId.length === 0) {
+  console.error("Expected sessionId in game.start-or-resume.sample.json");
+  process.exit(1);
+}
+
+if (!["seoul", "tokyo", "shanghai"].includes(gameStart.city)) {
+  console.error("Expected valid city in game.start-or-resume.sample.json");
+  process.exit(1);
+}
+
+if (!["food_street", "cafe", "convenience_store", "subway_hub", "practice_studio"].includes(gameStart.location)) {
+  console.error("Expected valid location in game.start-or-resume.sample.json");
+  process.exit(1);
+}
+
+if (!["hangout", "learn"].includes(gameStart.mode)) {
+  console.error("Expected valid mode in game.start-or-resume.sample.json");
+  process.exit(1);
+}
+
+if (!gameStart.profile || !gameStart.profile.proficiency) {
+  console.error("Expected profile in game.start-or-resume.sample.json");
+  process.exit(1);
+}
+
+if (!gameStart.progression || typeof gameStart.progression.currentMasteryLevel !== "number") {
+  console.error("Expected progression.currentMasteryLevel in game.start-or-resume.sample.json");
+  process.exit(1);
+}
+
+if (!Array.isArray(gameStart.actions) || gameStart.actions.length === 0) {
+  console.error("Expected non-empty actions in game.start-or-resume.sample.json");
+  process.exit(1);
+}
+
+if (!["new_session", "checkpoint", "scenario_seed"].includes(gameStart.resumeSource)) {
+  console.error("Expected valid resumeSource in game.start-or-resume.sample.json");
+  process.exit(1);
+}
+
+if (!gameStart.gameSession || gameStart.gameSession.sessionId !== gameStart.sessionId) {
+  console.error("game.start-or-resume sample must embed matching gameSession");
+  process.exit(1);
+}
+
+if (!gameStart.sceneSession || gameStart.sceneSession.gameSessionId !== gameStart.sessionId) {
+  console.error("game.start-or-resume sample must embed matching sceneSession");
+  process.exit(1);
+}
+
+if (!gameStart.activeCheckpoint || gameStart.activeCheckpoint.gameSessionId !== gameStart.sessionId) {
+  console.error("game.start-or-resume sample must embed matching activeCheckpoint");
+  process.exit(1);
+}
+
+if (!Array.isArray(gameStart.availableScenarioSeeds) || gameStart.availableScenarioSeeds.length === 0) {
+  console.error("Expected availableScenarioSeeds in game.start-or-resume.sample.json");
+  process.exit(1);
+}
+
+if (!gameStart.availableScenarioSeeds.every((seed) => seed.qaOnly === true)) {
+  console.error("Scenario seeds must be explicitly qaOnly=true");
+  process.exit(1);
+}
+
+if (gameSession.sessionId !== gameStart.gameSession.sessionId) {
+  console.error("game.session sample should align with embedded gameSession");
+  process.exit(1);
+}
+
+assertObjectiveDescriptor(gameSession.activeObjective, "game.session.activeObjective");
+assertMissionGate(gameSession.missionGate, "game.session.missionGate");
+assertUnlockSnapshot(gameSession.unlocks, "game.session.unlocks");
+
+if (!Array.isArray(gameSession.availableActions) || gameSession.availableActions.length === 0) {
+  console.error("game.session.availableActions should not be empty");
+  process.exit(1);
+}
+
+if (sceneSession.gameSessionId !== gameSession.sessionId) {
+  console.error("scene.session sample should point at the matching game session");
+  process.exit(1);
+}
+
+assertObjectiveDescriptor(sceneSession.objective, "scene.session.objective");
+assertRouteState(sceneSession.route, "scene.session");
+assertProgressionDelta(sceneSession.progressionDelta, "scene.session.progressionDelta");
+
+if (typeof sceneSession.checkpointable !== "boolean") {
+  console.error("scene.session.checkpointable must be boolean");
+  process.exit(1);
+}
+
+if (!sceneSession.uiPolicy || sceneSession.uiPolicy.allowOnlyDialogueAndHints !== true) {
+  console.error("scene.session uiPolicy should preserve immersive hangout constraints");
+  process.exit(1);
+}
+
+if (playerCheckpoint.kind !== "player_resume") {
+  console.error("checkpoint sample must use kind=player_resume");
+  process.exit(1);
+}
+
+assertRouteState(playerCheckpoint.route, "checkpoint.player-resume");
+assertObjectiveDescriptor(playerCheckpoint.objective, "checkpoint.player-resume.objective");
+assertProgressionDelta(playerCheckpoint.progressionDelta, "checkpoint.player-resume.progressionDelta");
+assertMissionGate(playerCheckpoint.missionGate, "checkpoint.player-resume.missionGate");
+assertUnlockSnapshot(playerCheckpoint.unlocks, "checkpoint.player-resume.unlocks");
+assertRngState(playerCheckpoint.rng, "checkpoint.player-resume");
+
+if (!playerCheckpoint.activeExercise || typeof playerCheckpoint.activeExercise.exerciseId !== "string") {
+  console.error("checkpoint.player-resume must include activeExercise state");
+  process.exit(1);
+}
+
+if (scenarioSeed.qaOnly !== true) {
+  console.error("scenario.seed sample must be qaOnly=true");
+  process.exit(1);
+}
+
+assertRouteState(scenarioSeed.route, "scenario.seed.review-ready");
+assertObjectiveDescriptor(scenarioSeed.objective, "scenario.seed.review-ready.objective");
+assertRngState(scenarioSeed.rng, "scenario.seed.review-ready");
+
+if (!["qa", "demo", "dev"].includes(scenarioSeed.source)) {
+  console.error("scenario.seed sample must declare source=qa|demo|dev");
+  process.exit(1);
+}
+
+if (!scenarioSeed.activeExercise || typeof scenarioSeed.activeExercise.exerciseType !== "string") {
+  console.error("scenario.seed sample must include deterministic activeExercise state");
   process.exit(1);
 }
 

--- a/scripts/mock_api_flow_check.mjs
+++ b/scripts/mock_api_flow_check.mjs
@@ -225,8 +225,25 @@ async function run() {
   });
   assert(gameStart.ok, `/game/start-or-resume failed (${gameStart.status})`);
   assert(typeof gameStart.data?.sessionId === 'string' && gameStart.data.sessionId.length > 0, 'gameStart.sessionId missing');
+  assert(typeof gameStart.data?.location === 'string' && gameStart.data.location.length > 0, 'gameStart.location missing');
+  assert(['hangout', 'learn'].includes(gameStart.data?.mode), 'gameStart.mode missing/invalid');
   assert(typeof gameStart.data?.progression?.xp === 'number', 'gameStart progression missing xp');
   assertArray(gameStart.data?.actions, 'gameStart.actions');
+  assert(gameStart.data?.gameSession?.sessionId === gameStart.data.sessionId, 'gameStart.gameSession.sessionId mismatch');
+  assert(gameStart.data?.sceneSession?.gameSessionId === gameStart.data.sessionId, 'gameStart.sceneSession.gameSessionId mismatch');
+  assert(gameStart.data?.activeCheckpoint?.gameSessionId === gameStart.data.sessionId, 'gameStart.activeCheckpoint.gameSessionId mismatch');
+  assert(gameStart.data?.sceneSession?.sceneSessionId === gameStart.data?.gameSession?.activeSceneSessionId, 'gameStart active scene session mismatch');
+  assert(gameStart.data?.gameSession?.activeCheckpointId === gameStart.data?.activeCheckpoint?.checkpointId, 'gameStart active checkpoint mismatch');
+  assert(['new_session', 'checkpoint', 'scenario_seed'].includes(gameStart.data?.resumeSource), 'gameStart.resumeSource missing/invalid');
+  assert(typeof gameStart.data?.gameSession?.missionGate?.readiness === 'number', 'gameStart missionGate.readiness missing');
+  assert(Array.isArray(gameStart.data?.gameSession?.unlocks?.locationIds), 'gameStart unlocks.locationIds missing');
+  assert(gameStart.data?.activeCheckpoint?.route?.pathname === '/game', 'gameStart activeCheckpoint.route.pathname missing');
+  assert(Number.isInteger(gameStart.data?.activeCheckpoint?.rng?.version), 'gameStart activeCheckpoint.rng.version missing');
+  assertArray(gameStart.data?.availableScenarioSeeds, 'gameStart.availableScenarioSeeds');
+  assert(
+    gameStart.data.availableScenarioSeeds.every((seed) => seed.qaOnly === true && typeof seed.seedId === 'string'),
+    'gameStart.availableScenarioSeeds must be QA-only entries',
+  );
   logPass('/api/v1/game/start-or-resume');
 
   const startHangout = await requestJson('/api/v1/scenes/hangout/start', {


### PR DESCRIPTION
## Summary
- add explicit shared contracts for `GameSession`, `SceneSession`, `Checkpoint`, and `ScenarioSeed`
- extend `POST /api/v1/game/start-or-resume` fixtures, docs, smoke checks, and mock API validation to use the additive nested session model
- keep the legacy top-level start-or-resume fields for compatibility while unblocking follow-up progression issues

Fixes #48

## How to test
- `npm run demo:smoke`
- `node --check apps/server/src/index.mjs`
- `node --check scripts/demo_smoke_check.mjs`
- `node --check scripts/mock_api_flow_check.mjs`
- `npm --prefix apps/server run start`
- `node scripts/mock_api_flow_check.mjs http://localhost:8787 --strict-state`
