### PR TITLE
fix: issue #48 - Contracts: define game session, scene session, checkpoint, and scenario

### DIFF
--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -21,3 +21,7 @@ Curriculum graph fixtures:
 Naming note:
 - The shared contract uses `learnerId` as the stable user-specific identifier.
 - The mock dashboard runtime also accepts `personaId` as an alias because the first milestone is driven by persona fixtures.
+
+Session contracts:
+- `StartOrResumeGameResponse` now includes canonical `gameSession`, `sceneSession`, `checkpoint`, and `scenarioSeed` payloads for resume + deterministic checkpoint workflows.
+- `fixtures/game.start-or-resume.sample.json` is the reference payload for those shapes.

--- a/packages/contracts/api-contract.md
+++ b/packages/contracts/api-contract.md
@@ -392,9 +392,65 @@ Response:
   "city": "seoul",
   "sceneId": "intro_001",
   "tongPrompt": "in-character system prompt token or id",
-  "actions": ["Train vocals", "Attend language class", "Meet cast member"]
+  "actions": ["Train vocals", "Attend language class", "Meet cast member"],
+  "gameSession": {
+    "gameSessionId": "sess_123",
+    "userId": "demo-user-1",
+    "city": "seoul",
+    "activeSceneId": "intro_001",
+    "activeSceneSessionId": "scene_sess_001",
+    "progression": {
+      "xp": 110,
+      "sp": 45,
+      "rp": 12,
+      "currentMasteryLevel": 1
+    },
+    "status": "active",
+    "startedAtIso": "2026-03-14T21:00:00.000Z",
+    "updatedAtIso": "2026-03-14T21:22:00.000Z"
+  },
+  "sceneSession": {
+    "sceneSessionId": "scene_sess_001",
+    "gameSessionId": "sess_123",
+    "sceneId": "intro_001",
+    "scenarioId": "seoul_food_street_hangout_first_order",
+    "city": "seoul",
+    "locationId": "food_street",
+    "mode": "hangout",
+    "turn": 0,
+    "status": "active",
+    "objectiveId": "ko_food_l2_001",
+    "lang": "ko",
+    "startedAtIso": "2026-03-14T21:00:00.000Z",
+    "updatedAtIso": "2026-03-14T21:22:00.000Z"
+  },
+  "checkpoint": {
+    "checkpointId": "chk_001",
+    "gameSessionId": "sess_123",
+    "sceneSessionId": "scene_sess_001",
+    "city": "seoul",
+    "locationId": "food_street",
+    "mode": "hangout",
+    "objectiveId": "ko_food_l2_001",
+    "turn": 0,
+    "label": "intro-open",
+    "reason": "autosave",
+    "savedAtIso": "2026-03-14T21:22:00.000Z"
+  },
+  "scenarioSeed": {
+    "scenarioSeedId": "seed_food_street_hangout_intro_v1",
+    "scenarioId": "seoul_food_street_hangout_first_order",
+    "city": "seoul",
+    "locationId": "food_street",
+    "mode": "hangout",
+    "objectiveId": "ko_food_l2_001",
+    "lang": "ko"
+  }
 }
 ```
+
+Contract note:
+- `gameSession`, `sceneSession`, `checkpoint`, and `scenarioSeed` are required so resume and deterministic checkpoint flows can share one canonical shape.
 
 ## GET `/api/v1/objectives/next`
 Query:

--- a/packages/contracts/fixtures/game.start-or-resume.sample.json
+++ b/packages/contracts/fixtures/game.start-or-resume.sample.json
@@ -2,6 +2,8 @@
   "sessionId": "sess_demo_001",
   "city": "seoul",
   "sceneId": "food_street_hangout_intro",
+  "tongPrompt": "in-character system prompt token or id",
+  "actions": ["Train vocals", "Attend language class", "Meet cast member"],
   "profile": {
     "nativeLanguage": "en",
     "targetLanguages": ["ko", "ja", "zh"],
@@ -16,5 +18,58 @@
     "sp": 45,
     "rp": 12,
     "currentMasteryLevel": 1
+  },
+  "gameSession": {
+    "gameSessionId": "sess_demo_001",
+    "userId": "demo-user-1",
+    "city": "seoul",
+    "activeSceneId": "food_street_hangout_intro",
+    "activeSceneSessionId": "scene_sess_demo_001",
+    "progression": {
+      "xp": 110,
+      "sp": 45,
+      "rp": 12,
+      "currentMasteryLevel": 1
+    },
+    "status": "active",
+    "startedAtIso": "2026-03-14T21:00:00.000Z",
+    "updatedAtIso": "2026-03-14T21:22:00.000Z"
+  },
+  "sceneSession": {
+    "sceneSessionId": "scene_sess_demo_001",
+    "gameSessionId": "sess_demo_001",
+    "sceneId": "food_street_hangout_intro",
+    "scenarioId": "seoul_food_street_hangout_first_order",
+    "city": "seoul",
+    "locationId": "food_street",
+    "mode": "hangout",
+    "turn": 3,
+    "status": "active",
+    "objectiveId": "ko_food_l2_001",
+    "lang": "ko",
+    "startedAtIso": "2026-03-14T21:00:00.000Z",
+    "updatedAtIso": "2026-03-14T21:22:00.000Z"
+  },
+  "checkpoint": {
+    "checkpointId": "chk_demo_001",
+    "gameSessionId": "sess_demo_001",
+    "sceneSessionId": "scene_sess_demo_001",
+    "city": "seoul",
+    "locationId": "food_street",
+    "mode": "hangout",
+    "objectiveId": "ko_food_l2_001",
+    "turn": 3,
+    "label": "food-street-order-midpoint",
+    "reason": "autosave",
+    "savedAtIso": "2026-03-14T21:22:00.000Z"
+  },
+  "scenarioSeed": {
+    "scenarioSeedId": "seed_food_street_hangout_intro_v1",
+    "scenarioId": "seoul_food_street_hangout_first_order",
+    "city": "seoul",
+    "locationId": "food_street",
+    "mode": "hangout",
+    "objectiveId": "ko_food_l2_001",
+    "lang": "ko"
   }
 }

--- a/packages/contracts/types.ts
+++ b/packages/contracts/types.ts
@@ -128,12 +128,77 @@ export interface StartOrResumeGameRequest {
   };
 }
 
+export interface GameProgressionState {
+  xp: number;
+  sp: number;
+  rp: number;
+  currentMasteryLevel: number;
+}
+
+export interface GameScenarioSeed {
+  scenarioSeedId: string;
+  scenarioId: string;
+  city: GraphCityId;
+  locationId: GraphLocationId;
+  mode: 'hangout' | 'learn';
+  objectiveId: string;
+  lang: TargetLanguage;
+}
+
+export interface GameSceneSession {
+  sceneSessionId: string;
+  gameSessionId: string;
+  sceneId: string;
+  scenarioId: string;
+  city: GraphCityId;
+  locationId: GraphLocationId;
+  mode: 'hangout' | 'learn';
+  turn: number;
+  status: 'active' | 'completed' | 'abandoned';
+  objectiveId: string;
+  lang: TargetLanguage;
+  startedAtIso: string;
+  updatedAtIso: string;
+}
+
+export interface GameCheckpoint {
+  checkpointId: string;
+  gameSessionId: string;
+  sceneSessionId: string;
+  city: GraphCityId;
+  locationId: GraphLocationId;
+  mode: 'hangout' | 'learn';
+  objectiveId: string;
+  turn: number;
+  label: string;
+  reason: 'autosave' | 'manual' | 'mission_gate' | 'qa_seed';
+  savedAtIso: string;
+}
+
+export interface GameSession {
+  gameSessionId: string;
+  userId: string;
+  city: GraphCityId;
+  activeSceneId: string;
+  activeSceneSessionId: string;
+  progression: GameProgressionState;
+  status: 'active' | 'paused' | 'completed';
+  startedAtIso: string;
+  updatedAtIso: string;
+}
+
 export interface StartOrResumeGameResponse {
   sessionId: string;
-  city: 'seoul' | 'tokyo' | 'shanghai';
+  city: GraphCityId;
   sceneId: string;
   tongPrompt: string;
   actions: string[];
+  profile?: StartOrResumeGameRequest['profile'];
+  progression?: GameProgressionState;
+  gameSession: GameSession;
+  sceneSession: GameSceneSession;
+  checkpoint: GameCheckpoint;
+  scenarioSeed: GameScenarioSeed;
 }
 
 export interface ObjectiveNextResponse {


### PR DESCRIPTION
### Motivation
- The `StartOrResumeGameResponse` was too shallow for deterministic resume and checkpoint flows and lacked canonical payloads for session, scene-session, checkpoint, and scenario-seed shapes.
- Client and server code and QA workflows require a single, repo-visible canonical shape and fixtures for resume, deterministic seeds, and QA checkpoints.

### Description
- Added typed contract models in `packages/contracts/types.ts`: `GameProgressionState`, `GameSession`, `GameSceneSession`, `GameCheckpoint`, and `GameScenarioSeed` and expanded `StartOrResumeGameResponse` to include `gameSession`, `sceneSession`, `checkpoint`, `scenarioSeed`, plus optional `profile`/`progression` for compatibility.
- Updated the canonical fixture `packages/contracts/fixtures/game.start-or-resume.sample.json` to show the new shape and expanded the `POST /api/v1/game/start-or-resume` example in `packages/contracts/api-contract.md` with an explicit contract note.
- Added a short README note in `packages/contracts/README.md` documenting the new session contract surfaces and kept changes limited to `packages/contracts/**` to avoid shared-zone collisions.
- Created a PR with the change and included the closing keyword to resolve the tracked issue.

### Testing
- QA workflow: ran the functional QA sequence for `erniesg/tong#48` (`validate-issue` → implemented fix → `validate-issue --verify-fix`) and confirmed the contracts now include the required session/checkpoint/seed structures; artifacts saved under `artifacts/qa-runs/functional-qa/erniesg-tong-48/`.
- Contract checks: `npm run demo:smoke` passed and `npm run test:graph-contracts` passed after the change, confirming fixture parsing and graph contract integrity.
- Network trace: `npm run test:api-flow` failed with `fetch failed` because no local API server was running at `http://localhost:8787` in this environment, which is an environment limitation and does not block the contract-only fix.
- How to test locally: run `npm run demo:smoke`, run `npm run test:graph-contracts`, inspect `packages/contracts/fixtures/game.start-or-resume.sample.json` and `packages/contracts/api-contract.md` for the canonical payload, and optionally run `npm run test:api-flow` against a running local API at `http://localhost:8787` to capture network traces.

Fixes #48

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5d1903fa4832aa4b2b61cde07d70b)