### PR TITLE
functional-qa: add #46 playbook + sync validation markers and title fallback

### DIFF
--- a/.agents/skills/_functional-qa/config/codex-cloud.json
+++ b/.agents/skills/_functional-qa/config/codex-cloud.json
@@ -49,32 +49,52 @@
     {
       "id": "batch-1",
       "description": "First cloud wave: Block Crush transition polish and dialogue streaming after the initial readability pass landed.",
-      "issues": ["#18", "#19"]
+      "issues": [
+        "#18",
+        "#19"
+      ]
     },
     {
       "id": "batch-parallel",
       "description": "Independent remote-first tooling and asset-foundation work that can run in parallel with the client-shell priority wave.",
-      "issues": ["#35", "#36", "#34"]
+      "issues": [
+        "#35",
+        "#36",
+        "#34"
+      ]
     },
     {
       "id": "batch-parallel",
       "description": "Independent remote-first tooling and asset-foundation work that can run in parallel with the client-shell priority wave.",
-      "issues": ["#35", "#36", "#34"]
+      "issues": [
+        "#35",
+        "#36",
+        "#34"
+      ]
     },
     {
       "id": "batch-2",
       "description": "Second cloud wave: follow-up onboarding, HUD, Block Crush guidance, and tap-flow fixes after the priority wave settles.",
-      "issues": ["#14", "#11", "#31", "#17"]
+      "issues": [
+        "#14",
+        "#11",
+        "#31",
+        "#17"
+      ]
     },
     {
       "id": "batch-3",
       "description": "Later follow-up cleanup after the focused fixes land, including residual readability audit work.",
-      "issues": ["#15"]
+      "issues": [
+        "#15"
+      ]
     },
     {
       "id": "batch-local",
       "description": "Asset-hosting or local-acceptance dependent work.",
-      "issues": ["#12"]
+      "issues": [
+        "#12"
+      ]
     }
   ],
   "issue_overrides": [
@@ -114,7 +134,9 @@
       "match": "#17",
       "cloud_mode": "cloud-ready-with-local-proof",
       "batch": "batch-2",
-      "depends_on": ["#11"],
+      "depends_on": [
+        "#11"
+      ],
       "needs_final_local_acceptance": true,
       "reason": "The wasted-tap fix can be developed in cloud, but final confidence depends on timed browser tracing."
     },
@@ -122,7 +144,9 @@
       "match": "#18",
       "cloud_mode": "cloud-ready-with-local-proof",
       "batch": "batch-2",
-      "depends_on": ["#13"],
+      "depends_on": [
+        "#13"
+      ],
       "needs_final_local_acceptance": true,
       "reason": "The transition bug is reproducible in cloud, but a fixed claim still needs reviewer-visible temporal evidence from the real Act 2 flow rather than a hidden local artifact path."
     },
@@ -130,7 +154,9 @@
       "match": "#19",
       "cloud_mode": "cloud-ready-with-local-proof",
       "batch": "batch-1",
-      "depends_on": ["#18"],
+      "depends_on": [
+        "#18"
+      ],
       "needs_final_local_acceptance": true,
       "reason": "Streaming behavior remains in the priority wave, but it should follow #18 so the client-shell queue stays serialized while the final player-visible result still gets browser-backed verification."
     },
@@ -141,6 +167,15 @@
       "depends_on": [],
       "needs_final_local_acceptance": false,
       "reason": "The Block Crush first-time hint and early-stage difficulty tuning are lightweight UI/gameplay follow-ups that fit the second wave."
+    },
+    {
+      "match": "#46",
+      "cloud_mode": "cloud-ready-with-local-proof",
+      "batch": "unassigned",
+      "depends_on": [],
+      "needs_final_local_acceptance": true,
+      "reason": "`animation-transition` is cloud-fixable, but final confidence still needs browser-backed local acceptance.",
+      "fallback_title": "Build first-class reviewer-proof capture workflow for timing-sensitive UI interactions"
     }
   ]
 }

--- a/.agents/skills/_functional-qa/config/repo-adapter.json
+++ b/.agents/skills/_functional-qa/config/repo-adapter.json
@@ -41,22 +41,32 @@
   "surfaces": [
     {
       "id": "overlay",
-      "routes": ["/overlay"],
+      "routes": [
+        "/overlay"
+      ],
       "notes": "Caption lanes plus dictionary popover."
     },
     {
       "id": "game",
-      "routes": ["/game", "/game/hangout", "/game/map"],
+      "routes": [
+        "/game",
+        "/game/hangout",
+        "/game/map"
+      ],
       "notes": "Primary narrative and exercise surface."
     },
     {
       "id": "insights",
-      "routes": ["/insights"],
+      "routes": [
+        "/insights"
+      ],
       "notes": "Vocabulary feed and clustering review surface."
     },
     {
       "id": "extension",
-      "routes": ["chrome-extension://apps/extension"],
+      "routes": [
+        "chrome-extension://apps/extension"
+      ],
       "notes": "YouTube overlay and subtitle augmentation surface."
     }
   ],
@@ -103,6 +113,15 @@
       "notes": [
         "Distinguish transport-level streaming from user-visible progressive rendering.",
         "Capture timestamps for request start, first visible dialogue, incremental updates, and completion."
+      ]
+    },
+    {
+      "match": "#46",
+      "issue_class_override": "animation-transition",
+      "notes": [
+        "Treat this as a timing-sensitive reviewer-proof workflow issue.",
+        "Require temporal capture and screenshots in validation and fix verification outputs.",
+        "Prefer qa-platform docs and workflow assets; keep cross-lane changes minimal."
       ]
     }
   ],
@@ -305,6 +324,30 @@
         "toolQueue",
         "processing"
       ]
+    },
+    {
+      "match": "#46",
+      "surface": "qa-platform",
+      "steps": [
+        "Generate the codex cloud queue prompt for erniesg/tong#46.",
+        "Validate the task prompt includes timing-sensitive evidence requirements and reviewer-visible media guidance.",
+        "Verify lane routing points to qa-platform with explicit docs paths."
+      ],
+      "screenshot_targets": [
+        "task prompt excerpt showing evidence requirements",
+        "task prompt excerpt showing reviewer-visible media requirement"
+      ],
+      "state_targets": [
+        "classification.issue_class",
+        "evidence_plan.required",
+        "recommended_worktree.id",
+        "validation_policy.ui_acceptance_required"
+      ],
+      "path_targets": [
+        "docs/codex-cloud-issue-runbook.md",
+        "docs/qa/issue-18-review-transition-evidence.md"
+      ],
+      "route_template": "/roadmap?demo={{demo_password}}&qa_run_id={{run_id}}&qa_trace=1"
     }
   ]
 }

--- a/.agents/skills/_functional-qa/scripts/codex_cloud_queue.py
+++ b/.agents/skills/_functional-qa/scripts/codex_cloud_queue.py
@@ -286,9 +286,12 @@ def build_cloud_issue(raw_issue: dict[str, Any], queue_dir: Path) -> dict[str, A
     readiness_reason = merge_readiness_reason(readiness_reason, portability)
 
     issue_number = issue_entry.get("number")
+    effective_title = issue_entry["title"]
+    if override and override.get("fallback_title") and issue_ref and issue_entry["title"].strip() == issue_ref:
+        effective_title = override["fallback_title"]
     file_stub = f"issue-{issue_number}" if issue_number is not None else slugify(issue_entry["title"])
-    branch_name = branch_name_for(issue_number, issue_entry["title"])
-    pr_title = pr_title_for(issue_number, issue_entry["title"])
+    branch_name = branch_name_for(issue_number, effective_title)
+    pr_title = pr_title_for(issue_number, effective_title)
     worktree = issue_entry["recommended_worktree"]
 
     issue_dir = queue_dir / "issues"

--- a/.agents/skills/_functional-qa/scripts/issue_router.py
+++ b/.agents/skills/_functional-qa/scripts/issue_router.py
@@ -261,7 +261,8 @@ def build_issue_entry(issue: dict[str, Any]) -> dict[str, Any]:
         playbook=playbook,
         evidence_plan=evidence_plan,
     )
-    explicit_paths = extract_paths(issue["title"], issue["body"])
+    playbook_paths = playbook.get("path_targets", []) if playbook else []
+    explicit_paths = sorted(set(extract_paths(issue["title"], issue["body"], "\n".join(playbook_paths))))
     issue["project_fields"] = project_fields
     worktree, routing_reasons, spans_multiple_worktrees, explicit_candidates = route_worktree(issue, classification["issue_class"], explicit_paths)
     shared_hits = shared_zone_hits(explicit_paths)

--- a/.agents/skills/_functional-qa/scripts/qa_runtime.py
+++ b/.agents/skills/_functional-qa/scripts/qa_runtime.py
@@ -1081,6 +1081,71 @@ def validation_gate_failures(run: dict[str, Any], evidence: dict[str, Any], *, f
     return failures
 
 
+EVIDENCE_SECTION_BY_REQUIREMENT = {
+    "screenshots": "screenshots",
+    "comparison-panel": "comparison_panels",
+    "comparison-focus-crop": "comparison_focus_crops",
+    "temporal-capture": "temporal_capture",
+    "console-state-trace": "console_logs",
+    "network-trace": "network_traces",
+    "contract-assertions": "contract_assertions",
+    "perf-profile": "perf_profiles",
+    "cross-env-matrix": "cross_env_matrix",
+}
+
+VISUAL_EVIDENCE_SECTIONS = {
+    "screenshots",
+    "comparison_panels",
+    "comparison_focus_crops",
+    "temporal_capture",
+}
+
+
+def sync_validation_markers(run: dict[str, Any], evidence: dict[str, Any]) -> None:
+    """Populate validation gate markers from current evidence entries.
+
+    This keeps `publish-github` and `finalize-run` aligned with the evidence plan
+    without requiring runners to manually toggle validation booleans.
+    """
+
+    validation = evidence.setdefault("validation", {})
+    required = run.get("evidence_plan", {}).get("required", [])
+
+    missing_required: list[str] = []
+    for requirement in required:
+        section = EVIDENCE_SECTION_BY_REQUIREMENT.get(requirement)
+        if not section:
+            continue
+        entries = evidence.get(section, [])
+        if not entries:
+            missing_required.append(requirement)
+
+    existing_missing = [
+        item
+        for item in validation.get("missing_requirements", [])
+        if not str(item).startswith("required evidence missing:")
+    ]
+    for requirement in missing_required:
+        note = f"required evidence missing: {requirement}"
+        if note not in existing_missing:
+            existing_missing.append(note)
+    validation["missing_requirements"] = existing_missing
+
+    if run.get("validation_policy", {}).get("requires_direct_issue_evidence"):
+        if not validation.get("direct_issue_evidence_complete", False):
+            validation["direct_issue_evidence_complete"] = not missing_required
+
+    if run.get("validation_policy", {}).get("ui_acceptance_required"):
+        visual_present = any(evidence.get(section) for section in VISUAL_EVIDENCE_SECTIONS)
+        missing_visual = any(
+            requirement in missing_required
+            and EVIDENCE_SECTION_BY_REQUIREMENT.get(requirement) in VISUAL_EVIDENCE_SECTIONS
+            for requirement in required
+        )
+        if not validation.get("ui_acceptance_complete", False):
+            validation["ui_acceptance_complete"] = visual_present and not missing_visual
+
+
 def render_validation_gate_lines(run: dict[str, Any], evidence: dict[str, Any]) -> str:
     policy = run.get("validation_policy", {})
     validation = evidence.get("validation", {})
@@ -1355,6 +1420,7 @@ def finalize_run(args: argparse.Namespace) -> int:
     run_dir = Path(args.run_dir).resolve()
     run = load_run_manifest(run_dir)
     evidence = load_json(run_dir / "evidence.json")
+    sync_validation_markers(run, evidence)
     verdict = args.verdict
     if verdict not in VERDICTS:
         raise ValueError(f"Unsupported verdict: {verdict}")
@@ -1380,6 +1446,7 @@ def finalize_run(args: argparse.Namespace) -> int:
         run["previous_run_id"] = args.previous_run_id
 
     (run_dir / "run.json").write_text(json.dumps(run, indent=2) + "\n", encoding="utf-8")
+    (run_dir / "evidence.json").write_text(json.dumps(evidence, indent=2) + "\n", encoding="utf-8")
     rendered = render_publish(run, run_dir)
     (run_dir / "publish.md").write_text(rendered + "\n", encoding="utf-8")
     print(str(run_dir / "publish.md"))
@@ -1390,6 +1457,8 @@ def publish_github(args: argparse.Namespace) -> int:
     run_dir = Path(args.run_dir).resolve()
     run = load_run_manifest(run_dir)
     evidence = load_json(run_dir / "evidence.json")
+    sync_validation_markers(run, evidence)
+    (run_dir / "evidence.json").write_text(json.dumps(evidence, indent=2) + "\n", encoding="utf-8")
     issue_ref = run.get("issue_ref")
     if not issue_ref:
         print("Run has no GitHub issue reference; skipping publish.")


### PR DESCRIPTION
### Motivation

- Add handling and playbook/notes for a new timing-sensitive issue (#46) and ensure reviewers get explicit temporal-evidence guidance.
- Keep run validation state consistent with actual evidence so `finalize-run`/`publish-github` enforce gates reliably without manual toggles.
- Use a fallback PR/branch title when an override supplies a reviewer-friendly replacement instead of the raw issue ref.

### Description

- Added a new issue override and playbook for `#46` in `.agents/skills/_functional-qa/config/codex-cloud.json` and `.agents/skills/_functional-qa/config/repo-adapter.json`, including `issue_class_override`, notes, `path_targets`, and a `fallback_title` for reviewer-facing prompts.
- Adjusted JSON array formatting in adapter/config files for more readable diffs (multiline arrays for routes and issues).
- In `scripts/codex_cloud_queue.py` implemented fallback title logic: compute `effective_title` from `issue_entry['title']` or `override['fallback_title']` and use it when generating `branch_name` and `pr_title` to avoid using raw issue refs as PR titles.
- In `scripts/issue_router.py` include playbook `path_targets` when extracting explicit paths by merging them into the `extract_paths` input to improve routing and detection of relevant docs/paths.
- In `scripts/qa_runtime.py` added `EVIDENCE_SECTION_BY_REQUIREMENT`, `VISUAL_EVIDENCE_SECTIONS`, and the `sync_validation_markers` function to populate `evidence.validation` entries from existing evidence sections, and wired `sync_validation_markers` into both `finalize_run` and `publish_github`; also persist updated `evidence.json` after syncing.

### Testing

- Ran the repository test suite with `pytest` against the functional-qa scripts and adapters with no failures observed.
- Exercised the `finalize-run` and `publish_github` flows on a local run directory to confirm `sync_validation_markers` updates `evidence.json` and that validation gates reflect present/missing evidence as expected.
- Rendered the codex queue output for a sample issue with an override `fallback_title` to confirm branch and PR title generation uses the fallback string instead of the raw issue ref.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5d124d138832aa18d0f86cb8f9c1a)