### PR TITLE
Unify KG objective ids with canonical aliases

### DIFF
--- a/apps/server/ingestion/pipeline.mjs
+++ b/apps/server/ingestion/pipeline.mjs
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { withObjectiveIdentity } from "../src/objective-identity.mjs";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const SOURCE_KEYS = ["youtube", "spotify"];
@@ -29,17 +30,17 @@ const CLUSTERS = [
 
 const OBJECTIVE_BY_CLUSTER = {
   "food-ordering": {
-    objectiveId: "ko_food_l2_001",
+    objectiveId: "ko-vocab-food-items",
     reason: "High utility in next food-location hangout",
     gap: 0.84
   },
   "performance-energy": {
-    objectiveId: "zh_stage_l3_002",
+    objectiveId: "zh-mission-stage-texting",
     reason: "Supports Shanghai advanced texting mission vocabulary",
     gap: 0.9
   },
   "transport-navigation": {
-    objectiveId: "ja_subway_l1_001",
+    objectiveId: "ja-vocab-subway-transfers",
     reason: "Improves route and transfer conversation readiness",
     gap: 0.72
   }
@@ -47,22 +48,22 @@ const OBJECTIVE_BY_CLUSTER = {
 
 const OBJECTIVE_BY_LANG = {
   ko: {
-    objectiveId: "ko_food_l2_001",
+    objectiveId: "ko-vocab-food-items",
     reason: "Reinforces Korean phrase utility for food-street scenes",
     gap: 0.74
   },
   ja: {
-    objectiveId: "ja_subway_l1_001",
+    objectiveId: "ja-vocab-subway-transfers",
     reason: "Builds Japanese transit phrase reliability",
     gap: 0.7
   },
   zh: {
-    objectiveId: "zh_stage_l3_002",
+    objectiveId: "zh-mission-stage-texting",
     reason: "Strengthens Mandarin mission vocabulary recall",
     gap: 0.8
   },
   en: {
-    objectiveId: "ja_subway_l1_001",
+    objectiveId: "ja-vocab-subway-transfers",
     reason: "Useful bridge terms for subway objective setup",
     gap: 0.62
   }
@@ -351,50 +352,43 @@ function plannerRecommendations(clusterScores, topTerms) {
   const byCluster = Object.fromEntries(clusterScores.map((item) => [item.clusterId, item.score]));
 
   const objectiveCandidates = [
-    {
-      objectiveId: "ko_food_l2_001",
+    withObjectiveIdentity({
       reason: "High food-ordering coverage from recent consumption",
       confidence: Number((byCluster["food-ordering"] ?? 0).toFixed(2))
-    },
-    {
-      objectiveId: "zh_stage_l3_002",
+    }, "ko-vocab-food-items"),
+    withObjectiveIdentity({
       reason: "Performance-energy cluster is active in CN/KR media",
       confidence: Number((byCluster["performance-energy"] ?? 0).toFixed(2))
-    },
-    {
-      objectiveId: "ja_subway_l1_001",
+    }, "zh-mission-stage-texting"),
+    withObjectiveIdentity({
       reason: "Transit vocabulary appears in multi-source content",
       confidence: Number((byCluster["transport-navigation"] ?? 0).toFixed(2))
-    }
+    }, "ja-vocab-subway-transfers")
   ].filter((item) => item.confidence > 0);
 
   const sceneCandidates = [
-    {
+    withObjectiveIdentity({
       sceneId: "food_street_hangout_intro",
       city: "seoul",
-      mode: "hangout",
-      objectiveId: "ko_food_l2_001"
-    },
-    {
+      mode: "hangout"
+    }, "ko-vocab-food-items"),
+    withObjectiveIdentity({
       sceneId: "shanghai_texting_mission_advanced",
       city: "shanghai",
-      mode: "hangout",
-      objectiveId: "zh_stage_l3_002"
-    }
+      mode: "hangout"
+    }, "zh-mission-stage-texting")
   ].filter((scene) => objectiveCandidates.some((objective) => objective.objectiveId === scene.objectiveId));
 
-  const exerciseCandidates = topTerms.slice(0, 6).map((term) => ({
+  const exerciseCandidates = topTerms.slice(0, 6).map((term) => withObjectiveIdentity({
     type: "targeted-drill",
     lemma: term.lemma,
     lang: term.lang,
-    objectiveId:
-      term.clusterId === "food-ordering"
-        ? "ko_food_l2_001"
-        : term.clusterId === "performance-energy"
-          ? "zh_stage_l3_002"
-          : "ja_subway_l1_001",
     reason: `Frequent in ${term.dominantSource} over last 72h`
-  }));
+  }, term.clusterId === "food-ordering"
+    ? "ko-vocab-food-items"
+    : term.clusterId === "performance-energy"
+      ? "zh-mission-stage-texting"
+      : "ja-vocab-subway-transfers"));
 
   return {
     objectiveCandidates,
@@ -647,10 +641,9 @@ export function buildVocabInsights({
     clusterId: term.clusterId,
     orthographyFeatures: orthographyFeaturesForTerm(term.lemma),
     objectiveLinks: [
-      {
-        objectiveId: term.objective.objectiveId,
+      withObjectiveIdentity({
         reason: term.objective.reason
-      }
+      }, term.objective.objectiveId)
     ]
   }));
 

--- a/apps/server/src/index.mjs
+++ b/apps/server/src/index.mjs
@@ -40,6 +40,13 @@ import {
   recordGraphEvidence,
   validatePack,
 } from './curriculum-graph.mjs';
+import {
+  canonicalObjectiveNodeId,
+  defaultObjectiveIdForLang,
+  objectiveMatchesLanguage,
+  resolveObjectiveIdentity,
+  withObjectiveIdentity,
+} from './objective-identity.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -100,9 +107,9 @@ const LANG_TARGETS = {
   },
 };
 const DEFAULT_OBJECTIVE_BY_LANG = {
-  ko: 'ko_food_l2_001',
-  ja: 'ko_city_l2_003',
-  zh: 'zh_stage_l3_002',
+  ko: defaultObjectiveIdForLang('ko', 'ko-vocab-food-items'),
+  ja: defaultObjectiveIdForLang('ja', 'ja-vocab-subway-transfers'),
+  zh: defaultObjectiveIdForLang('zh', 'zh-mission-stage-texting'),
 };
 const INGESTION_SOURCES = new Set(['youtube', 'spotify']);
 
@@ -734,10 +741,6 @@ function getDominantClusterId(ingestion) {
   );
 }
 
-function objectiveMatchesLanguage(objectiveId, lang) {
-  return typeof objectiveId === 'string' && objectiveId.startsWith(`${lang}_`);
-}
-
 function buildPersonalizedObjective({
   userId = DEFAULT_USER_ID,
   mode = 'hangout',
@@ -791,13 +794,20 @@ function buildPersonalizedObjective({
     linkedNodeIds: [`overlay:${item.dominantSource}:${dominantClusterId}`, `target:${item.lemma}`],
   }));
 
-  const objectiveNodeId = `objective:${objectiveId}`;
-  const graphCategory = lang === 'zh' ? 'sentences' : lang === 'ja' ? 'script' : 'vocabulary';
+  const resolvedObjective = resolveObjectiveIdentity(objectiveId);
+  const objectiveNodeId = canonicalObjectiveNodeId(objectiveId);
+  const graphCategory =
+    resolvedObjective.identity?.objectiveCategory ||
+    (lang === 'zh' ? 'conversation' : lang === 'ja' ? 'vocabulary' : 'vocabulary');
   const graphTargetNodeIds = vocabulary.map((term) => `target:${term}`);
+  const prerequisiteByLang = {
+    ko: ['ko-pron-food-words'],
+    ja: [],
+    zh: [],
+  };
 
-  return {
+  return withObjectiveIdentity({
     ...baseObjective,
-    objectiveId,
     mode,
     lang,
     objectiveGraph: {
@@ -806,7 +816,7 @@ function buildPersonalizedObjective({
       locationId: location,
       objectiveCategory: graphCategory,
       targetNodeIds: graphTargetNodeIds,
-      prerequisiteObjectiveIds: [`${lang}_food_l1_001`],
+      prerequisiteObjectiveIds: prerequisiteByLang[lang] || [],
       source: 'knowledge_graph',
     },
     coreTargets: {
@@ -830,7 +840,7 @@ function buildPersonalizedObjective({
         'mission',
       ],
     },
-  };
+  }, objectiveId);
 }
 
 function buildGameActions(lang, objectiveId) {
@@ -842,8 +852,7 @@ function buildGameActions(lang, objectiveId) {
 }
 
 function buildActiveObjectiveDescriptor({ objective, lang, city, location }) {
-  return {
-    objectiveId: objective.objectiveId,
+  return withObjectiveIdentity({
     lang,
     mode: 'hangout',
     cityId: city,
@@ -852,7 +861,7 @@ function buildActiveObjectiveDescriptor({ objective, lang, city, location }) {
     objectiveNodeId: objective.objectiveGraph?.objectiveNodeId,
     targetNodeIds: cloneJson(objective.objectiveGraph?.targetNodeIds || []),
     summary: `Resume ${lang.toUpperCase()} practice at ${location.replace(/_/g, ' ')}.`,
-  };
+  }, objective.objectiveId);
 }
 
 function buildInitialProgression() {
@@ -1645,25 +1654,25 @@ function listLearnSessions() {
 
 function createLearnSession(body = {}) {
   const learnSessionId = `learn_${Math.random().toString(36).slice(2, 8)}`;
-  const title = `Food Street ${body.objectiveId || 'Objective'} Drill`;
-  const item = {
+  const requestedObjectiveId = body.objectiveId || DEFAULT_OBJECTIVE_BY_LANG.ko;
+  const resolvedObjective = resolveObjectiveIdentity(requestedObjectiveId);
+  const title = `Food Street ${resolvedObjective.canonicalObjectiveId || 'Objective'} Drill`;
+  const item = withObjectiveIdentity({
     learnSessionId,
     title,
-    objectiveId: body.objectiveId || 'ko_food_l2_001',
     lastMessageAt: new Date().toISOString(),
-  };
+  }, requestedObjectiveId);
   state.learnSessions.unshift(item);
 
-  return {
+  return withObjectiveIdentity({
     learnSessionId,
     mode: 'learn',
     uiTheme: 'kakao_like',
-    objectiveId: item.objectiveId,
     firstMessage: {
       speaker: 'tong',
       text: "New session started. We'll train 주문 phrases for your next hangout.",
     },
-  };
+  }, item.objectiveId);
 }
 
 async function invokeAgentTool(toolName, rawArgs = {}) {

--- a/apps/server/src/ingestion.mjs
+++ b/apps/server/src/ingestion.mjs
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { withObjectiveIdentity } from './objective-identity.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -36,7 +37,7 @@ const TOPIC_DEFINITIONS = [
       '点餐',
       '料理',
     ],
-    objectiveId: 'ko_food_l2_001',
+    objectiveId: 'ko-vocab-food-items',
     objectiveReason: 'High utility in next food-location hangout',
     objectiveGap: 0.84,
   },
@@ -58,7 +59,7 @@ const TOPIC_DEFINITIONS = [
       '练',
       '舞台',
     ],
-    objectiveId: 'zh_stage_l3_002',
+    objectiveId: 'zh-mission-stage-texting',
     objectiveReason: 'Supports Shanghai advanced texting mission vocabulary',
     objectiveGap: 0.9,
   },
@@ -79,7 +80,7 @@ const TOPIC_DEFINITIONS = [
       '友達',
       'cafe',
     ],
-    objectiveId: 'ko_city_l2_003',
+    objectiveId: 'ko-vocab-city-social',
     objectiveReason: 'Builds social and navigation language transfer',
     objectiveGap: 0.72,
   },
@@ -92,22 +93,22 @@ const HAN_REGEX = /[\u4e00-\u9fff]/u;
 
 const OBJECTIVE_BY_LANG = {
   ko: {
-    objectiveId: 'ko_food_l2_001',
+    objectiveId: 'ko-vocab-food-items',
     reason: 'Reinforces Korean phrase utility for food-street scenes',
     gap: 0.74,
   },
   ja: {
-    objectiveId: 'ko_city_l2_003',
+    objectiveId: 'ja-vocab-subway-transfers',
     reason: 'Builds Japanese transit and social phrase reliability',
     gap: 0.7,
   },
   zh: {
-    objectiveId: 'zh_stage_l3_002',
+    objectiveId: 'zh-mission-stage-texting',
     reason: 'Strengthens Mandarin mission vocabulary recall',
     gap: 0.8,
   },
   en: {
-    objectiveId: 'ko_city_l2_003',
+    objectiveId: 'ja-vocab-subway-transfers',
     reason: 'Supports cross-city objective transfer terms',
     gap: 0.62,
   },
@@ -192,7 +193,7 @@ function getTopicMatches(text) {
         clusterId: 'general',
         label: 'General',
         keywords: ['general'],
-        objectiveId: 'ko_food_l2_001',
+        objectiveId: 'ko-vocab-food-items',
         objectiveReason: 'General fallback objective linkage',
         objectiveGap: 0.62,
       },
@@ -208,7 +209,7 @@ function topicFromId(clusterId) {
       clusterId,
       label: clusterId,
       keywords: ['general'],
-      objectiveId: 'ko_food_l2_001',
+        objectiveId: 'ko-vocab-food-items',
       objectiveReason: 'General fallback objective linkage',
       objectiveGap: 0.62,
     }
@@ -284,11 +285,10 @@ function objectiveLinkForEntry(entry) {
   const langFallback = OBJECTIVE_BY_LANG[entry.lang] || OBJECTIVE_BY_LANG.en;
   const topicGap = Number(topic.objectiveGap || 0);
   const gap = topicGap > 0 ? topicGap : langFallback.gap;
-  return {
-    objectiveId: topic.objectiveId || langFallback.objectiveId,
+  return withObjectiveIdentity({
     reason: topic.objectiveReason || langFallback.reason,
     gap,
-  };
+  }, topic.objectiveId || langFallback.objectiveId);
 }
 
 function aggregateTopMedia(sourceItems, source) {
@@ -474,10 +474,9 @@ export function runMockIngestion(snapshot, options = {}) {
       clusterId: row.entry.clusterId,
       orthographyFeatures: orthographyFeaturesForLemma(row.entry.lemma),
       objectiveLinks: [
-        {
-          objectiveId: row.objective.objectiveId,
+        withObjectiveIdentity({
           reason: row.objective.reason,
-        },
+        }, row.objective.objectiveId),
       ],
     }));
 

--- a/apps/server/src/objective-identity.mjs
+++ b/apps/server/src/objective-identity.mjs
@@ -1,0 +1,84 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '../../..');
+
+const objectiveIdentityMap = JSON.parse(
+  fs.readFileSync(path.join(repoRoot, 'packages/contracts/objective-identity-map.sample.json'), 'utf8'),
+);
+
+const identityByCanonical = new Map();
+const canonicalByAnyId = new Map();
+
+for (const identity of objectiveIdentityMap.objectives ?? []) {
+  identityByCanonical.set(identity.canonicalObjectiveId, identity);
+  canonicalByAnyId.set(identity.canonicalObjectiveId, identity.canonicalObjectiveId);
+  for (const legacyId of identity.legacyObjectiveIds ?? []) {
+    canonicalByAnyId.set(legacyId, identity.canonicalObjectiveId);
+  }
+}
+
+export function resolveObjectiveIdentity(objectiveId) {
+  if (typeof objectiveId !== 'string' || objectiveId.length === 0) {
+    return {
+      objectiveId,
+      canonicalObjectiveId: objectiveId,
+      legacyObjectiveId: null,
+      objectiveAliasIds: [],
+    };
+  }
+
+  const canonicalObjectiveId = canonicalByAnyId.get(objectiveId) ?? objectiveId;
+  const identity = identityByCanonical.get(canonicalObjectiveId);
+  const legacyObjectiveId = identity?.legacyObjectiveIds?.[0] ?? null;
+  const objectiveAliasIds = identity?.legacyObjectiveIds ? [...identity.legacyObjectiveIds] : [];
+
+  return {
+    objectiveId: canonicalObjectiveId,
+    canonicalObjectiveId,
+    legacyObjectiveId,
+    objectiveAliasIds,
+    identity,
+  };
+}
+
+export function withObjectiveIdentity(payload = {}, objectiveId) {
+  const resolved = resolveObjectiveIdentity(objectiveId);
+  return {
+    ...payload,
+    objectiveId: resolved.objectiveId,
+    canonicalObjectiveId: resolved.canonicalObjectiveId,
+    legacyObjectiveId: resolved.legacyObjectiveId,
+    objectiveAliasIds: resolved.objectiveAliasIds,
+  };
+}
+
+export function canonicalObjectiveNodeId(objectiveId) {
+  return `objective:${resolveObjectiveIdentity(objectiveId).canonicalObjectiveId}`;
+}
+
+export function objectiveMatchesLanguage(objectiveId, lang) {
+  return typeof resolveObjectiveIdentity(objectiveId).canonicalObjectiveId === 'string' &&
+    resolveObjectiveIdentity(objectiveId).canonicalObjectiveId.startsWith(`${lang}-`);
+}
+
+export function defaultObjectiveIdForLang(lang, fallbackObjectiveId = null) {
+  if (typeof fallbackObjectiveId === 'string' && fallbackObjectiveId.length > 0) {
+    const fallbackCanonicalId = resolveObjectiveIdentity(fallbackObjectiveId).canonicalObjectiveId;
+    if (typeof fallbackCanonicalId === 'string' && fallbackCanonicalId.startsWith(`${lang}-`)) {
+      return fallbackCanonicalId;
+    }
+  }
+
+  for (const identity of objectiveIdentityMap.objectives ?? []) {
+    if (identity.lang === lang) {
+      return identity.canonicalObjectiveId;
+    }
+  }
+  return fallbackObjectiveId;
+}
+
+export { objectiveIdentityMap };

--- a/docs/handoff-notes.md
+++ b/docs/handoff-notes.md
@@ -155,3 +155,10 @@ Template:
 - Intent:
   - Teach the active `/game` bootstrap path to consume deterministic `scenarioSeedId` mounts from the existing `start-or-resume` substrate without collapsing them into ordinary player checkpoints.
   - Add a CI-regenerable QA publish recipe for the issue #51 seeded mount flow so same-repo PRs can auto-resolve trusted publish metadata on PR open.
+
+## 2026-03-20 (KG objective identity unification intent)
+- Date: 2026-03-20
+- Branch/worktree: `codex/kg-contracts-schema` (shared root workspace crossing into `packages/contracts/**` and server KG contract validation)
+- Intent:
+  - Validate and then unify legacy objective ids with canonical graph objective ids without breaking fixture-backed APIs abruptly.
+  - Keep canonical curriculum graph node ids as the source of truth and add additive alias metadata/migration checks so existing consumers can bridge during rollout.

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -10,6 +10,7 @@ Keep this package stable:
 Typed contracts:
 - `types.ts` defines TypeScript request/response models for Tong demo endpoints.
 - `index.ts` re-exports typed contracts for app usage.
+- `objective-identity-map.sample.json` is the canonical alias bridge between graph objective ids and legacy fixture/api ids during migration.
 - `fixtures/game.start-or-resume.sample.json` now includes the additive nested session model used for player resume and QA seed routing.
 - `fixtures/game.session.sample.json`, `fixtures/scene.session.sample.json`, `fixtures/checkpoint.player-resume.sample.json`, and `fixtures/scenario.seed.review-ready.sample.json` are the canonical samples for progression/resume work.
 
@@ -23,3 +24,4 @@ Curriculum graph fixtures:
 Naming note:
 - The shared contract uses `learnerId` as the stable user-specific identifier.
 - The mock dashboard runtime also accepts `personaId` as an alias because the first milestone is driven by persona fixtures.
+- Objective payloads now carry canonical graph `objectiveId` values plus additive `legacyObjectiveId` / `objectiveAliasIds` compatibility fields while consumers migrate.

--- a/packages/contracts/api-contract.md
+++ b/packages/contracts/api-contract.md
@@ -110,7 +110,7 @@ Response:
         "relatedForms": ["炎", "灯", "烧"]
       },
       "objectiveLinks": [
-        { "objectiveId": "zh_stage_l3_002", "reason": "Grammar + vocab gap" }
+        { "objectiveId": "zh-mission-stage-texting", "legacyObjectiveId": "zh_stage_l3_002", "objectiveAliasIds": ["zh_stage_l3_002"], "reason": "Grammar + vocab gap" }
       ]
     }
   ]
@@ -363,7 +363,7 @@ Response:
         "burst": 1.34,
         "clusterId": "food-ordering",
         "objectiveLinks": [
-          { "objectiveId": "ko_food_l2_001", "reason": "High utility in next hangout" }
+          { "objectiveId": "ko-vocab-food-items", "legacyObjectiveId": "ko_food_l2_001", "objectiveAliasIds": ["ko_food_l2_001"], "reason": "High utility in next hangout" }
         ]
       }
     ]
@@ -475,6 +475,9 @@ Contract notes:
   - `packages/contracts/fixtures/scenario.seed.review-ready.sample.json`
 
 ## GET `/api/v1/objectives/next`
+
+Canonical identity note: `objectiveId` now carries the canonical graph objective id. `legacyObjectiveId` and `objectiveAliasIds` remain additive compatibility fields during migration.
+
 Query:
 ```json
 {
@@ -489,17 +492,17 @@ Query:
 Response:
 ```json
 {
-  "objectiveId": "ko_food_l2_001",
+  "objectiveId": "ko-vocab-food-items",
   "level": 2,
   "mode": "hangout",
   "lang": "ko",
   "objectiveGraph": {
-    "objectiveNodeId": "objective:ko_food_l2_001",
+    "objectiveNodeId": "objective:ko-vocab-food-items",
     "cityId": "seoul",
     "locationId": "food_street",
     "objectiveCategory": "vocabulary",
     "targetNodeIds": ["target:메뉴", "target:주문", "target:맵다"],
-    "prerequisiteObjectiveIds": ["ko_food_l1_001"],
+    "prerequisiteObjectiveIds": ["ko-pron-food-words"],
     "source": "knowledge_graph"
   },
   "coreTargets": {
@@ -539,7 +542,7 @@ Request:
   "city": "seoul",
   "location": "food_street",
   "lang": "ko",
-  "objectiveId": "ko_food_l2_001"
+  "objectiveId": "ko-vocab-food-items"
 }
 ```
 
@@ -613,7 +616,7 @@ Response:
     {
       "learnSessionId": "learn_101",
       "title": "Food Street L2 Drill",
-      "objectiveId": "ko_food_l2_001",
+      "objectiveId": "ko-vocab-food-items",
       "lastMessageAt": "2026-02-28T11:20:00.000Z"
     }
   ]
@@ -627,7 +630,7 @@ Request:
   "userId": "demo-user-1",
   "city": "seoul",
   "lang": "ko",
-  "objectiveId": "ko_food_l2_001"
+  "objectiveId": "ko-vocab-food-items"
 }
 ```
 
@@ -637,7 +640,7 @@ Response:
   "learnSessionId": "learn_202",
   "mode": "learn",
   "uiTheme": "kakao_like",
-  "objectiveId": "ko_food_l2_001",
+  "objectiveId": "ko-vocab-food-items",
   "firstMessage": {
     "speaker": "tong",
     "text": "New session started. We'll train 주문 phrases for your next hangout."

--- a/packages/contracts/fixtures/checkpoint.player-resume.sample.json
+++ b/packages/contracts/fixtures/checkpoint.player-resume.sample.json
@@ -16,15 +16,24 @@
   "locationId": "food_street",
   "mode": "hangout",
   "objective": {
-    "objectiveId": "ko_food_l2_001",
+    "objectiveId": "ko-vocab-food-items",
     "lang": "ko",
     "mode": "hangout",
     "cityId": "seoul",
     "locationId": "food_street",
     "objectiveCategory": "vocabulary",
-    "objectiveNodeId": "objective:ko_food_l2_001",
-    "targetNodeIds": ["target:메뉴", "target:주문", "target:맵다"],
-    "summary": "Resume mid-ordering exercise at the last safe player-visible state."
+    "objectiveNodeId": "objective:ko-vocab-food-items",
+    "targetNodeIds": [
+      "target:메뉴",
+      "target:주문",
+      "target:맵다"
+    ],
+    "summary": "Resume mid-ordering exercise at the last safe player-visible state.",
+    "canonicalObjectiveId": "ko-vocab-food-items",
+    "legacyObjectiveId": "ko_food_l2_001",
+    "objectiveAliasIds": [
+      "ko_food_l2_001"
+    ]
   },
   "phase": "exercise",
   "turn": 3,
@@ -37,7 +46,10 @@
     "state": {
       "targetChar": "뉴",
       "remainingLives": 2,
-      "boardPieces": ["ㅁ", "ㅠ"],
+      "boardPieces": [
+        "ㅁ",
+        "ㅠ"
+      ],
       "requiredMatches": 1
     }
   },
@@ -56,8 +68,12 @@
     "masteryTier": 1
   },
   "unlocks": {
-    "locationIds": ["food_street"],
-    "missionIds": ["ko_food_street_gate_01"],
+    "locationIds": [
+      "food_street"
+    ],
+    "missionIds": [
+      "ko_food_street_gate_01"
+    ],
     "rewardIds": []
   },
   "rng": {

--- a/packages/contracts/fixtures/game.session.sample.json
+++ b/packages/contracts/fixtures/game.session.sample.json
@@ -4,7 +4,11 @@
   "status": "active",
   "profile": {
     "nativeLanguage": "en",
-    "targetLanguages": ["ko", "ja", "zh"],
+    "targetLanguages": [
+      "ko",
+      "ja",
+      "zh"
+    ],
     "proficiency": {
       "ko": "beginner",
       "ja": "none",
@@ -17,15 +21,24 @@
   "activeSceneId": "food_street_hangout_intro",
   "activeSceneSessionId": "scene_sess_demo_001_001",
   "activeObjective": {
-    "objectiveId": "ko_food_l2_001",
+    "objectiveId": "ko-vocab-food-items",
     "lang": "ko",
     "mode": "hangout",
     "cityId": "seoul",
     "locationId": "food_street",
     "objectiveCategory": "vocabulary",
-    "objectiveNodeId": "objective:ko_food_l2_001",
-    "targetNodeIds": ["target:메뉴", "target:주문", "target:맵다"],
-    "summary": "Order street food politely in Korean."
+    "objectiveNodeId": "objective:ko-vocab-food-items",
+    "targetNodeIds": [
+      "target:메뉴",
+      "target:주문",
+      "target:맵다"
+    ],
+    "summary": "Order street food politely in Korean.",
+    "canonicalObjectiveId": "ko-vocab-food-items",
+    "legacyObjectiveId": "ko_food_l2_001",
+    "objectiveAliasIds": [
+      "ko_food_l2_001"
+    ]
   },
   "progression": {
     "xp": 110,
@@ -40,7 +53,9 @@
     "masteryTier": 1
   },
   "unlocks": {
-    "locationIds": ["food_street"],
+    "locationIds": [
+      "food_street"
+    ],
     "missionIds": [],
     "rewardIds": []
   },
@@ -48,7 +63,7 @@
   "availableActions": [
     "Start hangout validation",
     "Review personalized learn targets",
-    "Practice KO objective ko_food_l2_001"
+    "Practice KO objective ko-vocab-food-items"
   ],
   "resumeSource": "new_session",
   "activeCheckpointId": "ckpt_sess_demo_001_intro",

--- a/packages/contracts/fixtures/game.start-or-resume.sample.json
+++ b/packages/contracts/fixtures/game.start-or-resume.sample.json
@@ -7,7 +7,11 @@
   "tongPrompt": "tong.system.food_street_intro.v1",
   "profile": {
     "nativeLanguage": "en",
-    "targetLanguages": ["ko", "ja", "zh"],
+    "targetLanguages": [
+      "ko",
+      "ja",
+      "zh"
+    ],
     "proficiency": {
       "ko": "beginner",
       "ja": "none",
@@ -23,7 +27,7 @@
   "actions": [
     "Start hangout validation",
     "Review personalized learn targets",
-    "Practice KO objective ko_food_l2_001"
+    "Practice KO objective ko-vocab-food-items"
   ],
   "resumeSource": "new_session",
   "gameSession": {
@@ -32,7 +36,11 @@
     "status": "active",
     "profile": {
       "nativeLanguage": "en",
-      "targetLanguages": ["ko", "ja", "zh"],
+      "targetLanguages": [
+        "ko",
+        "ja",
+        "zh"
+      ],
       "proficiency": {
         "ko": "beginner",
         "ja": "none",
@@ -45,15 +53,24 @@
     "activeSceneId": "food_street_hangout_intro",
     "activeSceneSessionId": "scene_sess_demo_001_001",
     "activeObjective": {
-      "objectiveId": "ko_food_l2_001",
+      "objectiveId": "ko-vocab-food-items",
       "lang": "ko",
       "mode": "hangout",
       "cityId": "seoul",
       "locationId": "food_street",
       "objectiveCategory": "vocabulary",
-      "objectiveNodeId": "objective:ko_food_l2_001",
-      "targetNodeIds": ["target:메뉴", "target:주문", "target:맵다"],
-      "summary": "Order street food politely in Korean."
+      "objectiveNodeId": "objective:ko-vocab-food-items",
+      "targetNodeIds": [
+        "target:메뉴",
+        "target:주문",
+        "target:맵다"
+      ],
+      "summary": "Order street food politely in Korean.",
+      "canonicalObjectiveId": "ko-vocab-food-items",
+      "legacyObjectiveId": "ko_food_l2_001",
+      "objectiveAliasIds": [
+        "ko_food_l2_001"
+      ]
     },
     "progression": {
       "xp": 110,
@@ -68,7 +85,9 @@
       "masteryTier": 1
     },
     "unlocks": {
-      "locationIds": ["food_street"],
+      "locationIds": [
+        "food_street"
+      ],
       "missionIds": [],
       "rewardIds": []
     },
@@ -76,7 +95,7 @@
     "availableActions": [
       "Start hangout validation",
       "Review personalized learn targets",
-      "Practice KO objective ko_food_l2_001"
+      "Practice KO objective ko-vocab-food-items"
     ],
     "resumeSource": "new_session",
     "activeCheckpointId": "ckpt_sess_demo_001_intro",
@@ -91,15 +110,24 @@
     "locationId": "food_street",
     "mode": "hangout",
     "objective": {
-      "objectiveId": "ko_food_l2_001",
+      "objectiveId": "ko-vocab-food-items",
       "lang": "ko",
       "mode": "hangout",
       "cityId": "seoul",
       "locationId": "food_street",
       "objectiveCategory": "vocabulary",
-      "objectiveNodeId": "objective:ko_food_l2_001",
-      "targetNodeIds": ["target:메뉴", "target:주문", "target:맵다"],
-      "summary": "Order street food politely in Korean."
+      "objectiveNodeId": "objective:ko-vocab-food-items",
+      "targetNodeIds": [
+        "target:메뉴",
+        "target:주문",
+        "target:맵다"
+      ],
+      "summary": "Order street food politely in Korean.",
+      "canonicalObjectiveId": "ko-vocab-food-items",
+      "legacyObjectiveId": "ko_food_l2_001",
+      "objectiveAliasIds": [
+        "ko_food_l2_001"
+      ]
     },
     "phase": "intro",
     "turn": 1,
@@ -144,15 +172,24 @@
     "locationId": "food_street",
     "mode": "hangout",
     "objective": {
-      "objectiveId": "ko_food_l2_001",
+      "objectiveId": "ko-vocab-food-items",
       "lang": "ko",
       "mode": "hangout",
       "cityId": "seoul",
       "locationId": "food_street",
       "objectiveCategory": "vocabulary",
-      "objectiveNodeId": "objective:ko_food_l2_001",
-      "targetNodeIds": ["target:메뉴", "target:주문", "target:맵다"],
-      "summary": "Resume from the current safe intro boundary."
+      "objectiveNodeId": "objective:ko-vocab-food-items",
+      "targetNodeIds": [
+        "target:메뉴",
+        "target:주문",
+        "target:맵다"
+      ],
+      "summary": "Resume from the current safe intro boundary.",
+      "canonicalObjectiveId": "ko-vocab-food-items",
+      "legacyObjectiveId": "ko_food_l2_001",
+      "objectiveAliasIds": [
+        "ko_food_l2_001"
+      ]
     },
     "phase": "intro",
     "turn": 1,
@@ -171,7 +208,9 @@
       "masteryTier": 1
     },
     "unlocks": {
-      "locationIds": ["food_street"],
+      "locationIds": [
+        "food_street"
+      ],
       "missionIds": [],
       "rewardIds": []
     },
@@ -201,15 +240,24 @@
       "locationId": "food_street",
       "mode": "hangout",
       "objective": {
-        "objectiveId": "ko_food_l2_001",
+        "objectiveId": "ko-vocab-food-items",
         "lang": "ko",
         "mode": "hangout",
         "cityId": "seoul",
         "locationId": "food_street",
         "objectiveCategory": "vocabulary",
-        "objectiveNodeId": "objective:ko_food_l2_001",
-        "targetNodeIds": ["target:메뉴", "target:주문", "target:맵다"],
-        "summary": "QA-only seed for deterministic review and proof capture."
+        "objectiveNodeId": "objective:ko-vocab-food-items",
+        "targetNodeIds": [
+          "target:메뉴",
+          "target:주문",
+          "target:맵다"
+        ],
+        "summary": "QA-only seed for deterministic review and proof capture.",
+        "canonicalObjectiveId": "ko-vocab-food-items",
+        "legacyObjectiveId": "ko_food_l2_001",
+        "objectiveAliasIds": [
+          "ko_food_l2_001"
+        ]
       },
       "phase": "review",
       "turn": 4,
@@ -222,7 +270,10 @@
         "state": {
           "targetChar": "뉴",
           "remainingLives": 2,
-          "boardPieces": ["ㅁ", "ㅠ"],
+          "boardPieces": [
+            "ㅁ",
+            "ㅠ"
+          ],
           "requiredMatches": 1
         }
       },

--- a/packages/contracts/fixtures/learn.sessions.sample.json
+++ b/packages/contracts/fixtures/learn.sessions.sample.json
@@ -3,20 +3,30 @@
     {
       "learnSessionId": "learn_101",
       "title": "Food Street L2 Drill",
-      "objectiveId": "ko_food_l2_001",
+      "objectiveId": "ko-vocab-food-items",
       "city": "seoul",
       "lang": "ko",
       "uiTheme": "kakao_like",
-      "lastMessageAt": "2026-02-28T11:20:00.000Z"
+      "lastMessageAt": "2026-02-28T11:20:00.000Z",
+      "canonicalObjectiveId": "ko-vocab-food-items",
+      "legacyObjectiveId": "ko_food_l2_001",
+      "objectiveAliasIds": [
+        "ko_food_l2_001"
+      ]
     },
     {
       "learnSessionId": "learn_087",
       "title": "Pronunciation Warmup",
-      "objectiveId": "ko_food_l1_004",
+      "objectiveId": "ko-pron-food-words",
       "city": "seoul",
       "lang": "ko",
       "uiTheme": "kakao_like",
-      "lastMessageAt": "2026-02-27T10:10:00.000Z"
+      "lastMessageAt": "2026-02-27T10:10:00.000Z",
+      "canonicalObjectiveId": "ko-pron-food-words",
+      "legacyObjectiveId": "ko_food_l1_004",
+      "objectiveAliasIds": [
+        "ko_food_l1_004"
+      ]
     }
   ]
 }

--- a/packages/contracts/fixtures/objectives.next.sample.json
+++ b/packages/contracts/fixtures/objectives.next.sample.json
@@ -1,10 +1,10 @@
 {
-  "objectiveId": "ko_food_l2_001",
+  "objectiveId": "ko-vocab-food-items",
   "level": 2,
   "mode": "hangout",
   "lang": "ko",
   "objectiveGraph": {
-    "objectiveNodeId": "objective:ko_food_l2_001",
+    "objectiveNodeId": "objective:ko-vocab-food-items",
     "cityId": "seoul",
     "locationId": "food_street",
     "objectiveCategory": "vocabulary",
@@ -14,31 +14,56 @@
       "target:맵다"
     ],
     "prerequisiteObjectiveIds": [
-      "ko_food_l1_001"
+      "ko-pron-food-words"
     ],
     "source": "knowledge_graph"
   },
   "coreTargets": {
-    "vocabulary": ["메뉴", "주문", "맵다"],
-    "grammar": ["-고 싶어요", "-주세요"],
-    "sentenceStructures": ["N + 주세요", "N이/가 + adjective"]
+    "vocabulary": [
+      "메뉴",
+      "주문",
+      "맵다"
+    ],
+    "grammar": [
+      "-고 싶어요",
+      "-주세요"
+    ],
+    "sentenceStructures": [
+      "N + 주세요",
+      "N이/가 + adjective"
+    ]
   },
   "personalizedTargets": [
     {
       "lemma": "무대",
       "source": "youtube",
-      "linkedNodeIds": ["overlay:youtube:performance-energy", "target:무대"]
+      "linkedNodeIds": [
+        "overlay:youtube:performance-energy",
+        "target:무대"
+      ]
     },
     {
       "lemma": "연습",
       "source": "spotify",
-      "linkedNodeIds": ["overlay:spotify:practice-studio", "target:연습"]
+      "linkedNodeIds": [
+        "overlay:spotify:practice-studio",
+        "target:연습"
+      ]
     }
   ],
   "completionCriteria": {
     "requiredTurns": 4,
     "requiredAccuracy": 0.75,
     "minEvidenceEvents": 3,
-    "acceptedEvidenceModes": ["learn", "hangout", "mission"]
-  }
+    "acceptedEvidenceModes": [
+      "learn",
+      "hangout",
+      "mission"
+    ]
+  },
+  "canonicalObjectiveId": "ko-vocab-food-items",
+  "legacyObjectiveId": "ko_food_l2_001",
+  "objectiveAliasIds": [
+    "ko_food_l2_001"
+  ]
 }

--- a/packages/contracts/fixtures/planner.lesson-context.sample.json
+++ b/packages/contracts/fixtures/planner.lesson-context.sample.json
@@ -213,19 +213,34 @@
   "plannerInput": {
     "objectiveCandidates": [
       {
-        "objectiveId": "ko_food_l2_001",
+        "objectiveId": "ko-vocab-food-items",
         "reason": "High food-ordering coverage from recent consumption",
-        "confidence": 0.92
+        "confidence": 0.92,
+        "canonicalObjectiveId": "ko-vocab-food-items",
+        "legacyObjectiveId": "ko_food_l2_001",
+        "objectiveAliasIds": [
+          "ko_food_l2_001"
+        ]
       },
       {
-        "objectiveId": "zh_stage_l3_002",
+        "objectiveId": "zh-mission-stage-texting",
         "reason": "Performance-energy cluster is active in CN/KR media",
-        "confidence": 1
+        "confidence": 1,
+        "canonicalObjectiveId": "zh-mission-stage-texting",
+        "legacyObjectiveId": "zh_stage_l3_002",
+        "objectiveAliasIds": [
+          "zh_stage_l3_002"
+        ]
       },
       {
-        "objectiveId": "ja_subway_l1_001",
+        "objectiveId": "ja-vocab-subway-transfers",
         "reason": "Transit vocabulary appears in multi-source content",
-        "confidence": 0.61
+        "confidence": 0.61,
+        "canonicalObjectiveId": "ja-vocab-subway-transfers",
+        "legacyObjectiveId": "ja_subway_l1_001",
+        "objectiveAliasIds": [
+          "ja_subway_l1_001"
+        ]
       }
     ],
     "sceneCandidates": [
@@ -233,13 +248,23 @@
         "sceneId": "food_street_hangout_intro",
         "city": "seoul",
         "mode": "hangout",
-        "objectiveId": "ko_food_l2_001"
+        "objectiveId": "ko-vocab-food-items",
+        "canonicalObjectiveId": "ko-vocab-food-items",
+        "legacyObjectiveId": "ko_food_l2_001",
+        "objectiveAliasIds": [
+          "ko_food_l2_001"
+        ]
       },
       {
         "sceneId": "shanghai_texting_mission_advanced",
         "city": "shanghai",
         "mode": "hangout",
-        "objectiveId": "zh_stage_l3_002"
+        "objectiveId": "zh-mission-stage-texting",
+        "canonicalObjectiveId": "zh-mission-stage-texting",
+        "legacyObjectiveId": "zh_stage_l3_002",
+        "objectiveAliasIds": [
+          "zh_stage_l3_002"
+        ]
       }
     ],
     "exerciseCandidates": [
@@ -247,43 +272,73 @@
         "type": "targeted-drill",
         "lemma": "연습",
         "lang": "ko",
-        "objectiveId": "zh_stage_l3_002",
-        "reason": "Frequent in spotify over last 72h"
+        "objectiveId": "zh-mission-stage-texting",
+        "reason": "Frequent in spotify over last 72h",
+        "canonicalObjectiveId": "zh-mission-stage-texting",
+        "legacyObjectiveId": "zh_stage_l3_002",
+        "objectiveAliasIds": [
+          "zh_stage_l3_002"
+        ]
       },
       {
         "type": "targeted-drill",
         "lemma": "무대",
         "lang": "ko",
-        "objectiveId": "zh_stage_l3_002",
-        "reason": "Frequent in spotify over last 72h"
+        "objectiveId": "zh-mission-stage-texting",
+        "reason": "Frequent in spotify over last 72h",
+        "canonicalObjectiveId": "zh-mission-stage-texting",
+        "legacyObjectiveId": "zh_stage_l3_002",
+        "objectiveAliasIds": [
+          "zh_stage_l3_002"
+        ]
       },
       {
         "type": "targeted-drill",
         "lemma": "주문",
         "lang": "ko",
-        "objectiveId": "ko_food_l2_001",
-        "reason": "Frequent in youtube over last 72h"
+        "objectiveId": "ko-vocab-food-items",
+        "reason": "Frequent in youtube over last 72h",
+        "canonicalObjectiveId": "ko-vocab-food-items",
+        "legacyObjectiveId": "ko_food_l2_001",
+        "objectiveAliasIds": [
+          "ko_food_l2_001"
+        ]
       },
       {
         "type": "targeted-drill",
         "lemma": "subway",
         "lang": "en",
-        "objectiveId": "ja_subway_l1_001",
-        "reason": "Frequent in spotify over last 72h"
+        "objectiveId": "ja-vocab-subway-transfers",
+        "reason": "Frequent in spotify over last 72h",
+        "canonicalObjectiveId": "ja-vocab-subway-transfers",
+        "legacyObjectiveId": "ja_subway_l1_001",
+        "objectiveAliasIds": [
+          "ja_subway_l1_001"
+        ]
       },
       {
         "type": "targeted-drill",
         "lemma": "station",
         "lang": "en",
-        "objectiveId": "ja_subway_l1_001",
-        "reason": "Frequent in spotify over last 72h"
+        "objectiveId": "ja-vocab-subway-transfers",
+        "reason": "Frequent in spotify over last 72h",
+        "canonicalObjectiveId": "ja-vocab-subway-transfers",
+        "legacyObjectiveId": "ja_subway_l1_001",
+        "objectiveAliasIds": [
+          "ja_subway_l1_001"
+        ]
       },
       {
         "type": "targeted-drill",
         "lemma": "메뉴",
         "lang": "ko",
-        "objectiveId": "ko_food_l2_001",
-        "reason": "Frequent in youtube over last 72h"
+        "objectiveId": "ko-vocab-food-items",
+        "reason": "Frequent in youtube over last 72h",
+        "canonicalObjectiveId": "ko-vocab-food-items",
+        "legacyObjectiveId": "ko_food_l2_001",
+        "objectiveAliasIds": [
+          "ko_food_l2_001"
+        ]
       }
     ]
   }

--- a/packages/contracts/fixtures/scenario.seed.review-ready.sample.json
+++ b/packages/contracts/fixtures/scenario.seed.review-ready.sample.json
@@ -17,15 +17,24 @@
   "locationId": "food_street",
   "mode": "hangout",
   "objective": {
-    "objectiveId": "ko_food_l2_001",
+    "objectiveId": "ko-vocab-food-items",
     "lang": "ko",
     "mode": "hangout",
     "cityId": "seoul",
     "locationId": "food_street",
     "objectiveCategory": "vocabulary",
-    "objectiveNodeId": "objective:ko_food_l2_001",
-    "targetNodeIds": ["target:메뉴", "target:주문", "target:맵다"],
-    "summary": "QA-only seed for deterministic review and proof capture."
+    "objectiveNodeId": "objective:ko-vocab-food-items",
+    "targetNodeIds": [
+      "target:메뉴",
+      "target:주문",
+      "target:맵다"
+    ],
+    "summary": "QA-only seed for deterministic review and proof capture.",
+    "canonicalObjectiveId": "ko-vocab-food-items",
+    "legacyObjectiveId": "ko_food_l2_001",
+    "objectiveAliasIds": [
+      "ko_food_l2_001"
+    ]
   },
   "phase": "review",
   "turn": 4,
@@ -38,7 +47,10 @@
     "state": {
       "targetChar": "뉴",
       "remainingLives": 2,
-      "boardPieces": ["ㅁ", "ㅠ"],
+      "boardPieces": [
+        "ㅁ",
+        "ㅠ"
+      ],
       "requiredMatches": 1
     }
   },

--- a/packages/contracts/fixtures/scene.session.sample.json
+++ b/packages/contracts/fixtures/scene.session.sample.json
@@ -6,15 +6,24 @@
   "locationId": "food_street",
   "mode": "hangout",
   "objective": {
-    "objectiveId": "ko_food_l2_001",
+    "objectiveId": "ko-vocab-food-items",
     "lang": "ko",
     "mode": "hangout",
     "cityId": "seoul",
     "locationId": "food_street",
     "objectiveCategory": "vocabulary",
-    "objectiveNodeId": "objective:ko_food_l2_001",
-    "targetNodeIds": ["target:메뉴", "target:주문", "target:맵다"],
-    "summary": "Order street food politely in Korean."
+    "objectiveNodeId": "objective:ko-vocab-food-items",
+    "targetNodeIds": [
+      "target:메뉴",
+      "target:주문",
+      "target:맵다"
+    ],
+    "summary": "Order street food politely in Korean.",
+    "canonicalObjectiveId": "ko-vocab-food-items",
+    "legacyObjectiveId": "ko_food_l2_001",
+    "objectiveAliasIds": [
+      "ko_food_l2_001"
+    ]
   },
   "phase": "intro",
   "turn": 1,

--- a/packages/contracts/fixtures/tools.invoke.sample.json
+++ b/packages/contracts/fixtures/tools.invoke.sample.json
@@ -8,8 +8,15 @@
       {
         "clusterId": "food-ordering",
         "label": "Food Ordering",
-        "keywords": ["주문", "메뉴", "맵다"],
-        "topTerms": ["주문", "메뉴"]
+        "keywords": [
+          "주문",
+          "메뉴",
+          "맵다"
+        ],
+        "topTerms": [
+          "주문",
+          "메뉴"
+        ]
       }
     ],
     "items": [
@@ -22,12 +29,20 @@
         "clusterId": "food-ordering",
         "orthographyFeatures": {
           "scriptType": "hangul",
-          "syllables": ["주", "문"]
+          "syllables": [
+            "주",
+            "문"
+          ]
         },
         "objectiveLinks": [
           {
-            "objectiveId": "ko_food_l2_001",
-            "reason": "High utility in next hangout"
+            "objectiveId": "ko-vocab-food-items",
+            "reason": "High utility in next hangout",
+            "canonicalObjectiveId": "ko-vocab-food-items",
+            "legacyObjectiveId": "ko_food_l2_001",
+            "objectiveAliasIds": [
+              "ko_food_l2_001"
+            ]
           }
         ]
       }

--- a/packages/contracts/fixtures/vocab.insights.sample.json
+++ b/packages/contracts/fixtures/vocab.insights.sample.json
@@ -59,8 +59,13 @@
       },
       "objectiveLinks": [
         {
-          "objectiveId": "zh_stage_l3_002",
-          "reason": "Supports Shanghai advanced texting mission vocabulary"
+          "objectiveId": "zh-mission-stage-texting",
+          "reason": "Supports Shanghai advanced texting mission vocabulary",
+          "canonicalObjectiveId": "zh-mission-stage-texting",
+          "legacyObjectiveId": "zh_stage_l3_002",
+          "objectiveAliasIds": [
+            "zh_stage_l3_002"
+          ]
         }
       ]
     },
@@ -80,8 +85,13 @@
       },
       "objectiveLinks": [
         {
-          "objectiveId": "ko_food_l2_001",
-          "reason": "High utility in next food-location hangout"
+          "objectiveId": "ko-vocab-food-items",
+          "reason": "High utility in next food-location hangout",
+          "canonicalObjectiveId": "ko-vocab-food-items",
+          "legacyObjectiveId": "ko_food_l2_001",
+          "objectiveAliasIds": [
+            "ko_food_l2_001"
+          ]
         }
       ]
     },
@@ -101,8 +111,13 @@
       },
       "objectiveLinks": [
         {
-          "objectiveId": "zh_stage_l3_002",
-          "reason": "Supports Shanghai advanced texting mission vocabulary"
+          "objectiveId": "zh-mission-stage-texting",
+          "reason": "Supports Shanghai advanced texting mission vocabulary",
+          "canonicalObjectiveId": "zh-mission-stage-texting",
+          "legacyObjectiveId": "zh_stage_l3_002",
+          "objectiveAliasIds": [
+            "zh_stage_l3_002"
+          ]
         }
       ]
     },
@@ -122,8 +137,13 @@
       },
       "objectiveLinks": [
         {
-          "objectiveId": "ko_food_l2_001",
-          "reason": "High utility in next food-location hangout"
+          "objectiveId": "ko-vocab-food-items",
+          "reason": "High utility in next food-location hangout",
+          "canonicalObjectiveId": "ko-vocab-food-items",
+          "legacyObjectiveId": "ko_food_l2_001",
+          "objectiveAliasIds": [
+            "ko_food_l2_001"
+          ]
         }
       ]
     },
@@ -139,8 +159,13 @@
       },
       "objectiveLinks": [
         {
-          "objectiveId": "ja_subway_l1_001",
-          "reason": "Improves route and transfer conversation readiness"
+          "objectiveId": "ja-vocab-subway-transfers",
+          "reason": "Improves route and transfer conversation readiness",
+          "canonicalObjectiveId": "ja-vocab-subway-transfers",
+          "legacyObjectiveId": "ja_subway_l1_001",
+          "objectiveAliasIds": [
+            "ja_subway_l1_001"
+          ]
         }
       ]
     },
@@ -156,8 +181,13 @@
       },
       "objectiveLinks": [
         {
-          "objectiveId": "ja_subway_l1_001",
-          "reason": "Improves route and transfer conversation readiness"
+          "objectiveId": "ja-vocab-subway-transfers",
+          "reason": "Improves route and transfer conversation readiness",
+          "canonicalObjectiveId": "ja-vocab-subway-transfers",
+          "legacyObjectiveId": "ja_subway_l1_001",
+          "objectiveAliasIds": [
+            "ja_subway_l1_001"
+          ]
         }
       ]
     },
@@ -179,8 +209,13 @@
       },
       "objectiveLinks": [
         {
-          "objectiveId": "zh_stage_l3_002",
-          "reason": "Supports Shanghai advanced texting mission vocabulary"
+          "objectiveId": "zh-mission-stage-texting",
+          "reason": "Supports Shanghai advanced texting mission vocabulary",
+          "canonicalObjectiveId": "zh-mission-stage-texting",
+          "legacyObjectiveId": "zh_stage_l3_002",
+          "objectiveAliasIds": [
+            "zh_stage_l3_002"
+          ]
         }
       ]
     },
@@ -202,8 +237,13 @@
       },
       "objectiveLinks": [
         {
-          "objectiveId": "zh_stage_l3_002",
-          "reason": "Supports Shanghai advanced texting mission vocabulary"
+          "objectiveId": "zh-mission-stage-texting",
+          "reason": "Supports Shanghai advanced texting mission vocabulary",
+          "canonicalObjectiveId": "zh-mission-stage-texting",
+          "legacyObjectiveId": "zh_stage_l3_002",
+          "objectiveAliasIds": [
+            "zh_stage_l3_002"
+          ]
         }
       ]
     },
@@ -220,8 +260,13 @@
       },
       "objectiveLinks": [
         {
-          "objectiveId": "zh_stage_l3_002",
-          "reason": "Strengthens Mandarin mission vocabulary recall"
+          "objectiveId": "zh-mission-stage-texting",
+          "reason": "Strengthens Mandarin mission vocabulary recall",
+          "canonicalObjectiveId": "zh-mission-stage-texting",
+          "legacyObjectiveId": "zh_stage_l3_002",
+          "objectiveAliasIds": [
+            "zh_stage_l3_002"
+          ]
         }
       ]
     },
@@ -241,8 +286,13 @@
       },
       "objectiveLinks": [
         {
-          "objectiveId": "ko_food_l2_001",
-          "reason": "High utility in next food-location hangout"
+          "objectiveId": "ko-vocab-food-items",
+          "reason": "High utility in next food-location hangout",
+          "canonicalObjectiveId": "ko-vocab-food-items",
+          "legacyObjectiveId": "ko_food_l2_001",
+          "objectiveAliasIds": [
+            "ko_food_l2_001"
+          ]
         }
       ]
     },
@@ -262,8 +312,13 @@
       },
       "objectiveLinks": [
         {
-          "objectiveId": "ko_food_l2_001",
-          "reason": "High utility in next food-location hangout"
+          "objectiveId": "ko-vocab-food-items",
+          "reason": "High utility in next food-location hangout",
+          "canonicalObjectiveId": "ko-vocab-food-items",
+          "legacyObjectiveId": "ko_food_l2_001",
+          "objectiveAliasIds": [
+            "ko_food_l2_001"
+          ]
         }
       ]
     },
@@ -283,8 +338,13 @@
       },
       "objectiveLinks": [
         {
-          "objectiveId": "ko_food_l2_001",
-          "reason": "High utility in next food-location hangout"
+          "objectiveId": "ko-vocab-food-items",
+          "reason": "High utility in next food-location hangout",
+          "canonicalObjectiveId": "ko-vocab-food-items",
+          "legacyObjectiveId": "ko_food_l2_001",
+          "objectiveAliasIds": [
+            "ko_food_l2_001"
+          ]
         }
       ]
     },
@@ -305,8 +365,13 @@
       },
       "objectiveLinks": [
         {
-          "objectiveId": "ko_food_l2_001",
-          "reason": "Reinforces Korean phrase utility for food-street scenes"
+          "objectiveId": "ko-vocab-food-items",
+          "reason": "Reinforces Korean phrase utility for food-street scenes",
+          "canonicalObjectiveId": "ko-vocab-food-items",
+          "legacyObjectiveId": "ko_food_l2_001",
+          "objectiveAliasIds": [
+            "ko_food_l2_001"
+          ]
         }
       ]
     },
@@ -325,8 +390,13 @@
       },
       "objectiveLinks": [
         {
-          "objectiveId": "ko_food_l2_001",
-          "reason": "Reinforces Korean phrase utility for food-street scenes"
+          "objectiveId": "ko-vocab-food-items",
+          "reason": "Reinforces Korean phrase utility for food-street scenes",
+          "canonicalObjectiveId": "ko-vocab-food-items",
+          "legacyObjectiveId": "ko_food_l2_001",
+          "objectiveAliasIds": [
+            "ko_food_l2_001"
+          ]
         }
       ]
     },
@@ -342,8 +412,13 @@
       },
       "objectiveLinks": [
         {
-          "objectiveId": "ja_subway_l1_001",
-          "reason": "Improves route and transfer conversation readiness"
+          "objectiveId": "ja-vocab-subway-transfers",
+          "reason": "Improves route and transfer conversation readiness",
+          "canonicalObjectiveId": "ja-vocab-subway-transfers",
+          "legacyObjectiveId": "ja_subway_l1_001",
+          "objectiveAliasIds": [
+            "ja_subway_l1_001"
+          ]
         }
       ]
     },
@@ -359,8 +434,13 @@
       },
       "objectiveLinks": [
         {
-          "objectiveId": "ja_subway_l1_001",
-          "reason": "Useful bridge terms for subway objective setup"
+          "objectiveId": "ja-vocab-subway-transfers",
+          "reason": "Useful bridge terms for subway objective setup",
+          "canonicalObjectiveId": "ja-vocab-subway-transfers",
+          "legacyObjectiveId": "ja_subway_l1_001",
+          "objectiveAliasIds": [
+            "ja_subway_l1_001"
+          ]
         }
       ]
     },
@@ -376,8 +456,13 @@
       },
       "objectiveLinks": [
         {
-          "objectiveId": "ja_subway_l1_001",
-          "reason": "Useful bridge terms for subway objective setup"
+          "objectiveId": "ja-vocab-subway-transfers",
+          "reason": "Useful bridge terms for subway objective setup",
+          "canonicalObjectiveId": "ja-vocab-subway-transfers",
+          "legacyObjectiveId": "ja_subway_l1_001",
+          "objectiveAliasIds": [
+            "ja_subway_l1_001"
+          ]
         }
       ]
     }

--- a/packages/contracts/objective-catalog.sample.json
+++ b/packages/contracts/objective-catalog.sample.json
@@ -4,36 +4,70 @@
   "location": "food_street",
   "objectives": [
     {
-      "objectiveId": "ko_food_l0_001",
+      "objectiveId": "ko-script-menu-reading",
       "level": 0,
       "mode": "learn",
       "coreTargets": {
-        "vocabulary": ["떡볶이", "김밥", "메뉴"],
-        "grammar": ["topic marker 은/는"],
-        "sentenceStructures": ["N은/는 N이다"]
+        "vocabulary": [
+          "떡볶이",
+          "김밥",
+          "메뉴"
+        ],
+        "grammar": [
+          "topic marker 은/는"
+        ],
+        "sentenceStructures": [
+          "N은/는 N이다"
+        ]
       },
       "completionCriteria": {
         "requiredTurns": 3,
         "requiredAccuracy": 0.7
-      }
+      },
+      "canonicalObjectiveId": "ko-script-menu-reading",
+      "legacyObjectiveId": "ko_food_l0_001",
+      "objectiveAliasIds": [
+        "ko_food_l0_001"
+      ]
     },
     {
-      "objectiveId": "ko_food_l2_001",
+      "objectiveId": "ko-vocab-food-items",
       "level": 2,
       "mode": "hangout",
       "coreTargets": {
-        "vocabulary": ["주문", "맵다", "포장"],
-        "grammar": ["-고 싶어요", "-주세요"],
-        "sentenceStructures": ["N 주세요", "N이/가 adjective"]
+        "vocabulary": [
+          "주문",
+          "맵다",
+          "포장"
+        ],
+        "grammar": [
+          "-고 싶어요",
+          "-주세요"
+        ],
+        "sentenceStructures": [
+          "N 주세요",
+          "N이/가 adjective"
+        ]
       },
       "personalizedTargets": [
-        { "source": "youtube", "lemma": "무대" },
-        { "source": "spotify", "lemma": "연습" }
+        {
+          "source": "youtube",
+          "lemma": "무대"
+        },
+        {
+          "source": "spotify",
+          "lemma": "연습"
+        }
       ],
       "completionCriteria": {
         "requiredTurns": 4,
         "requiredAccuracy": 0.75
-      }
+      },
+      "canonicalObjectiveId": "ko-vocab-food-items",
+      "legacyObjectiveId": "ko_food_l2_001",
+      "objectiveAliasIds": [
+        "ko_food_l2_001"
+      ]
     }
   ]
 }

--- a/packages/contracts/objective-identity-map.sample.json
+++ b/packages/contracts/objective-identity-map.sample.json
@@ -1,0 +1,54 @@
+{
+  "version": "2026-03-20",
+  "sourceOfTruth": "canonical_graph_pack",
+  "objectives": [
+    {
+      "canonicalObjectiveId": "ko-script-menu-reading",
+      "legacyObjectiveIds": ["ko_food_l0_001"],
+      "lang": "ko",
+      "cityId": "seoul",
+      "locationId": "food_street",
+      "objectiveCategory": "script"
+    },
+    {
+      "canonicalObjectiveId": "ko-pron-food-words",
+      "legacyObjectiveIds": ["ko_food_l1_004"],
+      "lang": "ko",
+      "cityId": "seoul",
+      "locationId": "food_street",
+      "objectiveCategory": "pronunciation"
+    },
+    {
+      "canonicalObjectiveId": "ko-vocab-food-items",
+      "legacyObjectiveIds": ["ko_food_l2_001"],
+      "lang": "ko",
+      "cityId": "seoul",
+      "locationId": "food_street",
+      "objectiveCategory": "vocabulary"
+    },
+    {
+      "canonicalObjectiveId": "ja-vocab-subway-transfers",
+      "legacyObjectiveIds": ["ja_subway_l1_001"],
+      "lang": "ja",
+      "cityId": "tokyo",
+      "locationId": "subway_hub",
+      "objectiveCategory": "vocabulary"
+    },
+    {
+      "canonicalObjectiveId": "zh-mission-stage-texting",
+      "legacyObjectiveIds": ["zh_stage_l3_002"],
+      "lang": "zh",
+      "cityId": "shanghai",
+      "locationId": "practice_studio",
+      "objectiveCategory": "conversation"
+    },
+    {
+      "canonicalObjectiveId": "ko-vocab-city-social",
+      "legacyObjectiveIds": ["ko_city_l2_003"],
+      "lang": "ko",
+      "cityId": "seoul",
+      "locationId": "subway_hub",
+      "objectiveCategory": "conversation"
+    }
+  ]
+}

--- a/packages/contracts/types.ts
+++ b/packages/contracts/types.ts
@@ -72,6 +72,9 @@ export interface VocabInsightItem {
   orthographyFeatures: Record<string, unknown>;
   objectiveLinks: Array<{
     objectiveId: string;
+    canonicalObjectiveId?: string;
+    legacyObjectiveId?: string;
+    objectiveAliasIds?: string[];
     reason: string;
   }>;
 }
@@ -139,6 +142,9 @@ export type ScenarioSeedSource = 'qa' | 'demo' | 'dev';
 
 export interface ObjectiveDescriptor {
   objectiveId: string;
+  canonicalObjectiveId?: string;
+  legacyObjectiveId?: string;
+  objectiveAliasIds?: string[];
   lang: TargetLanguage;
   mode: SessionMode;
   cityId: GraphCityId;
@@ -317,6 +323,9 @@ export interface StartOrResumeGameResponse {
 
 export interface ObjectiveNextResponse {
   objectiveId: string;
+  canonicalObjectiveId?: string;
+  legacyObjectiveId?: string;
+  objectiveAliasIds?: string[];
   level: number;
   mode: SessionMode;
   lang: TargetLanguage;
@@ -393,6 +402,9 @@ export interface LearnSessionListItem {
   learnSessionId: string;
   title: string;
   objectiveId: string;
+  canonicalObjectiveId?: string;
+  legacyObjectiveId?: string;
+  objectiveAliasIds?: string[];
   lastMessageAt: string;
 }
 
@@ -405,6 +417,9 @@ export interface LearnSessionCreateResponse {
   mode: 'learn';
   uiTheme: 'kakao_like' | 'line_like' | 'wechat_like';
   objectiveId: string;
+  canonicalObjectiveId?: string;
+  legacyObjectiveId?: string;
+  objectiveAliasIds?: string[];
   firstMessage: {
     speaker: 'tong';
     text: string;
@@ -794,6 +809,9 @@ export interface GraphEvidenceRecordResponse {
     userId: string;
     nodeId: string;
     objectiveId: string | null;
+    canonicalObjectiveId?: string | null;
+    legacyObjectiveId?: string | null;
+    objectiveAliasIds?: string[];
     mode: 'learn' | 'hangout' | 'mission' | 'review' | 'exercise' | 'media';
     quality: number;
     occurredAtIso: string;

--- a/scripts/demo_smoke_check.mjs
+++ b/scripts/demo_smoke_check.mjs
@@ -70,6 +70,7 @@ const requiredFiles = [
   "packages/contracts/api-contract.md",
   "packages/contracts/game-loop.json",
   "packages/contracts/objective-catalog.sample.json",
+  "packages/contracts/objective-identity-map.sample.json",
   "packages/contracts/fixtures/captions.enriched.sample.json",
   "packages/contracts/fixtures/dictionary.entry.sample.json",
   "packages/contracts/fixtures/vocab.frequency.sample.json",
@@ -220,6 +221,18 @@ function assertObjectiveDescriptor(objective, label) {
     console.error(`${label} missing objectiveId`);
     process.exit(1);
   }
+  if (objective.canonicalObjectiveId !== undefined && objective.objectiveId !== objective.canonicalObjectiveId) {
+    console.error(`${label} objectiveId must equal canonicalObjectiveId when provided`);
+    process.exit(1);
+  }
+  if (objective.legacyObjectiveId !== undefined && typeof objective.legacyObjectiveId !== "string") {
+    console.error(`${label} legacyObjectiveId must be a string when present`);
+    process.exit(1);
+  }
+  if (objective.objectiveAliasIds !== undefined && !Array.isArray(objective.objectiveAliasIds)) {
+    console.error(`${label} objectiveAliasIds must be an array when present`);
+    process.exit(1);
+  }
   if (!["ko", "ja", "zh"].includes(objective.lang)) {
     console.error(`${label} has invalid lang`);
     process.exit(1);
@@ -234,6 +247,10 @@ function assertObjectiveDescriptor(objective, label) {
   }
   if (objective.targetNodeIds !== undefined && !Array.isArray(objective.targetNodeIds)) {
     console.error(`${label} targetNodeIds must be an array when present`);
+    process.exit(1);
+  }
+  if (objective.objectiveNodeId !== undefined && objective.objectiveNodeId !== `objective:${objective.objectiveId}`) {
+    console.error(`${label} objectiveNodeId must wrap the canonical objectiveId`);
     process.exit(1);
   }
 }

--- a/scripts/kg_contract_schema_check.mjs
+++ b/scripts/kg_contract_schema_check.mjs
@@ -12,9 +12,28 @@ function assert(condition, message) {
 }
 
 const objective = readJson('packages/contracts/fixtures/objectives.next.sample.json');
+const objectiveIdentityMap = readJson('packages/contracts/objective-identity-map.sample.json');
+
+const canonicalByLegacy = new Map();
+for (const identity of objectiveIdentityMap.objectives ?? []) {
+  for (const legacyId of identity.legacyObjectiveIds ?? []) {
+    canonicalByLegacy.set(legacyId, identity.canonicalObjectiveId);
+  }
+}
+
 assert(typeof objective.lang === 'string', 'objective.lang is required');
+assert(objectiveIdentityMap.sourceOfTruth === 'canonical_graph_pack', 'objective identity map sourceOfTruth mismatch');
+assert(objective.objectiveId === objective.canonicalObjectiveId, 'objectiveId must carry the canonical objective id');
+assert(
+  objective.legacyObjectiveId && canonicalByLegacy.get(objective.legacyObjectiveId) === objective.objectiveId,
+  'objective legacyObjectiveId must resolve to the canonical objectiveId',
+);
 assert(objective.objectiveGraph?.source === 'knowledge_graph', 'objectiveGraph.source must be knowledge_graph');
 assert(Array.isArray(objective.objectiveGraph?.targetNodeIds), 'objectiveGraph.targetNodeIds must be an array');
+assert(
+  objective.objectiveGraph?.objectiveNodeId === `objective:${objective.objectiveId}`,
+  'objectiveGraph.objectiveNodeId must wrap the canonical objective id',
+);
 assert(
   Array.isArray(objective.personalizedTargets) &&
     objective.personalizedTargets.every((item) => Array.isArray(item.linkedNodeIds) && item.linkedNodeIds.length > 0),
@@ -35,8 +54,13 @@ assert(Number.isFinite(evidence.recorded), 'graph evidence response must include
 assert(Array.isArray(evidence.events), 'graph evidence response must include events');
 assert(Number.isFinite(evidence.metrics?.evidenceCount), 'graph evidence response must include metrics.evidenceCount');
 assert(
-  evidence.events.every((evt) => typeof evt.nodeId === 'string' && typeof evt.objectiveId !== 'undefined'),
-  'each graph evidence event must include nodeId and objectiveId',
+  evidence.events.every(
+    (evt) =>
+      typeof evt.nodeId === 'string' &&
+      typeof evt.objectiveId !== 'undefined' &&
+      (evt.objectiveId === null || evt.objectiveId === evt.canonicalObjectiveId || evt.canonicalObjectiveId === undefined),
+  ),
+  'each graph evidence event must include nodeId and canonical objectiveId compatibility metadata',
 );
 
 console.log('KG contract schema check passed.');

--- a/scripts/mock_api_flow_check.mjs
+++ b/scripts/mock_api_flow_check.mjs
@@ -185,9 +185,10 @@ async function run() {
   assert(Number.isFinite(objectiveKo.data?.completionCriteria?.minEvidenceEvents), 'objectiveKo.minEvidenceEvents missing');
   assertArray(objectiveKo.data?.completionCriteria?.acceptedEvidenceModes, 'objectiveKo.acceptedEvidenceModes');
   assert(
-    typeof objectiveKo.data?.objectiveId === 'string' && objectiveKo.data.objectiveId.startsWith('ko_'),
-    `objectiveKo.objectiveId should start with ko_: ${objectiveKo.data?.objectiveId}`,
+    typeof objectiveKo.data?.objectiveId === 'string' && objectiveKo.data.objectiveId.startsWith('ko-'),
+    `objectiveKo.objectiveId should start with ko-: ${objectiveKo.data?.objectiveId}`,
   );
+  assert(objectiveKo.data?.legacyObjectiveId === 'ko_food_l2_001', 'objectiveKo.legacyObjectiveId mismatch');
   logPass('/api/v1/objectives/next?lang=ko');
 
   const objectiveZh = await requestJson(
@@ -199,9 +200,10 @@ async function run() {
   assert(objectiveZh.data?.objectiveGraph?.locationId === 'practice_studio', 'objectiveZh.objectiveGraph.locationId mismatch');
   assertArray(objectiveZh.data?.coreTargets?.vocabulary, 'objectiveZh.coreTargets.vocabulary');
   assert(
-    typeof objectiveZh.data?.objectiveId === 'string' && objectiveZh.data.objectiveId.startsWith('zh_'),
-    `objectiveZh.objectiveId should start with zh_: ${objectiveZh.data?.objectiveId}`,
+    typeof objectiveZh.data?.objectiveId === 'string' && objectiveZh.data.objectiveId.startsWith('zh-'),
+    `objectiveZh.objectiveId should start with zh-: ${objectiveZh.data?.objectiveId}`,
   );
+  assert(objectiveZh.data?.legacyObjectiveId === 'zh_stage_l3_002', 'objectiveZh.legacyObjectiveId mismatch');
   logPass('/api/v1/objectives/next?lang=zh');
 
   const graphEvidence = await requestJson('/api/v1/graph/evidence', {
@@ -404,7 +406,27 @@ async function run() {
   assert(createLearn.ok, `/learn/sessions POST failed (${createLearn.status})`);
   assert(typeof createLearn.data?.learnSessionId === 'string', 'learn session create missing learnSessionId');
   assert(typeof createLearn.data?.firstMessage?.text === 'string', 'learn session create missing firstMessage');
+  assert(createLearn.data?.objectiveId === objectiveKo.data.objectiveId, 'learn session create objectiveId mismatch');
   logPass('/api/v1/learn/sessions POST');
+
+  const createDefaultLearn = await requestJson('/api/v1/learn/sessions', {
+    method: 'POST',
+    body: JSON.stringify({
+      userId,
+      city: 'seoul',
+      lang: 'ko',
+    }),
+  });
+  assert(createDefaultLearn.ok, `/learn/sessions POST default failed (${createDefaultLearn.status})`);
+  assert(
+    createDefaultLearn.data?.objectiveId === 'ko-vocab-food-items',
+    `default learn session objectiveId mismatch: ${createDefaultLearn.data?.objectiveId}`,
+  );
+  assert(
+    createDefaultLearn.data?.legacyObjectiveId === 'ko_food_l2_001',
+    `default learn session legacyObjectiveId mismatch: ${createDefaultLearn.data?.legacyObjectiveId}`,
+  );
+  logPass('/api/v1/learn/sessions POST default objective');
 
   console.log('');
   console.log('Mock flow check complete.');

--- a/scripts/mock_tool_flow_check.mjs
+++ b/scripts/mock_tool_flow_check.mjs
@@ -102,7 +102,8 @@ async function run() {
   logPass('vocab.insights.get');
 
   const objective = await invoke('objectives.next.get', { userId, mode: 'hangout', lang: 'ko' });
-  assert(typeof objective?.objectiveId === 'string' && objective.objectiveId.startsWith('ko_'), 'objective language mismatch');
+  assert(typeof objective?.objectiveId === 'string' && objective.objectiveId.startsWith('ko-'), 'objective language mismatch');
+  assert(objective?.legacyObjectiveId === 'ko_food_l2_001', 'objective legacyObjectiveId mismatch');
   assert(Array.isArray(objective?.coreTargets?.vocabulary), 'objective coreTargets.vocabulary missing');
   logPass('objectives.next.get');
 


### PR DESCRIPTION
### Motivation
- Fix drift between canonical curriculum graph node ids (e.g. `ko-vocab-food-items`) and legacy objective ids used in fixtures/APIs (e.g. `ko_food_l2_001`) by establishing a contracts-first canonical identity model. 
- Keep the canonical graph pack as the source of truth while providing an additive compatibility layer so existing fixtures and consumers do not break. 
- Make the identity model enforceable via existing contract/schema checks and demo smoke flows.

### Description
- Added a canonical objective identity map `packages/contracts/objective-identity-map.sample.json` and typed compatibility fields (`canonicalObjectiveId`, `legacyObjectiveId`, `objectiveAliasIds`) to `packages/contracts/types.ts` and relevant fixture payloads. 
- Implemented a server-side normalization helper `apps/server/src/objective-identity.mjs` and wired it into ingestion, planner, and API payloads so all emitted `objectiveId` values are canonical while preserving legacy aliases additively. 
- Updated contract fixtures and API documentation to use canonical ids (many files under `packages/contracts/fixtures/**` and `packages/contracts/*`) and tightened schema/validation checks in `scripts/kg_contract_schema_check.mjs`, `scripts/demo_smoke_check.mjs`, `scripts/mock_api_flow_check.mjs`, and `scripts/mock_tool_flow_check.mjs` to assert canonical identity + alias compatibility. 
- Added a short handoff note to `docs/handoff-notes.md` describing intent and migration approach.

### Testing
- Ran KG schema checks with `npm run test:kg-contract-schema` and `node scripts/kg_contract_schema_check.mjs`, which passed. 
- Ran graph contract validation with `npm run test:graph-contracts`, which passed. 
- Ran the demo smoke check with `npm run demo:smoke` and executed the mock server plus end-to-end mock flows: started the server (`npm --prefix apps/server run start`) and ran `node scripts/mock_api_flow_check.mjs http://localhost:8787 --strict-state` and `node scripts/mock_tool_flow_check.mjs http://localhost:8787`, all of which passed.

How to test locally
- Run `npm run test:kg-contract-schema`, `npm run test:graph-contracts`, and `npm run demo:smoke` to validate contracts and fixtures. 
- Start the mock server with `npm --prefix apps/server run start` and run `node scripts/mock_api_flow_check.mjs http://localhost:8787 --strict-state` and `node scripts/mock_tool_flow_check.mjs http://localhost:8787` to verify API/tool flows.

Remaining blockers
- None within the contracts-first / server-api scope; no client runtime/UI changes were required for this migration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd5969889c832a9dc92f5796ae6983)