### PR TITLE
docs: add manual QA and reviewer-proof preflight

### DIFF
--- a/docs/codex-cloud-issue-runbook.md
+++ b/docs/codex-cloud-issue-runbook.md
@@ -27,7 +27,9 @@ Practical rule:
    - `npm --prefix apps/client install`
    - `npm run demo:smoke`
    - `npm run ingest:mock`
-3. If cloud tasks need large or private assets later, move them to shared storage first. Until then, leave asset-dependent issues as local-only.
+3. The shell that will publish reviewer-visible QA evidence should pass:
+   - `npm run qa:preflight-reviewer-proof`
+4. If cloud tasks need large or private assets later, move them to shared storage first. Until then, leave asset-dependent issues as local-only.
 
 ## Repo entry points
 

--- a/docs/qa-evidence-uploads.md
+++ b/docs/qa-evidence-uploads.md
@@ -47,6 +47,23 @@ Boundary reminder:
 
 The uploader uses the Wrangler auth already configured for `apps/client`.
 
+## Preflight the publishing shell
+
+Before asking a local or remote operator to publish reviewer-visible proof, run:
+
+```bash
+npm run qa:preflight-reviewer-proof
+```
+
+This checks:
+- `TONG_RUNS_R2_BUCKET`
+- `TONG_RUNS_PUBLIC_BASE_URL`
+- `node`, `npm`, `python3`, `ffmpeg`, and `ffprobe`
+- `wrangler` through `apps/client`
+- the repo entry points used by upload, proof-pack generation, and comment rendering
+
+`magick` is reported as a warning rather than a hard failure because upload still works without auto-generated comparison panels.
+
 ## Upload a run bundle
 
 ```bash

--- a/docs/qa/current-main-manual-checklist.md
+++ b/docs/qa/current-main-manual-checklist.md
@@ -1,0 +1,124 @@
+# Current Main Manual QA Checklist
+
+Use this checklist to validate the merged baseline on `main` as of March 15, 2026.
+
+Covered scope:
+- `#46` reviewer-proof upload and render workflow
+- `#48` session/checkpoint contract shape
+- `#49` persisted hangout checkpoint resume path
+- `#61` starter-pack and reward-hook content fixes
+
+This is a current-state checklist, not final product acceptance. `#50` and `#51` are still open, so do not fail the build just because player-facing map-return resume is not wired yet.
+
+## 1. Sync and install
+
+```bash
+git checkout main
+git pull origin main
+
+npm --prefix apps/server install
+npm --prefix apps/client install
+```
+
+Pass when both installs complete without dependency or postinstall errors.
+
+## 2. Run repo smoke
+
+```bash
+npm run demo:smoke
+```
+
+Pass when the command exits `0`.
+
+What this confirms:
+- shared fixtures and contracts still parse
+- runtime/demo fixture integrity is intact
+- recent content-template corrections did not reintroduce canonical-id drift
+
+## 3. Seed mock ingest data
+
+```bash
+npm run ingest:mock
+```
+
+Pass when the mock ingestion pipeline completes without crashing.
+
+## 4. Validate the persisted checkpoint API flow
+
+Terminal 1:
+
+```bash
+npm run dev:server
+```
+
+Terminal 2:
+
+```bash
+npm run test:api-flow:local
+```
+
+Pass when the strict local flow includes these markers:
+- `PASS /api/v1/game/start-or-resume`
+- `PASS /api/v1/scenes/hangout/start`
+- `PASS /api/v1/scenes/hangout/respond`
+- `PASS /api/v1/game/start-or-resume resume`
+
+What this confirms:
+- the server writes a checkpoint after a hangout turn
+- a later `start-or-resume` reuses the active session
+- resume comes back from the stored checkpoint instead of fabricating a fresh scene
+
+## 5. Run a browser sanity pass on `/game`
+
+Terminal 3:
+
+```bash
+NEXT_PUBLIC_TONG_API_BASE=http://localhost:8787 npm run dev:client
+```
+
+Open:
+
+```text
+http://localhost:3000/game?demo=TONG-JUDGE-DEMO
+```
+
+Confirm:
+- the page loads without a fatal error
+- you can start a hangout
+- the first scene renders dialogue, objective state, and normal controls
+- refreshing the route does not crash the bootstrap path
+
+Expected current limitation:
+- there is not yet a finished player-facing `Return to world map` and `Resume active hangout` UX from an in-progress scene. That is `#50`.
+
+## 6. Check reviewer-proof publication readiness
+
+```bash
+npm run qa:preflight-reviewer-proof
+```
+
+Pass when required env vars, tools, and repo entry points all report `PASS`.
+
+If you already have a finished QA run bundle, publish a reviewer-visible proof pack:
+
+```bash
+npm run qa:upload-evidence -- --run-dir <RUN_DIR> --include-supporting
+python3 .agents/skills/_functional-qa/scripts/capture_reviewer_proof.py --run-dir <RUN_DIR>
+npm run qa:render-comment -- --run-dir <RUN_DIR>
+```
+
+Pass when:
+- `<RUN_DIR>/upload-manifest.json` exists
+- `<RUN_DIR>/reviewer-proof.md` exists for timing-sensitive proof runs
+- `<RUN_DIR>/uploaded-comment.md` contains public `tong-runs` links instead of local-only artifact paths
+
+## 7. Know the acceptance boundary
+
+Current `main` is ready for:
+- local validation of the persisted resume/checkpoint backend path
+- reviewer-visible proof publication for portable QA runs, if uploader env is configured
+
+Current `main` is not yet the final gameplay acceptance baseline because:
+- `#50` still needs the player-facing world-map return/resume UX
+- `#51` still needs deterministic `/game` checkpoint mounts for short proof capture
+- the final full-route acceptance clip still needs one local browser-backed run after those land

--- a/docs/qa/remote-reviewer-proof-setup.md
+++ b/docs/qa/remote-reviewer-proof-setup.md
@@ -1,0 +1,92 @@
+# Remote Reviewer-Proof Setup
+
+Use this when you want a local or remote operator to publish reviewer-visible QA clips from Tong.
+
+## What "remote ready" means
+
+Remote proof is ready when all of the following are true:
+- the issue is portable from tracked repo state plus environment setup
+- the shell that will publish evidence has the `tong-runs` uploader env configured
+- the shell has the media tooling needed by the uploader
+- the resulting PR or issue comment links public `tong-runs` URLs instead of local artifact paths
+
+This is enough for short reviewer-proof clips on portable issues.
+
+It is not the same as final product acceptance. The full end-to-end acceptance recording still stays local/browser-backed after the progression issues land.
+
+## Required environment
+
+Export these before trying to publish reviewer-visible proof:
+
+```bash
+export TONG_RUNS_R2_BUCKET=tong-runs
+export TONG_RUNS_PUBLIC_BASE_URL=https://runs.tong.berlayar.ai
+```
+
+The uploader uses the Wrangler auth already configured for `apps/client`.
+
+## Required tooling
+
+The publishing shell needs:
+- `node`
+- `npm`
+- `python3`
+- `ffmpeg`
+- `ffprobe`
+- `npm --prefix apps/client exec wrangler -- --version`
+
+Optional but recommended:
+- `magick`
+
+Without `magick`, upload still works, but the auto-generated comparison panel and focused crop are skipped.
+
+## One-command preflight
+
+Run this in the exact shell or environment that will publish the evidence:
+
+```bash
+npm run qa:preflight-reviewer-proof
+```
+
+The command fails if a required env var, tool, or repo entry point is missing.
+
+## Publishing flow
+
+From an existing QA run bundle:
+
+```bash
+npm run qa:upload-evidence -- --run-dir <RUN_DIR> --include-supporting
+python3 .agents/skills/_functional-qa/scripts/capture_reviewer_proof.py --run-dir <RUN_DIR>
+npm run qa:render-comment -- --run-dir <RUN_DIR>
+```
+
+Expected outputs:
+- `upload-manifest.json`
+- `reviewer-proof.json`
+- `reviewer-proof.md`
+- `uploaded-comment.md`
+
+Required review surface:
+- `uploaded-comment.md` should point at public `tong-runs` URLs
+- do not treat `artifacts/qa-runs/...` as reviewer-visible proof
+
+## Codex cloud handoff
+
+Before sending a portable issue to Codex cloud:
+
+```bash
+npm run codex:cloud-plan
+```
+
+Use the generated task prompt and PR notes for the issue. If the issue needs timing-sensitive proof, keep the evidence requirement explicit in the task prompt and require public links in the final PR body or comment.
+
+## Current acceptance boundary
+
+As of March 15, 2026:
+- remote can publish reviewer-visible clips for portable issue validation and fix verification
+- remote should not be treated as the final full-demo acceptance recorder yet
+
+Why:
+- `#49` landed the persisted checkpoint backend path
+- `#50` is still needed for player-facing return-to-map and resume UX
+- `#51` is still needed for deterministic `/game` checkpoint mounts that make short proof clips practical

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "demo:smoke": "node scripts/demo_smoke_check.mjs",
     "demo:tools": "node scripts/mock_tool_flow_check.mjs",
     "demo:judge": "./scripts/run-judge-demo.sh",
+    "qa:preflight-reviewer-proof": "node scripts/qa_evidence_preflight.mjs",
     "qa:upload-evidence": "node scripts/upload-qa-evidence.mjs",
     "qa:render-comment": "node scripts/render-qa-comment.mjs",
     "secrets:sync:cf": "./scripts/sync-cf-secrets-from-env.sh",

--- a/scripts/qa_evidence_preflight.mjs
+++ b/scripts/qa_evidence_preflight.mjs
@@ -1,0 +1,282 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { relativeToRepo, resolveRepoRoot } from "./lib/qa_evidence.mjs";
+
+const REQUIRED_ENV_VARS = [
+  {
+    name: "TONG_RUNS_R2_BUCKET",
+    description: "Reviewer-facing QA evidence bucket",
+  },
+  {
+    name: "TONG_RUNS_PUBLIC_BASE_URL",
+    description: "Public base URL for uploaded reviewer-facing proof",
+    validate(value) {
+      try {
+        const url = new URL(value);
+        return url.protocol === "http:" || url.protocol === "https:";
+      } catch {
+        return false;
+      }
+    },
+    invalidMessage: "must be an absolute http(s) URL",
+  },
+];
+
+const REQUIRED_COMMANDS = [
+  {
+    label: "node",
+    command: "node",
+    args: ["--version"],
+    description: "Runs the QA scripts",
+  },
+  {
+    label: "npm",
+    command: "npm",
+    args: ["--version"],
+    description: "Runs repo package scripts",
+  },
+  {
+    label: "python3",
+    command: "python3",
+    args: ["--version"],
+    description: "Runs capture_reviewer_proof.py",
+  },
+  {
+    label: "ffmpeg",
+    command: "ffmpeg",
+    args: ["-version"],
+    description: "Generates reviewer GIF previews and poster frames",
+  },
+  {
+    label: "ffprobe",
+    command: "ffprobe",
+    args: ["-version"],
+    description: "Inspects proof video duration for preview selection",
+  },
+];
+
+const OPTIONAL_COMMANDS = [
+  {
+    label: "magick",
+    command: "magick",
+    args: ["-version"],
+    description: "Auto-generates comparison panels and focused crops",
+  },
+];
+
+const REQUIRED_FILES = [
+  "scripts/upload-qa-evidence.mjs",
+  "scripts/render-qa-comment.mjs",
+  ".agents/skills/_functional-qa/scripts/capture_reviewer_proof.py",
+  "apps/client/wrangler.toml",
+];
+
+function parseArgs(argv) {
+  const args = {
+    json: false,
+  };
+
+  for (const arg of argv) {
+    if (arg === "--json") {
+      args.json = true;
+    } else if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return args;
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/qa_evidence_preflight.mjs [options]
+
+Checks whether the current shell can publish reviewer-visible QA evidence.
+
+Options:
+  --json    Print the full result as JSON
+`);
+}
+
+function runCheck(command, args, cwd) {
+  return spawnSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    stdio: "pipe",
+  });
+}
+
+function firstLine(text) {
+  return (text || "").trim().split("\n")[0] || "";
+}
+
+function checkCommand(definition, cwd) {
+  const result = runCheck(definition.command, definition.args, cwd);
+  if (result.status !== 0) {
+    return {
+      kind: "command",
+      label: definition.label,
+      ok: false,
+      description: definition.description,
+      detail: firstLine(result.stderr || result.stdout) || "command failed",
+    };
+  }
+
+  return {
+    kind: "command",
+    label: definition.label,
+    ok: true,
+    description: definition.description,
+    detail: firstLine(result.stdout || result.stderr),
+  };
+}
+
+function checkWrangler(repoRoot) {
+  const result = runCheck("npm", ["--prefix", "apps/client", "exec", "wrangler", "--", "--version"], repoRoot);
+  if (result.status !== 0) {
+    return {
+      kind: "command",
+      label: "wrangler",
+      ok: false,
+      description: "Uploads evidence to the R2 reviewer-proof bucket",
+      detail: firstLine(result.stderr || result.stdout) || "wrangler command failed",
+    };
+  }
+
+  return {
+    kind: "command",
+    label: "wrangler",
+    ok: true,
+    description: "Uploads evidence to the R2 reviewer-proof bucket",
+    detail: firstLine(result.stdout || result.stderr),
+  };
+}
+
+function checkEnv(definition) {
+  const value = process.env[definition.name];
+  if (!value) {
+    return {
+      kind: "env",
+      label: definition.name,
+      ok: false,
+      description: definition.description,
+      detail: "missing",
+    };
+  }
+
+  if (definition.validate && !definition.validate(value)) {
+    return {
+      kind: "env",
+      label: definition.name,
+      ok: false,
+      description: definition.description,
+      detail: definition.invalidMessage || "invalid value",
+      value,
+    };
+  }
+
+  return {
+    kind: "env",
+    label: definition.name,
+    ok: true,
+    description: definition.description,
+    detail: value,
+  };
+}
+
+function checkFile(relativePath, repoRoot) {
+  const absolutePath = path.join(repoRoot, relativePath);
+  return {
+    kind: "file",
+    label: relativePath,
+    ok: fs.existsSync(absolutePath),
+    description: "Required repo entry point",
+    detail: relativeToRepo(repoRoot, absolutePath),
+  };
+}
+
+function buildResult(repoRoot) {
+  const required = [
+    ...REQUIRED_ENV_VARS.map((entry) => checkEnv(entry)),
+    ...REQUIRED_COMMANDS.map((entry) => checkCommand(entry, repoRoot)),
+    checkWrangler(repoRoot),
+    ...REQUIRED_FILES.map((entry) => checkFile(entry, repoRoot)),
+  ];
+
+  const warnings = OPTIONAL_COMMANDS.map((entry) => checkCommand(entry, repoRoot));
+
+  return {
+    repo_root: repoRoot,
+    ok: required.every((item) => item.ok),
+    required,
+    warnings,
+    next_steps: [
+      "npm run qa:upload-evidence -- --run-dir <RUN_DIR> --include-supporting",
+      "python3 .agents/skills/_functional-qa/scripts/capture_reviewer_proof.py --run-dir <RUN_DIR>",
+      "npm run qa:render-comment -- --run-dir <RUN_DIR>",
+    ],
+    notes: [
+      "`artifacts/qa-runs/...` is local staging only; reviewer-visible proof must publish to `tong-runs` or another reviewer-openable surface.",
+      "Missing `magick` does not block uploads, but the uploader will skip auto-generated comparison panels and focused crops.",
+    ],
+  };
+}
+
+function renderText(result) {
+  const lines = [];
+  lines.push("Reviewer-proof preflight");
+  lines.push("");
+
+  for (const item of result.required) {
+    const status = item.ok ? "PASS" : "FAIL";
+    lines.push(`- ${status} ${item.label}: ${item.detail}`);
+  }
+
+  for (const item of result.warnings) {
+    const status = item.ok ? "PASS" : "WARN";
+    lines.push(`- ${status} ${item.label}: ${item.detail}`);
+  }
+
+  lines.push("");
+  lines.push(result.ok ? "Ready for reviewer-visible evidence publication." : "Not ready for reviewer-visible evidence publication.");
+  lines.push("");
+  lines.push("Next:");
+  for (const step of result.next_steps) {
+    lines.push(`- ${step}`);
+  }
+  lines.push("");
+  lines.push("Notes:");
+  for (const note of result.notes) {
+    lines.push(`- ${note}`);
+  }
+
+  if (!result.ok) {
+    lines.push("");
+    lines.push("Missing env example:");
+    lines.push("- export TONG_RUNS_R2_BUCKET=tong-runs");
+    lines.push("- export TONG_RUNS_PUBLIC_BASE_URL=https://runs.tong.berlayar.ai");
+  }
+
+  return lines.join("\n");
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const repoRoot = resolveRepoRoot();
+  const result = buildResult(repoRoot);
+
+  if (args.json) {
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  } else {
+    process.stdout.write(`${renderText(result)}\n`);
+  }
+
+  process.exit(result.ok ? 0 : 1);
+}
+
+main();


### PR DESCRIPTION
## Summary
- add a strict manual QA checklist for the current merged baseline on `main`
- add a reviewer-proof publishing preflight script and package command
- document the preflight entry point in the cloud and evidence runbooks

## How to test
- `node --check scripts/qa_evidence_preflight.mjs`
- `npm run qa:preflight-reviewer-proof`

## Notes
- the preflight intentionally fails until `TONG_RUNS_R2_BUCKET` and `TONG_RUNS_PUBLIC_BASE_URL` are exported in the publishing shell
