### PR TITLE
fix: respect absolute QA recipe run paths

### DIFF
--- a/scripts/run_qa_publish_recipe.mjs
+++ b/scripts/run_qa_publish_recipe.mjs
@@ -167,7 +167,10 @@ function main() {
     fail(`Recipe ${args.recipe} did not print a run directory.`);
   }
   if (args.issueRef) {
-    const manifestPath = path.join(process.cwd(), runDir, "run.json");
+    const manifestPath = path.join(
+      path.isAbsolute(runDir) ? runDir : path.join(process.cwd(), runDir),
+      "run.json",
+    );
     const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
     manifest.issue_ref = args.issueRef;
     fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");


### PR DESCRIPTION
## Root Cause
The trusted QA recipe runner treated recipe-produced run directories as relative even when the recorder returned an absolute path. In GitHub Actions this produced invalid doubled paths and broke CI evidence generation for progression PRs.

## What Changed
- preserve absolute `run_dir` values emitted by recipe scripts
- only join with `process.cwd()` when the recipe returns a relative path

## Validation
- `node --check scripts/run_qa_publish_recipe.mjs`
- observed failing Actions logs for PRs #91, #92, and #93, then patched the runner and retriggered those branches

## How To Test
1. Open a same-repo PR whose title/branch resolves to a QA recipe.
2. Let `Trusted QA Publish` run on `pull_request`.
3. Confirm the run reaches recipe generation without an ENOENT on `run.json`.
