### PR TITLE
fix: classify issue 51 QA as server-state verification

### DIFF
--- a/.agents/skills/_functional-qa/config/repo-adapter.json
+++ b/.agents/skills/_functional-qa/config/repo-adapter.json
@@ -123,6 +123,14 @@
         "Require temporal capture and screenshots in validation and fix verification outputs.",
         "Prefer qa-platform docs and workflow assets; keep cross-lane changes minimal."
       ]
+    },
+    {
+      "match": "#51",
+      "issue_class_override": "persistence-state-sync",
+      "notes": [
+        "Treat the API half of scenario-seed mounts as a server-state verification issue, not a reviewer-proof visual transition.",
+        "Prefer strict API replay with contract assertions and console-state traces over screenshot gates."
+      ]
     }
   ],
   "issue_playbooks": [


### PR DESCRIPTION
## Root Cause
Issue #51 is the API half of deterministic scenario-seed mounting, but the QA adapter was classifying it as `animation-transition`. That forced screenshot and temporal-capture gates on a strict API replay recipe, so trusted publish failed even after the CI bundle was generated.

## What Changed
- override issue #51 QA classification to `persistence-state-sync`
- keep the scenario-seed API path on contract/assertion and console-trace evidence instead of reviewer-proof visual gates

## Validation
- `python3 .agents/skills/_functional-qa/scripts/qa_runtime.py init-run validate-issue --target erniesg/tong#51 --verify-fix`
- confirmed the generated run scaffold now uses:
  - `issue_class = persistence-state-sync`
  - `requires_direct_issue_evidence = false`
  - `ui_acceptance_required = false`
  - required evidence = `console-state-trace`, `contract-assertions`

## How To Test
1. Push a same-repo PR for issue #51 part 1.
2. Let `Trusted QA Publish` run on `pull_request`.
3. Confirm publish does not block on screenshot/temporal-capture gates.
