### PR TITLE
fix: harden remote runtime asset delivery

### DIFF
--- a/.agents/skills/_functional-qa/templates/codex-cloud-task.md.tmpl
+++ b/.agents/skills/_functional-qa/templates/codex-cloud-task.md.tmpl
@@ -21,7 +21,9 @@ Requirements:
 - Reviewer-facing evidence requirement: {{reviewer_evidence_expectation}}
 - If the runtime cannot publish that evidence directly into GitHub after PR creation, return paste-ready markdown with the exact comparison images or links a human should add to the PR.
 - For UI or transition fixes, include reviewer-visible media links or attachments in the task output and PR body. A local artifact path under `artifacts/qa-runs/` is not sufficient by itself.
+- A Codex task-local "Recording preview" is not a reviewer-visible upload by itself. Use the repo uploader flow when public `tong-runs` links are required.
 - If you cannot make the media reviewer-visible from the cloud task, do not claim correctness; report that a final local/browser-backed recording is still required.
+- If the surface depends on runtime media, verify the public asset host before capture. When the current repo assets are missing from `assets.tong.berlayar.ai`, run `npm run runtime-assets:upload` before treating the remote UI as representative.
 - Do not rely on `gh` CLI or shell-level `git push`.
 - Do not cite gitignored artifacts as committed GitHub blobs unless those files were actually checked in.
 - {{completion_instruction}}

--- a/.agents/skills/capture-reviewer-proof/SKILL.md
+++ b/.agents/skills/capture-reviewer-proof/SKILL.md
@@ -16,35 +16,41 @@ Read:
 - `.agents/skills/_functional-qa/config/repo-adapter.json`
 - `docs/codex-cloud-issue-runbook.md`
 - `docs/qa-evidence-uploads.md`
+- `docs/deployment-track.md`
 
 ## Workflow
 
 1. Start from a validated or verified issue run.
-2. If a deterministic checkpoint or scenario seed exists, use it only to reach the near-proof state.
-3. Wait for the readable ready state before recording.
-4. Show the actual tap or click if it is part of the issue or fix.
-5. Linger long enough on the post-action state for a reviewer to verify the result.
-6. Export:
+2. Before recording remote `/game` proof, confirm the runtime asset surface is reviewer-real:
+   - `NEXT_PUBLIC_TONG_ASSETS_BASE_URL` is set for the shell that runs the client
+   - representative asset URLs for the target scene return `200`, not `404`
+   - if the runtime asset host is missing the referenced files, run `npm run runtime-assets:upload` before treating the remote capture as meaningful
+3. If a deterministic checkpoint or scenario seed exists, use it only to reach the near-proof state.
+4. Wait for the readable ready state before recording.
+5. Show the actual tap or click if it is part of the issue or fix.
+6. Linger long enough on the post-action state for a reviewer to verify the result.
+7. Export:
    - short clip
    - GIF preview
    - ordered stills for pre-action, ready, post-input, and stable post-action
-7. Record the proof metadata in `evidence.json` under `reviewer_proof`:
+8. Record the proof metadata in `evidence.json` under `reviewer_proof`:
    - `classification`: `reviewer-proof` or `trace-only`
    - real route and optional scenario seed
    - ordered still paths for `pre_action`, `ready_state`, `immediate_post_input`, `later_transition`, and `stable_post_action`
    - cue timestamps for the proof moment
    - checks for semantic coherence, visible input, readable hold, stable post-action, and reviewer-visible media
-8. Prefer the configured uploader flow in `docs/qa-evidence-uploads.md`.
+9. Prefer the configured uploader flow in `docs/qa-evidence-uploads.md`.
    The standard `publish-github` runtime now auto-attempts this upload path for runs with visual evidence, so only do it manually when you need to inspect or edit `uploaded-comment.md` first.
-9. After upload, build the reviewer-proof pack:
+   A task-local "Recording preview" inside Codex is not the reviewer-proof destination and does not count as uploaded evidence by itself.
+10. After upload, build the reviewer-proof pack:
 
    ```bash
    python .agents/skills/_functional-qa/scripts/capture_reviewer_proof.py --run-dir <RUN_DIR>
    ```
 
    This writes `reviewer-proof.json`, `reviewer-proof.md`, and augments `upload-manifest.json` so the rendered comment can include ordered-frame links and cue timestamps.
-10. If hosted upload is unavailable, fall back to reviewer-openable git-tracked files on a dedicated branch or PR. Do not leave the reviewer with local-only artifact paths.
-11. Update the PR body or issue comment with public links.
+11. If hosted upload is unavailable, fall back to reviewer-openable git-tracked files on a dedicated branch or PR. Do not leave the reviewer with local-only artifact paths.
+12. Update the PR body or issue comment with public links.
 
 ## Output requirements
 

--- a/.agents/skills/publish-issue-update/SKILL.md
+++ b/.agents/skills/publish-issue-update/SKILL.md
@@ -64,6 +64,7 @@ The local run directory is the staging source bundle. The reviewer-visible proof
    ```
 
    Use the generated `uploaded-comment.md` when you need clean public links, an inline GIF preview, or an MP4 proof link without committing binaries into git.
+   A task-local Codex recording preview does not replace this step and should not be treated as the published reviewer-proof surface.
 
    If the uploader is not configured for the current environment, fall back to reviewer-openable git-tracked files on a dedicated branch or PR and use those GitHub blob or raw links in the posted comment. Do not leave reviewer-facing updates pointing only at local artifact paths inside `artifacts/qa-runs`.
 

--- a/.agents/skills/validate-issue/SKILL.md
+++ b/.agents/skills/validate-issue/SKILL.md
@@ -19,6 +19,7 @@ Read these files before doing substantive work:
 - `.agents/skills/_functional-qa/config/repo-adapter.json`
 - `.agents/skills/_functional-qa/config/publish-policy.json`
 - `docs/agent-native-project-setup.md`
+- `docs/deployment-track.md` when the issue depends on runtime assets or remote environment behavior
 
 ## Target input
 
@@ -64,13 +65,18 @@ If the invocation includes `--verify-fix`, replay the most recent matching valid
 
 6. For UI issues, do not claim success without visual evidence. Use screenshots, ordered frames, or other temporal capture that matches the selected evidence strategy.
 
+   For remote `/game` or runtime-media issues, confirm the shipped reviewer surface before treating the capture as valid:
+   - the shell is using `NEXT_PUBLIC_TONG_ASSETS_BASE_URL`
+   - referenced runtime assets return `200` from the public host
+   - if the asset host is missing the current repo files, run `npm run runtime-assets:upload` or report that the remote environment is not ready yet
+
    When the fix changes a reviewer-visible UI surface such as layout, typography, subtitles, translation copy, tooltip content, or focus styling, capture the same state before and after the fix and prepare:
    - one full-frame side-by-side comparison
    - one tighter comparison crop when the changed region is small or text-dense
 
    If the runtime can expose the proof moment directly, record cue timestamps in logs or structured state, for example `token_tapped_at_ms`, `tooltip_opened_at_ms`, `dictionary_card_visible_at_ms`, or `mission_complete_at_ms`. Use those cues when cutting reviewer-facing GIF previews or poster frames.
 
-   For timing-sensitive or transition bugs, reviewer-visible media is required for a "fixed" claim. A gitignored local artifact path is not enough by itself: attach or link the recording or ordered frames in the PR body, task result, or issue comment. If the runtime cannot make that media visible to reviewers, mark the fix verification incomplete and call out the blocker.
+   For timing-sensitive or transition bugs, reviewer-visible media is required for a "fixed" claim. A gitignored local artifact path is not enough by itself, and a Codex task-local "Recording preview" is not enough by itself either: attach or link the recording or ordered frames in the PR body, task result, or issue comment. If the runtime cannot make that media visible to reviewers, mark the fix verification incomplete and call out the blocker.
 
    For reviewer-facing interaction or transition clips, do not race the input. Wait on the readable pre-action state, show the actual tap or click, and hold on the first stable post-action frame. If the clip skips or truncates any of those phases, do not treat it as final acceptance proof.
 

--- a/.agents/skills/work-github-issues/SKILL.md
+++ b/.agents/skills/work-github-issues/SKILL.md
@@ -114,3 +114,4 @@ python .agents/skills/_functional-qa/scripts/codex_cloud_queue.py
 - Do not skip fix verification before publishing a "fixed" update.
 - Do not upgrade a validation-only or design-review issue into a fix run unless a human explicitly changes the direction.
 - Flag issues that are not remote-portable before sending them to Codex cloud or unattended workers.
+- For remote `/game` or runtime-media issues, treat public runtime asset availability as part of portability. If `assets.tong.berlayar.ai` is missing the referenced files, either publish the current runtime assets first or mark the remote run blocked.

--- a/apps/client/README.md
+++ b/apps/client/README.md
@@ -23,6 +23,16 @@ NEXT_PUBLIC_TONG_API_BASE=https://tong-api.<subdomain>.workers.dev
 NEXT_PUBLIC_TONG_ASSETS_BASE_URL=https://assets.tong.berlayar.ai
 ```
 
+If the remote app is missing map or character media, publish the runtime assets:
+
+```bash
+npm run runtime-assets:upload
+```
+
+At request time the app now hydrates its runtime asset manifest from
+`NEXT_PUBLIC_TONG_ASSETS_BASE_URL` plus `TONG_RUNTIME_ASSET_MANIFEST_KEY`, with the
+checked-in manifest only as a fallback.
+
 ## Cloudflare Workers Deploy (OpenNext)
 
 This app is configured for OpenNext on Cloudflare Workers:
@@ -34,6 +44,8 @@ From repo root:
 ```bash
 npm run deploy:client:cf
 ```
+
+That deploy path now publishes the current runtime asset set to `tong-assets` before shipping the worker build, so the app and the external asset host stay in sync.
 
 Or run direct commands:
 

--- a/apps/client/app/layout.tsx
+++ b/apps/client/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import { loadHydratedRuntimeAssetManifest } from '@/lib/runtime-assets.server';
 import './globals.css';
 
 export const metadata: Metadata = {
@@ -7,10 +8,20 @@ export const metadata: Metadata = {
     'An open-source game that drops you into the streets of Seoul, Shanghai and Tokyo — where every conversation teaches you something new.',
 };
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  const runtimeAssetManifest = await loadHydratedRuntimeAssetManifest();
+  const serializedRuntimeAssetManifest = JSON.stringify(runtimeAssetManifest).replace(/</g, '\\u003c');
+
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `window.__TONG_RUNTIME_ASSET_MANIFEST__=${serializedRuntimeAssetManifest};`,
+          }}
+        />
+        {children}
+      </body>
     </html>
   );
 }

--- a/apps/client/components/city-map/CityMap.tsx
+++ b/apps/client/components/city-map/CityMap.tsx
@@ -8,7 +8,7 @@ import { LocationPin } from './LocationPin';
 import { LocationSheet } from './LocationSheet';
 import { KoreanText } from '@/components/shared/KoreanText';
 import { getLanguageForCity } from '@/lib/content/locations';
-import { runtimeAssetUrl } from '@/lib/runtime-assets';
+import { fallbackRuntimeAssetCandidates, runtimeAssetUrl } from '@/lib/runtime-assets';
 
 /* ── Constants ──────────────────────────────────────────────── */
 
@@ -98,6 +98,8 @@ export function CityMap({
 }: CityMapProps) {
   const touchStartRef = useRef<{ x: number; y: number } | null>(null);
   const [dragOffset, setDragOffset] = useState(0);
+  const [videoCandidateIndex, setVideoCandidateIndex] = useState(0);
+  const [posterCandidateIndex, setPosterCandidateIndex] = useState(0);
 
   /* Two video refs for dissolve looping */
   const videoARef = useRef<HTMLVideoElement>(null);
@@ -109,6 +111,11 @@ export function CityMap({
   const locations = CITY_LOCATIONS[city] ?? [];
   const targetLang = getLanguageForCity(city);
   const explainLang = gameState.explainIn[city] ?? 'en';
+  const cityMedia = CITY_MEDIA[city];
+  const videoCandidates = fallbackRuntimeAssetCandidates(cityMedia.video);
+  const posterCandidates = fallbackRuntimeAssetCandidates(cityMedia.poster);
+  const videoSrc = videoCandidates[videoCandidateIndex] ?? '';
+  const posterSrc = posterCandidates[posterCandidateIndex] ?? cityMedia.poster;
 
   /* ── Two-video dissolve loop ─────────────────────────────── */
 
@@ -170,7 +177,7 @@ export function CityMap({
       vA.pause();
       vB.pause();
     };
-  }, [city, meta.hasVideo]);
+  }, [city, meta.hasVideo, videoSrc, posterSrc]);
 
   /* ── Swipe handling ─────────────────────────────────────── */
 
@@ -234,8 +241,11 @@ export function CityMap({
   /* ── Background ─────────────────────────────────────────── */
 
   const bgStyle = { transform: `translateX(${dragOffset}px)` };
-  const cityMedia = CITY_MEDIA[city];
-  const videoSrc = cityMedia.video;
+
+  useEffect(() => {
+    setVideoCandidateIndex(0);
+    setPosterCandidateIndex(0);
+  }, [city]);
 
   return (
     <div
@@ -245,7 +255,7 @@ export function CityMap({
       onTouchEnd={handleTouchEnd}
     >
       {/* Video backgrounds (two for dissolve) / static image */}
-      {meta.hasVideo ? (
+      {meta.hasVideo && videoSrc ? (
         <>
           <video
             ref={videoARef}
@@ -255,7 +265,15 @@ export function CityMap({
             muted
             playsInline
             preload="auto"
-            poster={cityMedia.poster}
+            poster={posterSrc}
+            onError={() => {
+              if (posterCandidateIndex + 1 < posterCandidates.length) {
+                setPosterCandidateIndex(posterCandidateIndex + 1);
+              }
+              if (videoCandidateIndex + 1 < videoCandidates.length) {
+                setVideoCandidateIndex(videoCandidateIndex + 1);
+              }
+            }}
           >
             <source src={videoSrc} type="video/mp4" />
           </video>
@@ -267,6 +285,15 @@ export function CityMap({
             muted
             playsInline
             preload="auto"
+            poster={posterSrc}
+            onError={() => {
+              if (posterCandidateIndex + 1 < posterCandidates.length) {
+                setPosterCandidateIndex(posterCandidateIndex + 1);
+              }
+              if (videoCandidateIndex + 1 < videoCandidates.length) {
+                setVideoCandidateIndex(videoCandidateIndex + 1);
+              }
+            }}
           >
             <source src={videoSrc} type="video/mp4" />
           </video>
@@ -276,8 +303,13 @@ export function CityMap({
           key={city}
           className={`city-map__bg${comingSoon ? ' city-map__bg--greyscale' : ''}`}
           style={bgStyle}
-          src={cityMedia.poster}
+          src={posterSrc}
           alt={meta.en}
+          onError={() => {
+            if (posterCandidateIndex + 1 < posterCandidates.length) {
+              setPosterCandidateIndex(posterCandidateIndex + 1);
+            }
+          }}
         />
       )}
 

--- a/apps/client/components/scene/Background.tsx
+++ b/apps/client/components/scene/Background.tsx
@@ -1,5 +1,8 @@
 'use client';
 
+import { useEffect, useMemo, useState } from 'react';
+import { fallbackRuntimeAssetCandidates } from '@/lib/runtime-assets';
+
 interface BackgroundProps {
   imageUrl: string;
   ambientDescription?: string;
@@ -7,12 +10,21 @@ interface BackgroundProps {
 }
 
 export function Background({ imageUrl, ambientDescription, fade = false }: BackgroundProps) {
+  const candidates = useMemo(() => fallbackRuntimeAssetCandidates(imageUrl), [imageUrl]);
+  const [candidateIndex, setCandidateIndex] = useState(0);
+
+  useEffect(() => {
+    setCandidateIndex(0);
+  }, [imageUrl]);
+
+  const activeImageUrl = candidates[candidateIndex] ?? '';
+
   return (
     <div className="absolute inset-0 overflow-hidden">
-      {imageUrl ? (
+      {activeImageUrl ? (
         // eslint-disable-next-line @next/next/no-img-element
         <img
-          src={imageUrl}
+          src={activeImageUrl}
           alt=""
           className="absolute inset-0 h-full w-full object-cover"
           style={{
@@ -20,7 +32,13 @@ export function Background({ imageUrl, ambientDescription, fade = false }: Backg
             transition: fade ? 'opacity 0.5s ease-in-out' : undefined,
             animation: fade ? 'backdrop-fade-in 0.5s ease-in-out' : undefined,
           }}
-          onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
+          onError={(e) => {
+            if (candidateIndex + 1 < candidates.length) {
+              setCandidateIndex(candidateIndex + 1);
+              return;
+            }
+            (e.target as HTMLImageElement).style.display = 'none';
+          }}
         />
       ) : ambientDescription ? (
         <div className="absolute inset-0 flex items-center justify-center bg-[var(--color-bg-dark)] p-8">

--- a/apps/client/components/scene/CharacterSprite.tsx
+++ b/apps/client/components/scene/CharacterSprite.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { cn } from '@/lib/utils/cn';
+import { fallbackRuntimeAssetCandidates } from '@/lib/runtime-assets';
 
 interface CharacterSpriteProps {
   spriteUrl: string;
@@ -22,8 +23,20 @@ export function CharacterSprite({
 }: CharacterSpriteProps) {
   const [mounted, setMounted] = useState(false);
   const [videoReady, setVideoReady] = useState(false);
+  const [videoCandidateIndex, setVideoCandidateIndex] = useState(0);
+  const [spriteCandidateIndex, setSpriteCandidateIndex] = useState(0);
   const videoRef = useRef<HTMLVideoElement>(null);
+  const idleVideoCandidates = useMemo(() => fallbackRuntimeAssetCandidates(idleVideoUrl), [idleVideoUrl]);
+  const spriteCandidates = useMemo(() => fallbackRuntimeAssetCandidates(spriteUrl), [spriteUrl]);
+
   useEffect(() => { setMounted(true); }, []);
+  useEffect(() => {
+    setVideoReady(false);
+    setVideoCandidateIndex(0);
+  }, [idleVideoUrl]);
+  useEffect(() => {
+    setSpriteCandidateIndex(0);
+  }, [spriteUrl]);
 
   const handleCanPlay = useCallback(() => { setVideoReady(true); }, []);
 
@@ -47,9 +60,14 @@ export function CharacterSprite({
     };
   }, [idleVideoUrl]);
 
-  if (!mounted || (!spriteUrl && !idleVideoUrl)) return null;
+  const activeIdleVideoUrl = idleVideoCandidates[videoCandidateIndex] ?? '';
+  const activeSpriteUrl = spriteCandidates[spriteCandidateIndex] ?? '';
+  const videoAvailable = Boolean(activeIdleVideoUrl);
+  const spriteAvailable = Boolean(activeSpriteUrl);
 
-  const showVideo = idleVideoUrl && videoReady;
+  if (!mounted || (!spriteAvailable && !videoAvailable)) return null;
+
+  const showVideo = videoAvailable && videoReady;
 
   return (
     <div
@@ -61,27 +79,40 @@ export function CharacterSprite({
         position === 'right' && 'slide-in-right',
       )}
     >
-      {idleVideoUrl ? (
+      {videoAvailable ? (
         <video
           ref={videoRef}
-          src={idleVideoUrl}
+          src={activeIdleVideoUrl}
           preload="auto"
           autoPlay
           loop
           muted
           playsInline
           onCanPlayThrough={handleCanPlay}
+          onError={() => {
+            setVideoReady(false);
+            if (videoCandidateIndex + 1 < idleVideoCandidates.length) {
+              setVideoCandidateIndex(videoCandidateIndex + 1);
+            } else {
+              setVideoCandidateIndex(idleVideoCandidates.length);
+            }
+          }}
           className="h-full w-full object-cover object-top"
         />
       ) : (
         /* eslint-disable-next-line @next/next/no-img-element */
         <img
-          src={spriteUrl}
+          src={activeSpriteUrl}
           alt={name}
           className="h-full w-full object-cover object-top"
           style={{
             maskImage: 'linear-gradient(to bottom, transparent 0%, black 8px, black calc(100% - 10px), transparent 100%)',
             WebkitMaskImage: 'linear-gradient(to bottom, transparent 0%, black 8px, black calc(100% - 10px), transparent 100%)',
+          }}
+          onError={() => {
+            if (spriteCandidateIndex + 1 < spriteCandidates.length) {
+              setSpriteCandidateIndex(spriteCandidateIndex + 1);
+            }
           }}
         />
       )}

--- a/apps/client/components/scene/CinematicOverlay.tsx
+++ b/apps/client/components/scene/CinematicOverlay.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useRef, useCallback, useState, useEffect } from 'react';
+import { useRef, useCallback, useState, useEffect, useMemo } from 'react';
 import { useUILang } from '@/lib/i18n/UILangContext';
 import { t } from '@/lib/i18n/ui-strings';
 import { KoreanText, type TargetLang } from '@/components/shared/KoreanText';
+import { fallbackRuntimeAssetCandidates } from '@/lib/runtime-assets';
 
 const CAPTION_CHARS_PER_TICK = 2;
 const CAPTION_TICK_MS = 35;
@@ -23,6 +24,9 @@ export function CinematicOverlay({ videoUrl, caption, captionTranslation, autoAd
   const videoRef = useRef<HTMLVideoElement>(null);
   const [fadingOut, setFadingOut] = useState(false);
   const [captionVisible, setCaptionVisible] = useState(false);
+  const [candidateIndex, setCandidateIndex] = useState(0);
+  const videoCandidates = useMemo(() => fallbackRuntimeAssetCandidates(videoUrl), [videoUrl]);
+  const activeVideoUrl = videoCandidates[candidateIndex] ?? '';
 
   // Typewriter state for caption
   const [captionChars, setCaptionChars] = useState(0);
@@ -42,6 +46,10 @@ export function CinematicOverlay({ videoUrl, caption, captionTranslation, autoAd
   const handleTap = useCallback(() => {
     if (!autoAdvance) triggerEnd();
   }, [autoAdvance, triggerEnd]);
+
+  useEffect(() => {
+    setCandidateIndex(0);
+  }, [videoUrl]);
 
   // Autoplay with unmute fallback + audio fade-in
   useEffect(() => {
@@ -67,7 +75,7 @@ export function CinematicOverlay({ videoUrl, caption, captionTranslation, autoAd
       }, 40);
       return () => clearInterval(fadeIn);
     }
-  }, [videoUrl, muted]);
+  }, [activeVideoUrl, muted]);
 
   // Fade out audio before video ends
   useEffect(() => {
@@ -81,7 +89,7 @@ export function CinematicOverlay({ videoUrl, caption, captionTranslation, autoAd
     };
     v.addEventListener('timeupdate', handleTimeUpdate);
     return () => v.removeEventListener('timeupdate', handleTimeUpdate);
-  }, [videoUrl, muted]);
+  }, [activeVideoUrl, muted]);
 
   // Fade in caption shortly after video starts playing, then start typewriter
   useEffect(() => {
@@ -112,7 +120,7 @@ export function CinematicOverlay({ videoUrl, caption, captionTranslation, autoAd
       clearTimeout(fadeTimer);
       if (captionTimerRef.current) clearInterval(captionTimerRef.current);
     };
-  }, [videoUrl, caption]);
+  }, [activeVideoUrl, caption]);
 
   return (
     <div
@@ -131,10 +139,17 @@ export function CinematicOverlay({ videoUrl, caption, captionTranslation, autoAd
     >
       <video
         ref={videoRef}
-        src={videoUrl}
+        src={activeVideoUrl}
         playsInline
         muted={muted}
         onEnded={handleEnded}
+        onError={() => {
+          if (candidateIndex + 1 < videoCandidates.length) {
+            setCandidateIndex(candidateIndex + 1);
+          } else {
+            triggerEnd();
+          }
+        }}
         className="cinematic-video"
         disablePictureInPicture
         disableRemotePlayback

--- a/apps/client/lib/runtime-assets-contract.ts
+++ b/apps/client/lib/runtime-assets-contract.ts
@@ -1,0 +1,67 @@
+export interface RuntimeAssetManifestEntry {
+  key: string;
+  uri: string;
+  type: string;
+  usage: string;
+  source: string;
+  status: string;
+}
+
+export interface RuntimeAssetManifest {
+  manifestVersion: string;
+  owner: string;
+  keyFormat: string;
+  sourceManifest: string;
+  notes: string;
+  assets: RuntimeAssetManifestEntry[];
+}
+
+export const DEFAULT_RUNTIME_ASSET_MANIFEST_KEY = 'runtime-assets/manifest.json';
+
+export function normalizeAssetBaseUrl(baseUrl?: string | null): string | null {
+  if (!baseUrl) return null;
+
+  const trimmed = baseUrl.trim();
+  if (!trimmed) return null;
+
+  return trimmed.replace(/\/+$/, '');
+}
+
+export function buildRuntimeAssetManifestUrl(baseUrl?: string | null, manifestKey?: string | null): string | null {
+  const normalizedBaseUrl = normalizeAssetBaseUrl(baseUrl);
+  if (!normalizedBaseUrl) return null;
+
+  const trimmedKey = manifestKey?.trim().replace(/^\/+/, '') || DEFAULT_RUNTIME_ASSET_MANIFEST_KEY;
+  if (!trimmedKey) return null;
+
+  return `${normalizedBaseUrl}/${trimmedKey}`;
+}
+
+function isRuntimeAssetManifestEntry(value: unknown): value is RuntimeAssetManifestEntry {
+  if (!value || typeof value !== 'object') return false;
+
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.key === 'string' &&
+    typeof candidate.uri === 'string' &&
+    typeof candidate.type === 'string' &&
+    typeof candidate.usage === 'string' &&
+    typeof candidate.source === 'string' &&
+    typeof candidate.status === 'string'
+  );
+}
+
+export function isRuntimeAssetManifest(value: unknown): value is RuntimeAssetManifest {
+  if (!value || typeof value !== 'object') return false;
+
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.manifestVersion === 'string' &&
+    typeof candidate.owner === 'string' &&
+    typeof candidate.keyFormat === 'string' &&
+    typeof candidate.sourceManifest === 'string' &&
+    typeof candidate.notes === 'string' &&
+    Array.isArray(candidate.assets) &&
+    candidate.assets.every(isRuntimeAssetManifestEntry)
+  );
+}

--- a/apps/client/lib/runtime-assets.server.ts
+++ b/apps/client/lib/runtime-assets.server.ts
@@ -1,0 +1,46 @@
+import 'server-only';
+
+import runtimeAssetManifestJson from '../../../assets/manifest/runtime-asset-manifest.json';
+import {
+  buildRuntimeAssetManifestUrl,
+  isRuntimeAssetManifest,
+  DEFAULT_RUNTIME_ASSET_MANIFEST_KEY,
+  type RuntimeAssetManifest,
+} from '@/lib/runtime-assets-contract';
+
+const fallbackRuntimeAssetManifest = runtimeAssetManifestJson as RuntimeAssetManifest;
+
+export function getRuntimeAssetManifestPublicUrl(): string | null {
+  return buildRuntimeAssetManifestUrl(
+    process.env.NEXT_PUBLIC_TONG_ASSETS_BASE_URL,
+    process.env.TONG_RUNTIME_ASSET_MANIFEST_KEY || DEFAULT_RUNTIME_ASSET_MANIFEST_KEY,
+  );
+}
+
+export async function loadHydratedRuntimeAssetManifest(): Promise<RuntimeAssetManifest> {
+  const manifestUrl = getRuntimeAssetManifestPublicUrl();
+  if (!manifestUrl) return fallbackRuntimeAssetManifest;
+
+  try {
+    const response = await fetch(manifestUrl, {
+      cache: 'no-store',
+      headers: {
+        Accept: 'application/json',
+        'User-Agent': 'tong-client-runtime-assets/1.0',
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Manifest fetch failed with ${response.status}`);
+    }
+
+    const manifest = await response.json();
+    if (isRuntimeAssetManifest(manifest)) {
+      return manifest;
+    }
+  } catch (error) {
+    console.warn('[runtime-assets] Falling back to bundled manifest.', error);
+  }
+
+  return fallbackRuntimeAssetManifest;
+}

--- a/apps/client/lib/runtime-assets.ts
+++ b/apps/client/lib/runtime-assets.ts
@@ -1,53 +1,97 @@
 import runtimeAssetManifestJson from '../../../assets/manifest/runtime-asset-manifest.json';
+import {
+  isRuntimeAssetManifest,
+  normalizeAssetBaseUrl,
+  type RuntimeAssetManifest,
+  type RuntimeAssetManifestEntry,
+} from '@/lib/runtime-assets-contract';
 
-interface RuntimeAssetManifestEntry {
-  key: string;
-  uri: string;
-  type: string;
-  usage: string;
-  source: string;
-  status: string;
+declare global {
+  var __TONG_RUNTIME_ASSET_MANIFEST__: RuntimeAssetManifest | undefined;
 }
 
-interface RuntimeAssetManifest {
-  manifestVersion: string;
-  owner: string;
-  keyFormat: string;
-  sourceManifest: string;
-  notes: string;
-  assets: RuntimeAssetManifestEntry[];
-}
-
-const runtimeAssetManifest = runtimeAssetManifestJson as RuntimeAssetManifest;
-const runtimeAssetsByKey = new Map(runtimeAssetManifest.assets.map((asset) => [asset.key, asset] as const));
+const fallbackRuntimeAssetManifest = runtimeAssetManifestJson as RuntimeAssetManifest;
 const runtimeAssetBaseUrl = normalizeAssetBaseUrl(process.env.NEXT_PUBLIC_TONG_ASSETS_BASE_URL);
 
-function normalizeAssetBaseUrl(baseUrl?: string): string | null {
-  if (!baseUrl) return null;
+let activeRuntimeAssetManifest = fallbackRuntimeAssetManifest;
+let activeRuntimeAssetsByKey = buildRuntimeAssetsByKey(fallbackRuntimeAssetManifest);
 
-  const trimmed = baseUrl.trim();
-  if (!trimmed) return null;
+function buildRuntimeAssetsByKey(manifest: RuntimeAssetManifest): Map<string, RuntimeAssetManifestEntry> {
+  return new Map(manifest.assets.map((asset) => [asset.key, asset] as const));
+}
 
-  return trimmed.replace(/\/+$/, '');
+function readHydratedRuntimeAssetManifest(): RuntimeAssetManifest | null {
+  if (typeof globalThis === 'undefined') return null;
+
+  const candidate = globalThis.__TONG_RUNTIME_ASSET_MANIFEST__;
+  return isRuntimeAssetManifest(candidate) ? candidate : null;
+}
+
+function ensureRuntimeAssetManifest(): RuntimeAssetManifest {
+  const hydratedManifest = readHydratedRuntimeAssetManifest();
+
+  if (hydratedManifest && hydratedManifest !== activeRuntimeAssetManifest) {
+    activeRuntimeAssetManifest = hydratedManifest;
+    activeRuntimeAssetsByKey = buildRuntimeAssetsByKey(hydratedManifest);
+  }
+
+  return activeRuntimeAssetManifest;
+}
+
+function runtimeAssetsByKey(): ReadonlyMap<string, RuntimeAssetManifestEntry> {
+  ensureRuntimeAssetManifest();
+  return activeRuntimeAssetsByKey;
 }
 
 function isAbsoluteUrl(value: string): boolean {
   return /^[a-z][a-z0-9+.-]*:\/\//i.test(value);
 }
 
+function normalizeAssetPathname(pathname: string): string {
+  if (!pathname) return '';
+  if (pathname.startsWith('/assets/')) return pathname;
+  if (pathname.startsWith('assets/')) return `/${pathname}`;
+  return pathname;
+}
+
 function joinAssetBase(pathname: string): string {
   if (!runtimeAssetBaseUrl) return pathname;
 
-  const normalizedPath = pathname.startsWith('/') ? pathname : `/${pathname}`;
+  const normalizedPath = normalizeAssetPathname(pathname);
   return `${runtimeAssetBaseUrl}${normalizedPath}`;
 }
 
+function assetPathFromResolvedUrl(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  if (trimmed.startsWith('/assets/') || trimmed.startsWith('assets/')) {
+    return normalizeAssetPathname(trimmed);
+  }
+
+  try {
+    const parsed = new URL(trimmed);
+    if (!parsed.pathname.startsWith('/assets/')) {
+      return null;
+    }
+    if (runtimeAssetBaseUrl) {
+      const normalizedBase = new URL(`${runtimeAssetBaseUrl}/`);
+      if (parsed.origin !== normalizedBase.origin) {
+        return null;
+      }
+    }
+    return parsed.pathname;
+  } catch {
+    return null;
+  }
+}
+
 export function hasRuntimeAssetKey(key: string): boolean {
-  return runtimeAssetsByKey.has(key);
+  return runtimeAssetsByKey().has(key);
 }
 
 export function getRuntimeAssetEntry(key: string): RuntimeAssetManifestEntry | null {
-  return runtimeAssetsByKey.get(key) ?? null;
+  return runtimeAssetsByKey().get(key) ?? null;
 }
 
 export function resolveRuntimeAssetUrl(ref?: string | null): string {
@@ -56,7 +100,7 @@ export function resolveRuntimeAssetUrl(ref?: string | null): string {
   const trimmed = ref.trim();
   if (!trimmed) return '';
 
-  const manifestEntry = runtimeAssetsByKey.get(trimmed);
+  const manifestEntry = runtimeAssetsByKey().get(trimmed);
   if (manifestEntry) {
     return resolveRuntimeAssetUrl(manifestEntry.uri);
   }
@@ -76,6 +120,42 @@ export function resolveRuntimeAssetUrl(ref?: string | null): string {
   return trimmed;
 }
 
+export function runtimeAssetLocalUrl(ref?: string | null): string {
+  if (!ref) return '';
+
+  const trimmed = ref.trim();
+  if (!trimmed) return '';
+
+  const manifestEntry = runtimeAssetsByKey().get(trimmed);
+  if (manifestEntry) {
+    return runtimeAssetLocalUrl(manifestEntry.uri);
+  }
+
+  const assetPath = assetPathFromResolvedUrl(trimmed);
+  return assetPath ?? trimmed;
+}
+
+export function runtimeAssetCandidateUrls(ref?: string | null): string[] {
+  if (!ref) return [];
+
+  const resolved = resolveRuntimeAssetUrl(ref);
+  const local = runtimeAssetLocalUrl(ref);
+
+  return [...new Set([resolved, local].filter(Boolean))];
+}
+
+export function fallbackRuntimeAssetUrl(resolvedUrl?: string | null): string {
+  if (!resolvedUrl) return '';
+  const assetPath = assetPathFromResolvedUrl(resolvedUrl);
+  return assetPath ?? '';
+}
+
+export function fallbackRuntimeAssetCandidates(resolvedUrl?: string | null): string[] {
+  if (!resolvedUrl) return [];
+  const fallback = fallbackRuntimeAssetUrl(resolvedUrl);
+  return [...new Set([resolvedUrl, fallback].filter(Boolean))];
+}
+
 export function resolveRuntimeAssetUrls(refs: Array<string | null | undefined>): string[] {
   const urls = refs
     .map((ref) => resolveRuntimeAssetUrl(ref))
@@ -90,7 +170,7 @@ export function resolveCharacterAssetUrl(pathSegment?: string | null): string {
 }
 
 export function runtimeAssetUrl(key: string, fallbackRef?: string): string {
-  const manifestEntry = runtimeAssetsByKey.get(key);
+  const manifestEntry = runtimeAssetsByKey().get(key);
   if (manifestEntry) {
     return resolveRuntimeAssetUrl(manifestEntry.uri);
   }
@@ -103,5 +183,5 @@ export function runtimeAssetUrl(key: string, fallbackRef?: string): string {
 }
 
 export function getRuntimeAssetManifest(): RuntimeAssetManifest {
-  return runtimeAssetManifest;
+  return ensureRuntimeAssetManifest();
 }

--- a/docs/cloudflare-worker-setup.md
+++ b/docs/cloudflare-worker-setup.md
@@ -60,6 +60,20 @@ NEXT_PUBLIC_TONG_ASSETS_BASE_URL=https://assets.tong.berlayar.ai
 
 Restart `npm run dev:client` after changing env.
 
+## 4b) Publish runtime assets to `tong-assets`
+
+If the remote shell shows missing city maps, character art, or cinematics, the asset host is usually missing the current files. Publish them from repo state:
+
+```bash
+npm run runtime-assets:upload
+```
+
+This uploads `apps/client/public/assets/**` plus the runtime manifests and verifies the public `assets.tong.berlayar.ai` URLs before returning success.
+
+The client also hydrates its runtime asset manifest from the public asset host at
+request time, so `NEXT_PUBLIC_TONG_ASSETS_BASE_URL` and `TONG_RUNTIME_ASSET_MANIFEST_KEY`
+must point at the published manifest path.
+
 ## 5) Quick endpoint checks
 ```bash
 curl "http://localhost:8787/health"

--- a/docs/deployment-track.md
+++ b/docs/deployment-track.md
@@ -43,10 +43,26 @@ Set these on Cloudflare Workers (and local `.dev.vars` equivalents when needed):
 2. `TONG_ASSETS_R2_BUCKET`
 3. `TONG_RUNTIME_ASSET_MANIFEST_KEY`
 
+The app now hydrates the runtime asset manifest from the public URL formed by
+`NEXT_PUBLIC_TONG_ASSETS_BASE_URL` + `TONG_RUNTIME_ASSET_MANIFEST_KEY`, then falls
+back to the bundled manifest only if that fetch fails.
+
 Checked-in examples for this contract live in:
 
 1. `.env.example`
 2. `apps/client/.env.example`
+
+### Publish runtime assets
+
+After adding or changing runtime media under `apps/client/public/assets/**` or either asset manifest:
+
+```bash
+npm run runtime-assets:upload
+```
+
+This uploads the runtime asset files to `tong-assets`, publishes the runtime manifests, and verifies the public `assets.tong.berlayar.ai` URLs with real `GET` requests before returning success.
+
+`npm run deploy:client:cf` now runs this publish step before the Cloudflare worker deploy so the client build does not point at a stale asset host.
 
 ### Boundary rule
 

--- a/docs/qa-evidence-uploads.md
+++ b/docs/qa-evidence-uploads.md
@@ -87,6 +87,14 @@ qa-runs/<suite>/<target-slug>/<run-id>/...
 ```
 
 5. Writes a local upload manifest in the run directory and uploads `manifest.json` beside the evidence files.
+6. Verifies the reviewer-facing URLs with real `GET` requests before returning success.
+
+Public verification notes:
+
+- The uploader checks the uploaded `manifest.json` plus the available primary review assets.
+- This is a reviewer-surface check, not just a bucket-write check.
+- The probe uses `GET`, not `HEAD`, because some edges reject `HEAD` while serving normal reviewer traffic correctly.
+- Use `--skip-public-verification` only when intentionally publishing to a not-yet-public surface or when isolating uploader failures.
 
 Comparison generation uses the previous validation run linked in `run.json.previous_run_id`. That means the normal path is:
 

--- a/docs/qa/remote-reviewer-proof-setup.md
+++ b/docs/qa/remote-reviewer-proof-setup.md
@@ -60,6 +60,8 @@ python3 .agents/skills/_functional-qa/scripts/capture_reviewer_proof.py --run-di
 npm run qa:render-comment -- --run-dir <RUN_DIR>
 ```
 
+The upload step now performs reviewer-surface verification with real `GET` requests before it returns success. That means a passing upload has already confirmed the public `tong-runs` URLs are readable, not just that the bucket write completed.
+
 Expected outputs:
 - `upload-manifest.json`
 - `reviewer-proof.json`

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "qa:preflight-reviewer-proof": "node scripts/qa_evidence_preflight.mjs",
     "qa:upload-evidence": "node scripts/upload-qa-evidence.mjs",
     "qa:render-comment": "node scripts/render-qa-comment.mjs",
+    "runtime-assets:upload": "node scripts/upload-runtime-assets.mjs",
     "secrets:sync:cf": "./scripts/sync-cf-secrets-from-env.sh",
     "build:client:cf": "npm --prefix apps/client run cf:build",
     "deploy:client:cf": "./scripts/deploy-client-cloudflare.sh",

--- a/scripts/deploy-client-cloudflare.sh
+++ b/scripts/deploy-client-cloudflare.sh
@@ -46,25 +46,45 @@ DEMO_PASSWORD_HINT="${NEXT_PUBLIC_TONG_DEMO_PASSWORD_HINT:-}"
 if [[ -z "$DEMO_PASSWORD_HINT" ]]; then DEMO_PASSWORD_HINT="$(read_env_value NEXT_PUBLIC_TONG_DEMO_PASSWORD_HINT)"; fi
 if [[ -z "$DEMO_PASSWORD_HINT" ]]; then DEMO_PASSWORD_HINT="Ask demo host for access password."; fi
 
-echo "[1/4] Installing client dependencies..."
+ASSETS_BASE_URL="${NEXT_PUBLIC_TONG_ASSETS_BASE_URL:-}"
+if [[ -z "$ASSETS_BASE_URL" ]]; then ASSETS_BASE_URL="$(read_env_value NEXT_PUBLIC_TONG_ASSETS_BASE_URL)"; fi
+if [[ -z "$ASSETS_BASE_URL" ]]; then ASSETS_BASE_URL="https://assets.tong.berlayar.ai"; fi
+
+ASSETS_BUCKET="${TONG_ASSETS_R2_BUCKET:-}"
+if [[ -z "$ASSETS_BUCKET" ]]; then ASSETS_BUCKET="$(read_env_value TONG_ASSETS_R2_BUCKET)"; fi
+if [[ -z "$ASSETS_BUCKET" ]]; then ASSETS_BUCKET="tong-assets"; fi
+
+RUNTIME_ASSET_MANIFEST_KEY="${TONG_RUNTIME_ASSET_MANIFEST_KEY:-}"
+if [[ -z "$RUNTIME_ASSET_MANIFEST_KEY" ]]; then RUNTIME_ASSET_MANIFEST_KEY="$(read_env_value TONG_RUNTIME_ASSET_MANIFEST_KEY)"; fi
+if [[ -z "$RUNTIME_ASSET_MANIFEST_KEY" ]]; then RUNTIME_ASSET_MANIFEST_KEY="runtime-assets/manifest.json"; fi
+
+echo "[1/5] Installing client dependencies..."
 npm --prefix "$ROOT_DIR/apps/client" install
 
-echo "[2/4] Building + deploying Next.js app to Cloudflare Workers (OpenNext)..."
+echo "[2/5] Publishing runtime assets to R2..."
+NEXT_PUBLIC_TONG_ASSETS_BASE_URL="$ASSETS_BASE_URL" \
+TONG_ASSETS_R2_BUCKET="$ASSETS_BUCKET" \
+TONG_RUNTIME_ASSET_MANIFEST_KEY="$RUNTIME_ASSET_MANIFEST_KEY" \
+  npm --prefix "$ROOT_DIR" run runtime-assets:upload
+
+echo "[3/5] Building + deploying Next.js app to Cloudflare Workers (OpenNext)..."
 NEXT_PUBLIC_TONG_PUBLIC_DOMAIN="$PUBLIC_DOMAIN" \
 NEXT_PUBLIC_TONG_API_BASE="$API_BASE" \
+NEXT_PUBLIC_TONG_ASSETS_BASE_URL="$ASSETS_BASE_URL" \
 NEXT_PUBLIC_TONG_EXTENSION_ZIP_URL="$EXTENSION_ZIP_URL" \
 NEXT_PUBLIC_TONG_YOUTUBE_DEMO_URL="$YOUTUBE_DEMO_URL" \
 NEXT_PUBLIC_TONG_DEMO_PASSWORD_HINT="$DEMO_PASSWORD_HINT" \
   npm --prefix "$ROOT_DIR/apps/client" run cf:deploy
 
-echo "[3/4] Attaching custom domain trigger ($PUBLIC_DOMAIN)..."
+echo "[4/5] Attaching custom domain trigger ($PUBLIC_DOMAIN)..."
 npx --prefix "$ROOT_DIR/apps/client" wrangler deploy \
   --config "$ROOT_DIR/apps/client/wrangler.toml" \
   --domain "$PUBLIC_DOMAIN" \
   --keep-vars
 
-echo "[4/4] Deployment complete."
+echo "[5/5] Deployment complete."
 echo
 echo "Public URL: https://$PUBLIC_DOMAIN"
 echo "Workers URL: https://tong-berlayar-web.erniesg.workers.dev"
 echo "API base wired into frontend build: $API_BASE"
+echo "Runtime assets wired into frontend build: $ASSETS_BASE_URL"

--- a/scripts/upload-qa-evidence.mjs
+++ b/scripts/upload-qa-evidence.mjs
@@ -24,6 +24,9 @@ const DEFAULT_GIF_FPS = 6;
 const DEFAULT_GIF_WIDTH = 360;
 const DEFAULT_PREVIEW_TRAILING_PADDING = 0.5;
 const DEFAULT_CACHE_CONTROL = "public, max-age=31536000, immutable";
+const DEFAULT_PUBLIC_VERIFY_ATTEMPTS = 4;
+const DEFAULT_PUBLIC_VERIFY_DELAY_MS = 1500;
+const DEFAULT_PUBLIC_VERIFY_TIMEOUT_MS = 15000;
 const DEFAULT_COMPARISON_DIFF_THRESHOLD = "2%";
 const DEFAULT_COMPARISON_PADDING = 28;
 const DEFAULT_COMPARISON_LABEL_HEIGHT = 54;
@@ -60,8 +63,12 @@ function parseArgs(argv) {
     includeSupporting: false,
     manifestName: DEFAULT_MANIFEST_NAME,
     posterAtSeconds: null,
+    publicVerifyAttempts: DEFAULT_PUBLIC_VERIFY_ATTEMPTS,
+    publicVerifyDelayMs: DEFAULT_PUBLIC_VERIFY_DELAY_MS,
+    publicVerifyTimeoutMs: DEFAULT_PUBLIC_VERIFY_TIMEOUT_MS,
     previewStartSeconds: null,
     previewTrailingPaddingSeconds: DEFAULT_PREVIEW_TRAILING_PADDING,
+    skipPublicVerification: false,
     wranglerConfig: "apps/client/wrangler.toml",
   };
 
@@ -87,6 +94,12 @@ function parseArgs(argv) {
       args.previewStartSeconds = Number(argv[++i]);
     } else if (arg === "--poster-at-seconds") {
       args.posterAtSeconds = Number(argv[++i]);
+    } else if (arg === "--public-verify-attempts") {
+      args.publicVerifyAttempts = Number(argv[++i]);
+    } else if (arg === "--public-verify-delay-ms") {
+      args.publicVerifyDelayMs = Number(argv[++i]);
+    } else if (arg === "--public-verify-timeout-ms") {
+      args.publicVerifyTimeoutMs = Number(argv[++i]);
     } else if (arg === "--preview-trailing-padding-seconds") {
       args.previewTrailingPaddingSeconds = Number(argv[++i]);
     } else if (arg === "--dry-run") {
@@ -99,6 +112,8 @@ function parseArgs(argv) {
       args.generatePoster = false;
     } else if (arg === "--skip-comparisons") {
       args.generateComparisons = false;
+    } else if (arg === "--skip-public-verification") {
+      args.skipPublicVerification = true;
     } else if (arg === "--help" || arg === "-h") {
       printHelp();
       process.exit(0);
@@ -115,6 +130,15 @@ function parseArgs(argv) {
   }
   if (!args.publicBaseUrl) {
     throw new Error("Missing public base URL. Set --public-base-url or TONG_RUNS_PUBLIC_BASE_URL.");
+  }
+  if (!Number.isFinite(args.publicVerifyAttempts) || args.publicVerifyAttempts < 1) {
+    throw new Error("`--public-verify-attempts` must be a positive number.");
+  }
+  if (!Number.isFinite(args.publicVerifyDelayMs) || args.publicVerifyDelayMs < 0) {
+    throw new Error("`--public-verify-delay-ms` must be zero or greater.");
+  }
+  if (!Number.isFinite(args.publicVerifyTimeoutMs) || args.publicVerifyTimeoutMs < 1) {
+    throw new Error("`--public-verify-timeout-ms` must be a positive number.");
   }
 
   return args;
@@ -135,10 +159,15 @@ Options:
   --gif-width <n>               GIF width in pixels (default: ${DEFAULT_GIF_WIDTH})
   --preview-start-seconds <n>   GIF preview start timestamp (default: auto, near clip end)
   --poster-at-seconds <n>       Poster frame timestamp (default: midpoint of preview window)
+  --public-verify-attempts <n>  Retry count for reviewer-visible URL checks (default: ${DEFAULT_PUBLIC_VERIFY_ATTEMPTS})
+  --public-verify-delay-ms <n>  Delay between reviewer-visible URL checks (default: ${DEFAULT_PUBLIC_VERIFY_DELAY_MS})
+  --public-verify-timeout-ms <n>
+                                Timeout per reviewer-visible URL check (default: ${DEFAULT_PUBLIC_VERIFY_TIMEOUT_MS})
   --preview-trailing-padding-seconds <n>
                                 Leave this much time at clip end when auto-picking preview start
   --manifest-name <name>        Local manifest filename (default: ${DEFAULT_MANIFEST_NAME})
   --wrangler-config <path>      Wrangler config path (default: apps/client/wrangler.toml)
+  --skip-public-verification    Skip GET-based checks for reviewer-facing URLs after upload
   --dry-run                     Generate previews and manifest without uploading to R2
 `);
 }
@@ -930,7 +959,96 @@ function uploadArtifacts(configPath, bucket, artifacts, dryRun, repoRoot) {
   }
 }
 
-function main() {
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function buildPublicVerificationTargets(manifest) {
+  const targets = [
+    { label: "manifest", url: manifest.manifest_url },
+    { label: "summary", url: manifest.primary?.summary?.url },
+    { label: "gif preview", url: manifest.primary?.gif_preview?.url },
+    { label: "screen recording", url: manifest.primary?.proof_video?.url },
+    { label: "comparison panel", url: manifest.primary?.comparison_panel?.url },
+    { label: "focused comparison crop", url: manifest.primary?.comparison_focus_crop?.url },
+    { label: "dialogue screenshot", url: manifest.primary?.dialogue_screenshot?.url },
+    { label: "tooltip screenshot", url: manifest.primary?.tooltip_screenshot?.url },
+  ];
+
+  const seen = new Set();
+  return targets.filter((target) => {
+    if (!target.url || seen.has(target.url)) {
+      return false;
+    }
+    seen.add(target.url);
+    return true;
+  });
+}
+
+async function readProbeChunk(response) {
+  const reader = response.body?.getReader?.();
+  if (!reader) {
+    return;
+  }
+
+  try {
+    await reader.read();
+  } finally {
+    try {
+      await reader.cancel();
+    } catch {
+      // Best-effort cleanup only; the status code is the important signal.
+    }
+  }
+}
+
+async function verifyPublicTarget(target, options) {
+  let lastError = null;
+
+  for (let attempt = 1; attempt <= options.publicVerifyAttempts; attempt += 1) {
+    try {
+      const response = await fetch(target.url, {
+        headers: {
+          Range: "bytes=0-63",
+          "User-Agent": "tong-qa-evidence/1.0",
+        },
+        signal: AbortSignal.timeout(options.publicVerifyTimeoutMs),
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+
+      await readProbeChunk(response);
+      return response.status;
+    } catch (error) {
+      lastError = error;
+      if (attempt < options.publicVerifyAttempts) {
+        await sleep(options.publicVerifyDelayMs);
+      }
+    }
+  }
+
+  throw new Error(`Public URL check failed for ${target.label}: ${lastError?.message || lastError}`);
+}
+
+async function verifyPublicArtifacts(manifest, options) {
+  if (options.dryRun) {
+    return;
+  }
+  if (options.skipPublicVerification) {
+    console.log("Public URL verification: skipped");
+    return;
+  }
+
+  const targets = buildPublicVerificationTargets(manifest);
+  for (const target of targets) {
+    const status = await verifyPublicTarget(target, options);
+    console.log(`Public URL verified: ${target.label} (${status})`);
+  }
+}
+
+async function main() {
   const options = parseArgs(process.argv.slice(2));
   const bundle = loadQaRunBundle(path.resolve(options.runDir), resolveRepoRoot());
   const repoRoot = bundle.repoRoot;
@@ -961,6 +1079,7 @@ function main() {
     "application/json; charset=utf-8",
     options.dryRun,
   );
+  await verifyPublicArtifacts(manifest, options);
 
   console.log(`Manifest written: ${relativeToRepo(repoRoot, manifestPath)}`);
   console.log(`Run prefix: ${runPrefix}`);
@@ -977,7 +1096,7 @@ function main() {
 }
 
 try {
-  main();
+  await main();
 } catch (error) {
   console.error(String(error.message || error));
   process.exit(1);

--- a/scripts/upload-runtime-assets.mjs
+++ b/scripts/upload-runtime-assets.mjs
@@ -1,0 +1,339 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { relativeToRepo, resolveRepoRoot } from "./lib/qa_evidence.mjs";
+
+const DEFAULT_BUCKET = "tong-assets";
+const DEFAULT_PUBLIC_BASE_URL = "https://assets.tong.berlayar.ai";
+const DEFAULT_RUNTIME_MANIFEST_KEY = "runtime-assets/manifest.json";
+const DEFAULT_CANONICAL_MANIFEST_KEY = "runtime-assets/canonical-asset-manifest.json";
+const DEFAULT_PUBLIC_VERIFY_ATTEMPTS = 4;
+const DEFAULT_PUBLIC_VERIFY_DELAY_MS = 1500;
+const DEFAULT_PUBLIC_VERIFY_TIMEOUT_MS = 15000;
+
+const CLIENT_PUBLIC_ASSETS_DIR = "apps/client/public/assets";
+const RUNTIME_MANIFEST_PATH = "assets/manifest/runtime-asset-manifest.json";
+const CANONICAL_MANIFEST_PATH = "assets/manifest/canonical-asset-manifest.json";
+
+function parseArgs(argv) {
+  const args = {
+    bucket: process.env.TONG_ASSETS_R2_BUCKET || DEFAULT_BUCKET,
+    canonicalManifestKey: DEFAULT_CANONICAL_MANIFEST_KEY,
+    dryRun: false,
+    publicBaseUrl: process.env.NEXT_PUBLIC_TONG_ASSETS_BASE_URL || DEFAULT_PUBLIC_BASE_URL,
+    publicVerifyAttempts: DEFAULT_PUBLIC_VERIFY_ATTEMPTS,
+    publicVerifyDelayMs: DEFAULT_PUBLIC_VERIFY_DELAY_MS,
+    publicVerifyTimeoutMs: DEFAULT_PUBLIC_VERIFY_TIMEOUT_MS,
+    runtimeManifestKey: process.env.TONG_RUNTIME_ASSET_MANIFEST_KEY || DEFAULT_RUNTIME_MANIFEST_KEY,
+    skipPublicVerification: false,
+    wranglerConfig: "apps/client/wrangler.toml",
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--bucket") {
+      args.bucket = argv[++i];
+    } else if (arg === "--public-base-url") {
+      args.publicBaseUrl = argv[++i];
+    } else if (arg === "--runtime-manifest-key") {
+      args.runtimeManifestKey = argv[++i];
+    } else if (arg === "--canonical-manifest-key") {
+      args.canonicalManifestKey = argv[++i];
+    } else if (arg === "--wrangler-config") {
+      args.wranglerConfig = argv[++i];
+    } else if (arg === "--public-verify-attempts") {
+      args.publicVerifyAttempts = Number(argv[++i]);
+    } else if (arg === "--public-verify-delay-ms") {
+      args.publicVerifyDelayMs = Number(argv[++i]);
+    } else if (arg === "--public-verify-timeout-ms") {
+      args.publicVerifyTimeoutMs = Number(argv[++i]);
+    } else if (arg === "--dry-run") {
+      args.dryRun = true;
+    } else if (arg === "--skip-public-verification") {
+      args.skipPublicVerification = true;
+    } else if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!args.bucket) {
+    throw new Error("Missing bucket name. Set --bucket or TONG_ASSETS_R2_BUCKET.");
+  }
+  if (!args.publicBaseUrl) {
+    throw new Error("Missing public base URL. Set --public-base-url or NEXT_PUBLIC_TONG_ASSETS_BASE_URL.");
+  }
+  if (!args.runtimeManifestKey) {
+    throw new Error("Missing runtime manifest key. Set --runtime-manifest-key or TONG_RUNTIME_ASSET_MANIFEST_KEY.");
+  }
+  if (!Number.isFinite(args.publicVerifyAttempts) || args.publicVerifyAttempts < 1) {
+    throw new Error("`--public-verify-attempts` must be a positive number.");
+  }
+  if (!Number.isFinite(args.publicVerifyDelayMs) || args.publicVerifyDelayMs < 0) {
+    throw new Error("`--public-verify-delay-ms` must be zero or greater.");
+  }
+  if (!Number.isFinite(args.publicVerifyTimeoutMs) || args.publicVerifyTimeoutMs < 1) {
+    throw new Error("`--public-verify-timeout-ms` must be a positive number.");
+  }
+
+  return args;
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/upload-runtime-assets.mjs [options]
+
+Uploads runtime product assets to the tong-assets R2 bucket and optionally verifies
+that the public asset URLs are readable.
+
+Options:
+  --bucket <name>                R2 bucket name (default: ${DEFAULT_BUCKET})
+  --public-base-url <url>        Public runtime asset base URL (default: ${DEFAULT_PUBLIC_BASE_URL})
+  --runtime-manifest-key <key>   Bucket key for runtime manifest (default: ${DEFAULT_RUNTIME_MANIFEST_KEY})
+  --canonical-manifest-key <key> Bucket key for canonical manifest (default: ${DEFAULT_CANONICAL_MANIFEST_KEY})
+  --wrangler-config <path>       Wrangler config path (default: apps/client/wrangler.toml)
+  --public-verify-attempts <n>   Retry count for public URL checks (default: ${DEFAULT_PUBLIC_VERIFY_ATTEMPTS})
+  --public-verify-delay-ms <n>   Delay between public URL checks (default: ${DEFAULT_PUBLIC_VERIFY_DELAY_MS})
+  --public-verify-timeout-ms <n> Timeout per public URL check (default: ${DEFAULT_PUBLIC_VERIFY_TIMEOUT_MS})
+  --skip-public-verification     Skip GET-based public URL checks after upload
+  --dry-run                      Print the planned upload set without uploading
+`);
+}
+
+function runCommand(command, commandArgs, options = {}) {
+  const result = spawnSync(command, commandArgs, {
+    encoding: "utf8",
+    stdio: options.stdio || "pipe",
+    cwd: options.cwd,
+    env: options.env || process.env,
+  });
+
+  if (result.status !== 0) {
+    const details = result.stderr || result.stdout || `exit code ${result.status}`;
+    throw new Error(`${command} ${commandArgs.join(" ")} failed: ${details.trim()}`);
+  }
+
+  return (result.stdout || "").trim();
+}
+
+function contentTypeFor(filePath) {
+  const ext = path.extname(filePath).toLowerCase();
+  switch (ext) {
+    case ".png":
+      return "image/png";
+    case ".jpg":
+    case ".jpeg":
+      return "image/jpeg";
+    case ".webp":
+      return "image/webp";
+    case ".gif":
+      return "image/gif";
+    case ".svg":
+      return "image/svg+xml";
+    case ".mp4":
+      return "video/mp4";
+    case ".mov":
+      return "video/quicktime";
+    case ".webm":
+      return "video/webm";
+    case ".json":
+      return "application/json; charset=utf-8";
+    case ".txt":
+    case ".md":
+    case ".log":
+      return "text/plain; charset=utf-8";
+    default:
+      return "application/octet-stream";
+  }
+}
+
+function walkFiles(dirPath, files = []) {
+  for (const entry of fs.readdirSync(dirPath, { withFileTypes: true })) {
+    const fullPath = path.join(dirPath, entry.name);
+    if (entry.isDirectory()) {
+      walkFiles(fullPath, files);
+      continue;
+    }
+    if (entry.isFile()) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function toPublicUrl(publicBaseUrl, key) {
+  const normalizedBase = publicBaseUrl.replace(/\/+$/, "");
+  const encodedKey = key
+    .split("/")
+    .map((part) => encodeURIComponent(part))
+    .join("/");
+  return `${normalizedBase}/${encodedKey}`;
+}
+
+function buildAssetUploadSet(repoRoot, options) {
+  const clientAssetsRoot = path.join(repoRoot, CLIENT_PUBLIC_ASSETS_DIR);
+  const runtimeManifestPath = path.join(repoRoot, RUNTIME_MANIFEST_PATH);
+  const canonicalManifestPath = path.join(repoRoot, CANONICAL_MANIFEST_PATH);
+
+  if (!fs.existsSync(clientAssetsRoot)) {
+    throw new Error(`Missing runtime assets directory: ${relativeToRepo(repoRoot, clientAssetsRoot)}`);
+  }
+  if (!fs.existsSync(runtimeManifestPath)) {
+    throw new Error(`Missing runtime manifest: ${relativeToRepo(repoRoot, runtimeManifestPath)}`);
+  }
+  if (!fs.existsSync(canonicalManifestPath)) {
+    throw new Error(`Missing canonical manifest: ${relativeToRepo(repoRoot, canonicalManifestPath)}`);
+  }
+
+  const uploads = walkFiles(clientAssetsRoot).map((absolutePath) => ({
+    kind: "asset",
+    label: relativeToRepo(repoRoot, absolutePath),
+    absolutePath,
+    bucketKey: path.posix.join("assets", path.relative(clientAssetsRoot, absolutePath).split(path.sep).join("/")),
+    contentType: contentTypeFor(absolutePath),
+  }));
+
+  uploads.push({
+    kind: "runtime-manifest",
+    label: RUNTIME_MANIFEST_PATH,
+    absolutePath: runtimeManifestPath,
+    bucketKey: options.runtimeManifestKey,
+    contentType: "application/json; charset=utf-8",
+  });
+
+  uploads.push({
+    kind: "canonical-manifest",
+    label: CANONICAL_MANIFEST_PATH,
+    absolutePath: canonicalManifestPath,
+    bucketKey: options.canonicalManifestKey,
+    contentType: "application/json; charset=utf-8",
+  });
+
+  return uploads;
+}
+
+function wranglerArgs(configPath, objectPath, filePath, contentType) {
+  return [
+    "--config",
+    configPath,
+    "r2",
+    "object",
+    "put",
+    objectPath,
+    "--file",
+    filePath,
+    "--content-type",
+    contentType,
+    "--cache-control",
+    "public, max-age=31536000, immutable",
+    "--remote",
+  ];
+}
+
+function uploadFile(configPath, bucket, upload, dryRun) {
+  if (dryRun) return;
+  runCommand("npm", [
+    "--prefix",
+    "apps/client",
+    "exec",
+    "wrangler",
+    "--",
+    ...wranglerArgs(configPath, `${bucket}/${upload.bucketKey}`, upload.absolutePath, upload.contentType),
+  ]);
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function readProbeChunk(response) {
+  const reader = response.body?.getReader?.();
+  if (!reader) return;
+
+  try {
+    await reader.read();
+  } finally {
+    try {
+      await reader.cancel();
+    } catch {
+      // Best-effort cleanup only.
+    }
+  }
+}
+
+async function verifyPublicUrl(target, options) {
+  let lastError = null;
+
+  for (let attempt = 1; attempt <= options.publicVerifyAttempts; attempt += 1) {
+    try {
+      const response = await fetch(target.url, {
+        headers: {
+          Connection: "close",
+          Range: "bytes=0-63",
+          "User-Agent": "tong-runtime-assets/1.0",
+        },
+        signal: AbortSignal.timeout(options.publicVerifyTimeoutMs),
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+
+      await readProbeChunk(response);
+      return response.status;
+    } catch (error) {
+      lastError = error;
+      if (attempt < options.publicVerifyAttempts) {
+        await sleep(options.publicVerifyDelayMs);
+      }
+    }
+  }
+
+  throw new Error(`Public URL check failed for ${target.label}: ${lastError?.message || lastError}`);
+}
+
+async function verifyUploads(uploads, options) {
+  if (options.dryRun) return;
+  if (options.skipPublicVerification) {
+    console.log("Public URL verification: skipped");
+    return;
+  }
+
+  for (const upload of uploads) {
+    const status = await verifyPublicUrl(
+      { label: upload.label, url: toPublicUrl(options.publicBaseUrl, upload.bucketKey) },
+      options,
+    );
+    console.log(`Public URL verified: ${upload.bucketKey} (${status})`);
+  }
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const repoRoot = resolveRepoRoot();
+  const wranglerConfigPath = path.resolve(repoRoot, options.wranglerConfig);
+  const uploads = buildAssetUploadSet(repoRoot, options);
+
+  for (const upload of uploads) {
+    uploadFile(wranglerConfigPath, options.bucket, upload, options.dryRun);
+  }
+
+  await verifyUploads(uploads, options);
+
+  console.log(`Bucket: ${options.bucket}`);
+  console.log(`Public base URL: ${options.publicBaseUrl}`);
+  console.log(`Wrangler config: ${relativeToRepo(repoRoot, wranglerConfigPath)}`);
+  console.log(`Files prepared: ${uploads.length}`);
+  console.log(`Dry run: ${options.dryRun ? "yes" : "no"}`);
+}
+
+try {
+  await main();
+  process.exit(0);
+} catch (error) {
+  console.error(String(error.message || error));
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- hydrate the client runtime asset manifest from the published `tong-assets` manifest with bundled fallback
- add same-origin media fallbacks for map, backdrop, character, and cinematic assets when the public host is stale
- add reusable runtime asset publishing and public URL verification, and wire Cloudflare deploy + QA docs/skills to use it

## How to test
- `npm --prefix apps/client run build`
- `npm run demo:smoke`
- `node --check scripts/upload-runtime-assets.mjs`
- verify `https://assets.tong.berlayar.ai/runtime-assets/manifest.json` and representative asset URLs return `200` with normal `GET` requests