### PR TITLE
Add all-city KG validator dashboard

### DIFF
--- a/apps/client/app/dashboard/page.tsx
+++ b/apps/client/app/dashboard/page.tsx
@@ -14,6 +14,9 @@ import {
 } from '@/lib/api';
 
 const STATUS_COLORS: Record<string, { bg: string; fg: string; border: string }> = {
+  foundation_authored: { bg: '#e6f7f2', fg: '#0f766e', border: '#9ed8ca' },
+  overlay_only: { bg: '#eef4ff', fg: '#294f8f', border: '#c8d8ff' },
+  missing: { bg: '#f8e7eb', fg: '#9f1239', border: '#f3c7d4' },
   locked: { bg: '#f5efe7', fg: '#8a6b53', border: '#e7d5c5' },
   available: { bg: '#fff1e8', fg: '#9b401c', border: '#f0c8b2' },
   active: { bg: '#fff1e8', fg: '#9b401c', border: '#f0c8b2' },
@@ -75,6 +78,56 @@ function ProgressBar({ value }: { value: number }) {
       />
     </div>
   );
+}
+
+const SHARED_LOCATION_ORDER = [
+  { locationId: 'food_street', label: 'Food Street' },
+  { locationId: 'cafe', label: 'Cafe' },
+  { locationId: 'convenience_store', label: 'Convenience Store' },
+  { locationId: 'subway_hub', label: 'Subway Hub' },
+  { locationId: 'practice_studio', label: 'Practice Studio' },
+] as const;
+
+type ValidatorSurfaceStatus = 'foundation_authored' | 'overlay_only' | 'preview' | 'missing';
+
+function classifyValidatorStatus(args: {
+  cityId: string;
+  locationId: string;
+  roadmapStatus?: string;
+  progress?: string;
+  authoredPack?: { cityId: string; locationId: string } | null;
+}) {
+  const progress = (args.progress || '').toLowerCase();
+  const matchesAuthoredPack =
+    args.authoredPack?.cityId === args.cityId && args.authoredPack?.locationId === args.locationId;
+
+  if (matchesAuthoredPack) {
+    return 'foundation_authored' as const;
+  }
+
+  if (progress.includes('overlay')) {
+    return 'overlay_only' as const;
+  }
+
+  if (args.roadmapStatus === 'preview') {
+    return 'preview' as const;
+  }
+
+  return 'missing' as const;
+}
+
+function validatorStatusDescription(status: ValidatorSurfaceStatus, progress: string) {
+  switch (status) {
+    case 'foundation_authored':
+      return 'Foundation-authored pack is present in the current read model.';
+    case 'overlay_only':
+      return 'Only overlay coverage is surfaced right now; no authored foundation pack is shown.';
+    case 'preview':
+      return progress || 'Preview scaffold exists, but the pack is not yet truly authored.';
+    case 'missing':
+    default:
+      return progress || 'No authored or preview pack is surfaced for this city/location yet.';
+  }
 }
 
 export default function DashboardPage() {
@@ -160,14 +213,71 @@ export default function DashboardPage() {
     [personas, personaId],
   );
 
+  const validatorCities = useMemo(() => {
+    if (!dashboard) return [];
+
+    return dashboard.worldRoadmap.map((city) => {
+      const locations = SHARED_LOCATION_ORDER.map((sharedLocation) => {
+        const roadmapLocation = city.locations.find((location) => location.locationId === sharedLocation.locationId);
+        const validatorStatus = classifyValidatorStatus({
+          cityId: city.cityId,
+          locationId: sharedLocation.locationId,
+          roadmapStatus: roadmapLocation?.status,
+          progress: roadmapLocation?.progress,
+          authoredPack: {
+            cityId: dashboard.locationSkillTree.cityId,
+            locationId: dashboard.locationSkillTree.locationId,
+          },
+        });
+
+        return {
+          locationId: sharedLocation.locationId,
+          label: sharedLocation.label,
+          validatorStatus,
+          roadmapStatus: roadmapLocation?.status || 'locked',
+          progress: roadmapLocation?.progress || 'Missing from roadmap read model.',
+          note: validatorStatusDescription(validatorStatus, roadmapLocation?.progress || ''),
+        };
+      });
+
+      return {
+        ...city,
+        validatorSummary: locations.reduce<Record<ValidatorSurfaceStatus, number>>(
+          (summary, location) => {
+            summary[location.validatorStatus] += 1;
+            return summary;
+          },
+          {
+            foundation_authored: 0,
+            overlay_only: 0,
+            preview: 0,
+            missing: 0,
+          },
+        ),
+        validatorLocations: locations,
+      };
+    });
+  }, [dashboard]);
+
+  const validatorNotes = useMemo(() => {
+    return validatorCities.flatMap((city) =>
+      city.validatorLocations.map((location) => ({
+        id: `${city.cityId}-${location.locationId}`,
+        title: `${city.label} · ${location.label}`,
+        status: location.validatorStatus,
+        note: location.note,
+      })),
+    );
+  }, [validatorCities]);
+
   return (
     <main className="app-shell">
       <header className="page-header">
         <p className="kicker">Learner Graph Dashboard</p>
         <h1 className="page-title">Foundation map + user-specific media overlays</h1>
         <p className="page-copy">
-          This view shows the curriculum graph, learner progression, K-pop/creator overlays, and the reusable agent
-          tools that can drive recommendations for lessons and hangouts.
+          This view shows the curriculum graph, learner progression, K-pop/creator overlays, and an all-city validator
+          readout that distinguishes truly authored packs from overlay-only, preview, and missing coverage.
         </p>
         <div className="nav-links">
           <Link href="/" className="nav-link">
@@ -308,6 +418,135 @@ export default function DashboardPage() {
                 </div>
               ))}
             </article>
+          </section>
+
+          <section className="card stack" style={{ marginBottom: 16 }}>
+            <div className="row" style={{ alignItems: 'flex-start' }}>
+              <div>
+                <h3>All-City Graph Validator Dashboard</h3>
+                <p>
+                  Read-model audit for Seoul, Tokyo, and Shanghai. Each location is classified from the existing
+                  roadmap, selected pack, and overlay summary without inventing new backend semantics.
+                </p>
+              </div>
+              <span className="pill">{validatorCities.length} cities</span>
+            </div>
+
+            <div className="row" style={{ flexWrap: 'wrap', justifyContent: 'flex-start' }}>
+              <StatusPill status="foundation_authored" />
+              <StatusPill status="overlay_only" />
+              <StatusPill status="preview" />
+              <StatusPill status="missing" />
+            </div>
+
+            <div className="grid grid-3">
+              {validatorCities.map((city) => (
+                <article key={`validator-${city.cityId}`} className="card stack" style={{ padding: 14 }}>
+                  <div className="row" style={{ alignItems: 'flex-start' }}>
+                    <div>
+                      <strong>{city.label}</strong>
+                      <p>
+                        {city.focus} · {city.proficiency} proficiency
+                      </p>
+                    </div>
+                    <span className="pill">{city.validatorLocations.length} locations</span>
+                  </div>
+
+                  <div className="row" style={{ flexWrap: 'wrap', justifyContent: 'flex-start' }}>
+                    {city.validatorSummary.foundation_authored > 0 && (
+                      <span className="pill">
+                        {city.validatorSummary.foundation_authored} authored
+                      </span>
+                    )}
+                    {city.validatorSummary.overlay_only > 0 && (
+                      <span className="pill">
+                        {city.validatorSummary.overlay_only} overlay-only
+                      </span>
+                    )}
+                    {city.validatorSummary.preview > 0 && (
+                      <span className="pill">
+                        {city.validatorSummary.preview} preview
+                      </span>
+                    )}
+                    {city.validatorSummary.missing > 0 && (
+                      <span className="pill">
+                        {city.validatorSummary.missing} missing
+                      </span>
+                    )}
+                  </div>
+
+                  <div className="stack" style={{ gap: 10 }}>
+                    {city.validatorLocations.map((location) => (
+                      <div
+                        key={`${city.cityId}-${location.locationId}`}
+                        style={{
+                          border: '1px solid var(--line)',
+                          borderRadius: 14,
+                          padding: 12,
+                          background: '#fffaf2',
+                        }}
+                      >
+                        <div className="row" style={{ alignItems: 'flex-start', marginBottom: 8 }}>
+                          <div>
+                            <strong>{location.label}</strong>
+                            <p>{location.note}</p>
+                          </div>
+                          <StatusPill status={location.validatorStatus} />
+                        </div>
+                        <div className="row" style={{ flexWrap: 'wrap', justifyContent: 'flex-start' }}>
+                          <span className="pill">Roadmap {location.roadmapStatus.replace(/_/g, ' ')}</span>
+                          <span className="pill">{location.locationId}</span>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </article>
+              ))}
+            </div>
+
+            <div className="grid grid-2">
+              <article className="card stack" style={{ padding: 14 }}>
+                <div className="row" style={{ alignItems: 'flex-start' }}>
+                  <div>
+                    <h3 style={{ marginBottom: 6 }}>Truly Authored Now</h3>
+                    <p>The current read model only exposes authored foundation coverage where a canonical pack is actually loaded.</p>
+                  </div>
+                  <StatusPill status="foundation_authored" />
+                </div>
+                {validatorNotes
+                  .filter((item) => item.status === 'foundation_authored' || item.status === 'overlay_only')
+                  .map((item) => (
+                    <div key={item.id} style={{ borderTop: '1px solid var(--line)', paddingTop: 10 }}>
+                      <div className="row" style={{ alignItems: 'flex-start' }}>
+                        <strong>{item.title}</strong>
+                        <StatusPill status={item.status} />
+                      </div>
+                      <p>{item.note}</p>
+                    </div>
+                  ))}
+              </article>
+
+              <article className="card stack" style={{ padding: 14 }}>
+                <div className="row" style={{ alignItems: 'flex-start' }}>
+                  <div>
+                    <h3 style={{ marginBottom: 6 }}>Still Stubbed / Not Yet Authored</h3>
+                    <p>These locations remain preview scaffolds or entirely missing in the current pack readout.</p>
+                  </div>
+                  <StatusPill status="preview" />
+                </div>
+                {validatorNotes
+                  .filter((item) => item.status === 'preview' || item.status === 'missing')
+                  .map((item) => (
+                    <div key={item.id} style={{ borderTop: '1px solid var(--line)', paddingTop: 10 }}>
+                      <div className="row" style={{ alignItems: 'flex-start' }}>
+                        <strong>{item.title}</strong>
+                        <StatusPill status={item.status} />
+                      </div>
+                      <p>{item.note}</p>
+                    </div>
+                  ))}
+              </article>
+            </div>
           </section>
 
           <section className="card stack" style={{ marginBottom: 16 }}>


### PR DESCRIPTION
### Motivation
- Provide a concise, read-model-only validation surface that shows Knowledge Graph coverage per city/location (Seoul, Tokyo, Shanghai) without changing KG semantics.
- Make it easy for reviewers and content owners to distinguish truly authored foundation packs from overlay-only, preview scaffolds, or missing coverage.

### Description
- Add classification helpers (`classifyValidatorStatus`, `validatorStatusDescription`) and a shared location order list to derive per-location status from the existing dashboard read model.
- Add an "All-City Graph Validator Dashboard" section to the existing `/dashboard` UI that displays city-level counts, per-location status pills (`foundation_authored`, `overlay_only`, `preview`, `missing`), and short notes explaining each classification.
- Keep changes additive and read-only to the graph model, using the existing `worldRoadmap` and `locationSkillTree` values rather than inventing backend data; implementation located in `apps/client/app/dashboard/page.tsx`.

### Testing
- How to test: run `npm --prefix apps/client run build` and `node scripts/dashboard_smoke_check.mjs`, then open `http://localhost:3000/dashboard` to inspect the new validator section and per-location pills.
- Automated build: `npm --prefix apps/client run build` completed successfully in a clean PR worktree.
- Smoke checks: `TONG_LOCAL_API_BASE_URL=http://127.0.0.1:8791 TONG_LOCAL_CLIENT_BASE_URL=http://127.0.0.1:3105 node scripts/dashboard_smoke_check.mjs` passed with `PASS graph personas`, `PASS graph dashboard`, `PASS graph evidence`, and `PASS dashboard hydration (text=World Roadmap)`.

### Reviewer Evidence
- Screenshot: https://runs.tong.berlayar.ai/qa-runs/functional-qa/erniesg-tong-105/functional-qa-validate-issue-20260320T155736Z-erniesg-tong-105/screenshots/dashboard-validator-smoke.png
- Summary: https://runs.tong.berlayar.ai/qa-runs/functional-qa/erniesg-tong-105/functional-qa-validate-issue-20260320T155736Z-erniesg-tong-105/summary.md
- Manifest: https://runs.tong.berlayar.ai/qa-runs/functional-qa/erniesg-tong-105/functional-qa-validate-issue-20260320T155736Z-erniesg-tong-105/manifest.json

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd6270a8f0832ab09da9182922179a)