### PR TITLE
fix: issue #46 - Build first-class reviewer-proof capture workflow for timing-sensitive U

### DIFF
--- a/.agents/skills/_functional-qa/scripts/capture_reviewer_proof.py
+++ b/.agents/skills/_functional-qa/scripts/capture_reviewer_proof.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""Validate and render a reviewer-proof pack from a QA run bundle."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SCRIPT_PATH = Path(__file__).resolve()
+REPO_ROOT = SCRIPT_PATH.parents[4]
+REQUIRED_FRAME_STAGES = (
+    "pre_action",
+    "ready_state",
+    "immediate_post_input",
+    "later_transition",
+    "stable_post_action",
+)
+REQUIRED_CUE_KEYS = (
+    "ready_state",
+    "input",
+    "immediate_post_input",
+    "later_transition",
+    "stable_post_action",
+)
+REQUIRED_CHECKS = (
+    "real_route",
+    "semantically_coherent",
+    "ready_state_legible",
+    "input_visible",
+    "pre_action_hold",
+    "stable_post_action",
+)
+STAGE_LABELS = {
+    "pre_action": "Pre-action",
+    "ready_state": "Ready state",
+    "immediate_post_input": "Immediate post-input",
+    "later_transition": "Later transition",
+    "stable_post_action": "Stable post-action",
+}
+
+
+def load_json(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def relative_to_repo(path: Path) -> str:
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Build reviewer-proof metadata from an existing QA run.")
+    parser.add_argument("--run-dir", required=True, help="Path to the QA run directory.")
+    return parser.parse_args()
+
+
+def normalize_artifact_entry(entry: Any) -> dict[str, Any]:
+    if isinstance(entry, str):
+        return {"path": entry}
+    if isinstance(entry, dict):
+        return dict(entry)
+    return {}
+
+
+def artifact_lookup(upload_manifest: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    mapping: dict[str, dict[str, Any]] = {}
+    for artifact in upload_manifest.get("artifacts", []):
+        local_path = artifact.get("local_path")
+        relative_run_path = artifact.get("relative_run_path")
+        if local_path:
+            mapping[str(local_path)] = artifact
+        if relative_run_path:
+            mapping[str(relative_run_path)] = artifact
+        if local_path:
+            mapping[Path(str(local_path)).name] = artifact
+        if relative_run_path:
+            mapping[Path(str(relative_run_path)).name] = artifact
+    return mapping
+
+
+def resolve_artifact(entry: Any, upload_lookup: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    normalized = normalize_artifact_entry(entry)
+    candidate_path = normalized.get("path") or normalized.get("local_path") or normalized.get("relative_run_path") or ""
+    artifact = upload_lookup.get(str(candidate_path)) or upload_lookup.get(Path(str(candidate_path)).name)
+    resolved = {
+        "path": candidate_path,
+        "label": normalized.get("label") or (artifact or {}).get("label"),
+        "description": normalized.get("description") or (artifact or {}).get("description"),
+        "url": normalized.get("url") or (artifact or {}).get("url"),
+        "artifact_id": normalized.get("artifact_id") or (artifact or {}).get("id"),
+    }
+    return resolved
+
+
+def route_is_real(route: str) -> bool:
+    if not route or not route.startswith("/game"):
+        return False
+    return "dev=exercise" not in route
+
+
+def format_ms(value: Any) -> str | None:
+    if isinstance(value, (int, float)):
+        return f"+{int(value)}ms"
+    return None
+
+
+def build_missing_requirements(
+    reviewer_proof: dict[str, Any],
+    frames: dict[str, dict[str, Any]],
+    proof_video: dict[str, Any],
+    gif_preview: dict[str, Any],
+) -> list[str]:
+    missing: list[str] = []
+    classification = reviewer_proof.get("classification") or "not-evaluated"
+
+    if classification not in {"reviewer-proof", "trace-only"}:
+        missing.append("classification must be `reviewer-proof` or `trace-only`")
+        return missing
+
+    route = reviewer_proof.get("route", "")
+    checks = reviewer_proof.get("checks") or {}
+    cue_timestamps_ms = reviewer_proof.get("cue_timestamps_ms") or {}
+
+    if classification == "trace-only":
+        if not reviewer_proof.get("notes"):
+            missing.append("trace-only packs need a note explaining why the capture is not reviewer-ready")
+        return missing
+
+    if not route:
+        missing.append("route is required")
+    elif not route_is_real(route):
+        missing.append("route must use the real `/game` surface and not the isolated `?dev=exercise` tester")
+
+    for key in REQUIRED_CHECKS:
+        if not checks.get(key):
+            missing.append(f"check `{key}` must be true for reviewer-proof classification")
+
+    if not checks.get("reviewer_visible_media", False):
+        missing.append("check `reviewer_visible_media` must be true for reviewer-proof classification")
+
+    for stage in REQUIRED_FRAME_STAGES:
+        if not frames.get(stage, {}).get("path"):
+            missing.append(f"ordered frame `{stage}` is required")
+        if not frames.get(stage, {}).get("url"):
+            missing.append(f"ordered frame `{stage}` must have a reviewer-visible URL")
+
+    if not proof_video.get("path"):
+        missing.append("proof video is required")
+    if not proof_video.get("url"):
+        missing.append("proof video must have a reviewer-visible URL")
+    if not gif_preview.get("path"):
+        missing.append("GIF preview is required")
+    if not gif_preview.get("url"):
+        missing.append("GIF preview must have a reviewer-visible URL")
+
+    for cue_key in REQUIRED_CUE_KEYS:
+        if cue_key not in cue_timestamps_ms:
+            missing.append(f"cue timestamp `{cue_key}` is required")
+
+    return missing
+
+
+def render_markdown(proof_pack: dict[str, Any]) -> str:
+    lines = [
+        "## Reviewer Proof",
+        "",
+        f"- Status: `{proof_pack['status']}`",
+        f"- Route: `{proof_pack.get('route') or 'n/a'}`",
+    ]
+
+    if proof_pack.get("scenario_seed"):
+        lines.append(f"- Scenario seed: `{proof_pack['scenario_seed']}`")
+
+    deterministic_setup = proof_pack.get("deterministic_setup") or {}
+    if deterministic_setup.get("used"):
+        description = deterministic_setup.get("description") or "Used only to reach the near-proof state."
+        lines.append(f"- Deterministic setup: {description}")
+
+    cue_timestamps = proof_pack.get("cue_timestamps_ms") or {}
+    if cue_timestamps:
+        formatted = []
+        for key in REQUIRED_CUE_KEYS:
+            label = STAGE_LABELS.get(key, key.replace("_", " "))
+            value = format_ms(cue_timestamps.get(key))
+            if value:
+                formatted.append(f"{label} {value}")
+        if formatted:
+            lines.append(f"- Cue timestamps: {', '.join(formatted)}")
+
+    media = proof_pack.get("media") or {}
+    proof_video = media.get("proof_video") or {}
+    gif_preview = media.get("gif_preview") or {}
+    if proof_video.get("url"):
+        lines.append(f"- Proof clip: [{Path(proof_video['path']).name}]({proof_video['url']})")
+    if gif_preview.get("url"):
+        lines.append(f"- GIF preview: [{Path(gif_preview['path']).name}]({gif_preview['url']})")
+
+    ordered_frames = proof_pack.get("ordered_frames") or {}
+    if ordered_frames:
+        lines.extend(["", "### Ordered Frames", ""])
+        for stage in REQUIRED_FRAME_STAGES:
+            frame = ordered_frames.get(stage) or {}
+            if not frame.get("url"):
+                continue
+            label = STAGE_LABELS[stage]
+            description = frame.get("description") or frame.get("label") or ""
+            suffix = f" - {description}" if description else ""
+            lines.append(f"- {label}: [{Path(frame['path']).name}]({frame['url']}){suffix}")
+
+    if proof_pack.get("notes"):
+        lines.extend(["", "### Notes", ""])
+        lines.extend(f"- {note}" for note in proof_pack["notes"])
+
+    if proof_pack.get("missing_requirements"):
+        lines.extend(["", "### Missing Requirements", ""])
+        lines.extend(f"- {item}" for item in proof_pack["missing_requirements"])
+
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    args = parse_args()
+    run_dir = Path(args.run_dir).resolve()
+    evidence_path = run_dir / "evidence.json"
+    run_path = run_dir / "run.json"
+    upload_manifest_path = run_dir / "upload-manifest.json"
+
+    evidence = load_json(evidence_path)
+    run = load_json(run_path)
+    reviewer_proof = dict(evidence.get("reviewer_proof") or {})
+    classification = reviewer_proof.get("classification") or "not-evaluated"
+    if classification == "not-evaluated":
+        print("Reviewer proof classification is `not-evaluated`; nothing to do.")
+        return 0
+
+    upload_manifest = load_json(upload_manifest_path) if upload_manifest_path.exists() else {}
+    upload_lookup = artifact_lookup(upload_manifest)
+
+    artifacts = reviewer_proof.get("artifacts") or {}
+    proof_video = resolve_artifact(artifacts.get("proof_video"), upload_lookup)
+    gif_preview = resolve_artifact(artifacts.get("gif_preview"), upload_lookup)
+    if not gif_preview.get("path"):
+        gif_preview = resolve_artifact(
+            {
+                "path": ((upload_manifest.get("primary") or {}).get("gif_preview") or {}).get("local_path", ""),
+            },
+            upload_lookup,
+        )
+
+    frames = {
+        stage: resolve_artifact((reviewer_proof.get("ordered_frames") or {}).get(stage), upload_lookup)
+        for stage in REQUIRED_FRAME_STAGES
+    }
+
+    if frames.get("ready_state", {}).get("url") and proof_video.get("url") and gif_preview.get("url"):
+        reviewer_proof.setdefault("checks", {})["reviewer_visible_media"] = True
+
+    missing_requirements = build_missing_requirements(reviewer_proof, frames, proof_video, gif_preview)
+    status = "reviewer-proof" if classification == "reviewer-proof" and not missing_requirements else "trace-only" if classification == "trace-only" else "incomplete"
+
+    proof_pack = {
+        "schema_version": "1",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "status": status,
+        "classification": classification,
+        "issue_ref": run.get("issue_ref"),
+        "surface": reviewer_proof.get("surface") or "/game",
+        "route": reviewer_proof.get("route") or "",
+        "scenario_seed": reviewer_proof.get("scenario_seed") or "",
+        "proof_moment": reviewer_proof.get("proof_moment") or "",
+        "deterministic_setup": reviewer_proof.get("deterministic_setup") or {"used": False, "description": ""},
+        "checks": reviewer_proof.get("checks") or {},
+        "cue_timestamps_ms": reviewer_proof.get("cue_timestamps_ms") or {},
+        "media": {
+            "proof_video": proof_video,
+            "gif_preview": gif_preview,
+            "uploaded_manifest": {
+                "path": relative_to_repo(upload_manifest_path) if upload_manifest_path.exists() else "",
+                "url": upload_manifest.get("manifest_url"),
+            },
+        },
+        "ordered_frames": frames,
+        "notes": reviewer_proof.get("notes") or [],
+        "missing_requirements": missing_requirements,
+    }
+
+    reviewer_proof.update(
+        {
+            "status": status,
+            "checks": proof_pack["checks"],
+            "missing_requirements": missing_requirements,
+            "artifacts": {
+                "proof_video": proof_video.get("path", ""),
+                "gif_preview": gif_preview.get("path", ""),
+            },
+        }
+    )
+    evidence["reviewer_proof"] = reviewer_proof
+    write_json(evidence_path, evidence)
+
+    reviewer_proof_json_path = run_dir / "reviewer-proof.json"
+    reviewer_proof_md_path = run_dir / "reviewer-proof.md"
+    write_json(reviewer_proof_json_path, proof_pack)
+    reviewer_proof_md_path.write_text(render_markdown(proof_pack), encoding="utf-8")
+
+    if upload_manifest:
+        upload_manifest["reviewer_proof"] = {
+            **proof_pack,
+            "json_path": relative_to_repo(reviewer_proof_json_path),
+            "snippet_path": relative_to_repo(reviewer_proof_md_path),
+        }
+        write_json(upload_manifest_path, upload_manifest)
+
+    print(relative_to_repo(reviewer_proof_md_path))
+    if status == "incomplete":
+        print("Reviewer-proof pack is incomplete.", flush=True)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/_functional-qa/scripts/qa_runtime.py
+++ b/.agents/skills/_functional-qa/scripts/qa_runtime.py
@@ -25,6 +25,7 @@ REPRO_STATUSES = {"reproduced", "not-reproduced", "partially-reproduced", "ambig
 FIX_STATUSES = {"not-checked", "fixed", "still-reproduces", "inconclusive"}
 ISSUE_ACCURACY = {"accurate", "stale", "misdescribed", "n/a"}
 FIX_ALLOWED_EXECUTION_MODES = {"safe-unattended", "requires-live-model"}
+REVIEWER_PROOF_REQUIRED_CLASSES = {"interaction-input", "animation-transition", "async-streaming-state"}
 
 
 def load_json(path: Path) -> Any:
@@ -1031,6 +1032,41 @@ def bootstrap_text(
         "cross_env_matrix": [],
         "open_questions": [],
         "notes": [],
+        "reviewer_proof": {
+            "classification": "not-evaluated",
+            "status": "not-evaluated",
+            "surface": "",
+            "route": "",
+            "scenario_seed": "",
+            "proof_moment": "",
+            "deterministic_setup": {
+                "used": False,
+                "description": "",
+            },
+            "artifacts": {
+                "proof_video": "",
+                "gif_preview": "",
+            },
+            "ordered_frames": {
+                "pre_action": "",
+                "ready_state": "",
+                "immediate_post_input": "",
+                "later_transition": "",
+                "stable_post_action": "",
+            },
+            "cue_timestamps_ms": {},
+            "checks": {
+                "real_route": False,
+                "semantically_coherent": False,
+                "ready_state_legible": False,
+                "input_visible": False,
+                "pre_action_hold": False,
+                "stable_post_action": False,
+                "reviewer_visible_media": False,
+            },
+            "notes": [],
+            "missing_requirements": [],
+        },
         "portability": {
             **portability,
             "notes": [],
@@ -1046,6 +1082,15 @@ def bootstrap_text(
         }
     }
     return ("\n".join(summary_lines) + "\n", "\n".join(steps_lines) + "\n", evidence)
+
+
+def reviewer_proof_required(run: dict[str, Any], *, for_fixed_claim: bool) -> bool:
+    if not for_fixed_claim:
+        return False
+    if not run.get("validation_policy", {}).get("ui_acceptance_required"):
+        return False
+    issue_class = run.get("classification", {}).get("issue_class")
+    return issue_class in REVIEWER_PROOF_REQUIRED_CLASSES
 
 
 def validation_gate_failures(run: dict[str, Any], evidence: dict[str, Any], *, for_fixed_claim: bool) -> list[str]:
@@ -1078,6 +1123,14 @@ def validation_gate_failures(run: dict[str, Any], evidence: dict[str, Any], *, f
     for item in validation.get("missing_requirements", []):
         failures.append(f"missing requirement noted by runner: {item}")
 
+    if reviewer_proof_required(run, for_fixed_claim=for_fixed_claim):
+        reviewer_proof = evidence.get("reviewer_proof") or {}
+        status = reviewer_proof.get("status") or reviewer_proof.get("classification") or "missing"
+        if status != "reviewer-proof":
+            failures.append(f"reviewer-proof pack status is `{status}`")
+        for item in reviewer_proof.get("missing_requirements", []):
+            failures.append(f"reviewer-proof requirement missing: {item}")
+
     return failures
 
 
@@ -1086,11 +1139,15 @@ def render_validation_gate_lines(run: dict[str, Any], evidence: dict[str, Any]) 
     validation = evidence.get("validation", {})
     runtime_modes = validation.get("runtime_modes_exercised", [])
     failures = validation_gate_failures(run, evidence, for_fixed_claim=run["functional"]["fix_status"] == "fixed" or run["functional"]["verdict"] == "fixed")
+    reviewer_proof = evidence.get("reviewer_proof") or {}
+    reviewer_proof_required_for_run = reviewer_proof_required(run, for_fixed_claim=True)
+    reviewer_proof_status = reviewer_proof.get("status") or reviewer_proof.get("classification") or "missing"
 
     lines = [
         f"- Execution mode: `{policy.get('execution_mode', 'safe-unattended')}`",
         f"- Direct issue evidence: `{'complete' if validation.get('direct_issue_evidence_complete', False) else 'missing' if policy.get('requires_direct_issue_evidence') else 'not-required'}`",
         f"- UI acceptance gate: `{'complete' if validation.get('ui_acceptance_complete', False) else 'missing' if policy.get('ui_acceptance_required') else 'not-required'}`",
+        f"- Reviewer-proof pack: `{reviewer_proof_status if reviewer_proof_required_for_run else 'not-required'}`",
         f"- Runtime modes exercised: `{', '.join(runtime_modes) if runtime_modes else 'none recorded'}`",
         f"- Live model confirmation: `{'confirmed' if validation.get('live_model_confirmed', False) else 'missing' if policy.get('requires_live_model_for_fixed') else 'not-required'}`",
         f"- Human review: `{'complete' if validation.get('human_review_completed', False) else 'missing' if policy.get('human_review_required') else 'not-required'}`",
@@ -1177,6 +1234,32 @@ def load_evidence(run_dir: Path) -> dict[str, Any]:
     return load_json(evidence_path)
 
 
+def maybe_generate_reviewer_proof(run_dir: Path) -> bool:
+    reviewer_proof = (load_evidence(run_dir).get("reviewer_proof") or {})
+    classification = reviewer_proof.get("classification") or reviewer_proof.get("status") or "not-evaluated"
+    if classification in {"", "not-evaluated", "missing", None}:
+        return True
+
+    script_path = SCRIPT_PATH.parent / "capture_reviewer_proof.py"
+    if not script_path.exists():
+        print(f"Reviewer-proof script missing: {relative_to_repo(script_path)}")
+        return False
+
+    result = run_command(
+        [
+            sys.executable,
+            str(script_path),
+            "--run-dir",
+            str(run_dir),
+        ],
+        allow_failure=True,
+    )
+    if result.returncode != 0:
+        print_command_failure("Reviewer-proof pack generation", result)
+        return False
+    return True
+
+
 def should_attempt_uploaded_reviewer_comment(run: dict[str, Any], evidence: dict[str, Any]) -> bool:
     if run.get("evidence_plan", {}).get("requires_ui_capture"):
         return True
@@ -1209,6 +1292,9 @@ def render_uploaded_comment(run_dir: Path, *, dry_run: bool) -> Path | None:
     upload_result = run_command(upload_command, allow_failure=True)
     if upload_result.returncode != 0:
         print_command_failure("Evidence upload", upload_result)
+        return None
+
+    if not maybe_generate_reviewer_proof(run_dir):
         return None
 
     render_result = run_command(

--- a/.agents/skills/capture-reviewer-proof/SKILL.md
+++ b/.agents/skills/capture-reviewer-proof/SKILL.md
@@ -28,10 +28,23 @@ Read:
    - short clip
    - GIF preview
    - ordered stills for pre-action, ready, post-input, and stable post-action
-7. Prefer the configured uploader flow in `docs/qa-evidence-uploads.md`.
+7. Record the proof metadata in `evidence.json` under `reviewer_proof`:
+   - `classification`: `reviewer-proof` or `trace-only`
+   - real route and optional scenario seed
+   - ordered still paths for `pre_action`, `ready_state`, `immediate_post_input`, `later_transition`, and `stable_post_action`
+   - cue timestamps for the proof moment
+   - checks for semantic coherence, visible input, readable hold, stable post-action, and reviewer-visible media
+8. Prefer the configured uploader flow in `docs/qa-evidence-uploads.md`.
    The standard `publish-github` runtime now auto-attempts this upload path for runs with visual evidence, so only do it manually when you need to inspect or edit `uploaded-comment.md` first.
-8. If hosted upload is unavailable, fall back to reviewer-openable git-tracked files on a dedicated branch or PR. Do not leave the reviewer with local-only artifact paths.
-9. Update the PR body or issue comment with public links.
+9. After upload, build the reviewer-proof pack:
+
+   ```bash
+   python .agents/skills/_functional-qa/scripts/capture_reviewer_proof.py --run-dir <RUN_DIR>
+   ```
+
+   This writes `reviewer-proof.json`, `reviewer-proof.md`, and augments `upload-manifest.json` so the rendered comment can include ordered-frame links and cue timestamps.
+10. If hosted upload is unavailable, fall back to reviewer-openable git-tracked files on a dedicated branch or PR. Do not leave the reviewer with local-only artifact paths.
+11. Update the PR body or issue comment with public links.
 
 ## Output requirements
 

--- a/.agents/skills/validate-issue/SKILL.md
+++ b/.agents/skills/validate-issue/SKILL.md
@@ -121,6 +121,12 @@ If the invocation includes `--verify-fix`, replay the most recent matching valid
    ```
 
    If the run needs reviewer-facing media links rather than a text-only QA update, continue with `capture-reviewer-proof` before considering the publication complete. The published proof should land on `tong-runs` when the uploader is configured; the local run bundle remains the staging source.
+   For timing-sensitive interaction fixes that need a reviewer-proof pack, upload the run bundle and then build the proof metadata before the final fixed claim:
+
+   ```bash
+   npm run qa:upload-evidence -- --run-dir <RUN_DIR> --include-supporting
+   python .agents/skills/_functional-qa/scripts/capture_reviewer_proof.py --run-dir <RUN_DIR>
+   ```
 
 11. Decide issue closure status deliberately:
 

--- a/docs/codex-cloud-issue-runbook.md
+++ b/docs/codex-cloud-issue-runbook.md
@@ -138,7 +138,8 @@ Important delivery rules:
 5. Reserve `@codex` GitHub comments for review or explicitly manual experiments, not the default implementation path.
 6. Do not treat a truncated or deterministic-jump clip as final acceptance proof unless the interaction sequence is still legible to a human reviewer: readable pre-action state, visible input, and stable post-action result.
 7. For timing-sensitive `/game` issues, prefer seeded checkpoint setup plus a short route-faithful proof clip over a full playthrough.
-8. Do not treat local-only artifact paths as reviewer-visible proof.
+8. For timing-sensitive fix verification, add `reviewer_proof` metadata to `evidence.json`, run `capture_reviewer_proof.py`, and make sure the rendered comment includes ordered frame links and cue timestamps instead of a generic screenshot list.
+9. Do not treat local-only artifact paths as reviewer-visible proof.
 
 ## Acceptance policy
 

--- a/docs/qa-evidence-uploads.md
+++ b/docs/qa-evidence-uploads.md
@@ -77,6 +77,21 @@ Comparison generation uses the previous validation run linked in `run.json.previ
 2. run `validate-issue --verify-fix` after the fix
 3. upload the verify-fix run bundle
 
+For timing-sensitive reviewer-proof runs, follow the upload with:
+
+```bash
+python .agents/skills/_functional-qa/scripts/capture_reviewer_proof.py \
+  --run-dir artifacts/qa-runs/functional-qa/erniesg-tong-18/20260314T115603Z
+```
+
+That script validates the `reviewer_proof` block in `evidence.json`, writes `reviewer-proof.json` and `reviewer-proof.md`, and augments `upload-manifest.json` with:
+
+1. reviewer-proof status (`reviewer-proof`, `trace-only`, or `incomplete`)
+2. ordered frame links for the proof sequence
+3. cue timestamps for the proof moment
+4. route and deterministic-setup notes
+5. any missing reviewer-ready requirements
+
 ## Render a PR-ready comment
 
 ```bash
@@ -89,6 +104,7 @@ This reads `upload-manifest.json` from the run directory and writes `uploaded-co
 - direct links to the before/after comparison panel and focused crop when available
 - inline GIF preview
 - direct link to the MP4 proof recording with audio
+- reviewer-proof stage links and cue timestamps when `capture_reviewer_proof.py` populated the manifest
 - dialogue and tooltip screenshot links
 - selected trace and summary links
 

--- a/docs/qa/issue-18-review-transition-evidence.md
+++ b/docs/qa/issue-18-review-transition-evidence.md
@@ -29,3 +29,21 @@ Use the real hangout route, not the isolated dev exercise tester:
 - A local artifact path by itself is not reviewer-visible proof. Link or attach the recording or ordered frames in the PR body, task result, or issue comment.
 - For this issue class, a single still image is not sufficient evidence.
 - If deterministic fast-forward or state injection is used to skip the full playthrough, the captured review state must still make sense to a reviewer. Do not post a clip whose visible objective or HUD implies a different target than the review state being dismissed.
+
+## Reviewer-proof pack
+
+After the verify-fix run is uploaded, populate `evidence.json.reviewer_proof` with:
+
+1. `classification: reviewer-proof`
+2. `route: /game?dev_intro=1&dev_act=2&demo=TONG-JUDGE-DEMO&qa_trace=1`
+3. ordered frames for `pre_action`, `ready_state`, `immediate_post_input`, `later_transition`, and `stable_post_action`
+4. cue timestamps for `ready_state`, `input`, `immediate_post_input`, `later_transition`, and `stable_post_action`
+5. reviewer-proof checks confirming real route, semantic coherence, visible input, readable pre-action hold, stable post-action, and reviewer-visible media
+
+Then run:
+
+```bash
+python .agents/skills/_functional-qa/scripts/capture_reviewer_proof.py --run-dir <RUN_DIR>
+```
+
+The generated `reviewer-proof.md` is the paste-ready PR/body snippet, and `uploaded-comment.md` will include the ordered frame links and cue timestamps once the manifest is augmented.

--- a/scripts/render-qa-comment.mjs
+++ b/scripts/render-qa-comment.mjs
@@ -143,6 +143,60 @@ function renderComparisonGap(manifest) {
   return `Comparison assets are still missing for this reviewer-visible QA run. ${reason}`;
 }
 
+function renderReviewerProofStatus(manifest) {
+  const reviewerProof = manifest.reviewer_proof;
+  if (!reviewerProof) return [];
+
+  const lines = [];
+  const status = reviewerProof.status || reviewerProof.classification || "missing";
+  const route = reviewerProof.route ? ` Route: \`${reviewerProof.route}\`.` : "";
+  const scenarioSeed = reviewerProof.scenario_seed ? ` Scenario seed: \`${reviewerProof.scenario_seed}\`.` : "";
+  lines.push(`Reviewer-proof pack: \`${status}\`.${route}${scenarioSeed}`);
+
+  const deterministicSetup = reviewerProof.deterministic_setup;
+  if (deterministicSetup?.used) {
+    lines.push(`Deterministic setup note: ${deterministicSetup.description || "Used only to reach the near-proof state."}`);
+  }
+
+  const cues = reviewerProof.cue_timestamps_ms || {};
+  const cueFragments = [
+    ["Ready", cues.ready_state],
+    ["Input", cues.input],
+    ["Immediate post-input", cues.immediate_post_input],
+    ["Later transition", cues.later_transition],
+    ["Stable post-action", cues.stable_post_action],
+  ]
+    .filter(([, value]) => typeof value === "number")
+    .map(([label, value]) => `${label} +${Math.trunc(value)}ms`);
+
+  if (cueFragments.length > 0) {
+    lines.push(`Cue timestamps: ${cueFragments.join(", ")}.`);
+  }
+
+  if (Array.isArray(reviewerProof.missing_requirements) && reviewerProof.missing_requirements.length > 0) {
+    lines.push(`Reviewer-proof gaps: ${reviewerProof.missing_requirements.join("; ")}`);
+  }
+
+  return lines;
+}
+
+function renderReviewerProofBullets(manifest, cacheBustToken) {
+  const reviewerProof = manifest.reviewer_proof;
+  if (!reviewerProof?.ordered_frames) return [];
+
+  const orderedStages = [
+    ["Pre-action frame", reviewerProof.ordered_frames.pre_action],
+    ["Ready-state frame", reviewerProof.ordered_frames.ready_state],
+    ["Immediate post-input frame", reviewerProof.ordered_frames.immediate_post_input],
+    ["Later transition frame", reviewerProof.ordered_frames.later_transition],
+    ["Stable post-action frame", reviewerProof.ordered_frames.stable_post_action],
+  ];
+
+  return orderedStages
+    .map(([label, artifact]) => renderBullet(label, artifact, cacheBustToken))
+    .filter(Boolean);
+}
+
 function renderComment(manifest) {
   const cacheBustToken = buildCacheBustToken(manifest);
   const issueRef = manifest.issue?.issue_ref || manifest.run.issue_ref;
@@ -154,6 +208,8 @@ function renderComment(manifest) {
   const summarySentence = renderSummarySentence(manifest);
   const comparisonContext = renderComparisonContext(manifest);
   const comparisonGap = renderComparisonGap(manifest);
+  const reviewerProofStatusLines = renderReviewerProofStatus(manifest);
+  const reviewerProofBullets = renderReviewerProofBullets(manifest, cacheBustToken);
   const validationSentence = renderValidationSentence(manifest);
 
   const lines = [];
@@ -179,12 +235,18 @@ function renderComment(manifest) {
     lines.push(comparisonGap);
   }
 
+  if (reviewerProofStatusLines.length > 0) {
+    lines.push("");
+    lines.push(...reviewerProofStatusLines);
+  }
+
   lines.push("");
   const bullets = [
     renderBullet("Before/after comparison panel", manifest.primary?.comparison_panel, cacheBustToken),
     renderBullet("Focused comparison crop", manifest.primary?.comparison_focus_crop, cacheBustToken),
     renderBullet("GIF preview", manifest.primary?.gif_preview, cacheBustToken),
     renderBullet("Screen recording with audio", manifest.primary?.proof_video, cacheBustToken),
+    ...reviewerProofBullets,
     renderBullet("Tooltip screenshot", tooltipArtifact, cacheBustToken),
     renderBullet("Dialogue screenshot", dialogueArtifact, cacheBustToken),
     renderBullet("Romanization-bait trace", manifest.primary?.romanization_trace, cacheBustToken),


### PR DESCRIPTION
Fixes #46

## Validation
- Pre-fix `validate-issue` reproduced the gap: the QA platform could upload timing-sensitive media, but it still published proof as a flat list of files without reviewer-proof status, ordered frame roles, cue timestamps, or a PR-ready snippet.
- `npm run demo:smoke` passed before and after the workflow changes.

## Root Cause
There was no first-class workflow layer between capture and publish. The runtime could host screenshots and video, but it could not validate reviewer-proof semantics or render the readable ready state, visible input, and stable post-action sequence as structured reviewer-facing evidence.

## What Changed
- Added `capture_reviewer_proof.py` to validate `evidence.json.reviewer_proof`, generate `reviewer-proof.json` and `reviewer-proof.md`, and augment `upload-manifest.json`.
- Added fixed-claim gating in the QA runtime so timing-sensitive UI issues require `reviewer_proof.status == reviewer-proof`.
- Updated the uploaded comment renderer to include route context, cue timestamps, and ordered reviewer-frame links.
- Updated the reviewer-proof skill and runbook docs for the new flow.
- Kept the non-qa-platform boundary minimal: one renderer change in `scripts/render-qa-comment.mjs` so the new proof pack actually reaches reviewer-facing markdown.

## Verify Fix
- `validate-issue --verify-fix` passed for `erniesg/tong#46` against the canonical issue `#18` proof bundle.
- The verify run now produces reviewer-proof status, ordered stage links, cue timestamps, route metadata, and a paste-ready reviewer-proof snippet from the run bundle itself.

## Reviewer-Visible Evidence
- GIF preview: https://runs.tong.berlayar.ai/qa-runs/functional-qa/erniesg-tong-46/functional-qa-validate-issue-20260315T053412Z-erniesg-tong-46/previews/issue-18-review-dismiss-proof-short.preview.gif
- MP4: https://runs.tong.berlayar.ai/qa-runs/functional-qa/erniesg-tong-46/functional-qa-validate-issue-20260315T053412Z-erniesg-tong-46/_repo/artifacts/qa-runs/functional-qa/erniesg-tong-18/20260314T115603Z/videos/issue-18-review-dismiss-proof-short.mp4
- Ready-state frame: https://runs.tong.berlayar.ai/qa-runs/functional-qa/erniesg-tong-46/functional-qa-validate-issue-20260315T053412Z-erniesg-tong-46/_repo/artifacts/qa-runs/functional-qa/erniesg-tong-18/20260314T115603Z/screenshots/review-ready.png
- Immediate post-input frame: https://runs.tong.berlayar.ai/qa-runs/functional-qa/erniesg-tong-46/functional-qa-validate-issue-20260315T053412Z-erniesg-tong-46/_repo/artifacts/qa-runs/functional-qa/erniesg-tong-18/20260314T115603Z/screenshots/dismiss-t090.png
- Stable post-action frame: https://runs.tong.berlayar.ai/qa-runs/functional-qa/erniesg-tong-46/functional-qa-validate-issue-20260315T053412Z-erniesg-tong-46/_repo/artifacts/qa-runs/functional-qa/erniesg-tong-18/20260314T115603Z/screenshots/post-dismiss.png

Cue timestamps: ready `+30370ms`, input `+30831ms`, immediate post-input `+30921ms`, later transition `+31101ms`, stable post-action `+31305ms`.

## Final Acceptance
Final local/browser-backed acceptance recording is still required after merge for timing-sensitive `/game` work, per repo policy.
