### PR TITLE
fix: harden QA publish request handling

### DIFF
--- a/.github/workflows/codex-headless-pr.yml
+++ b/.github/workflows/codex-headless-pr.yml
@@ -98,31 +98,25 @@ jobs:
           sandbox: workspace-write
 
       - name: Write PR body
-        run: |
-          cat > "$RUNNER_TEMP/pr-body.md" <<'EOF'
-          ${{ inputs.pr_body }}
-
-          ## QA Publish Request
-
-          ```json
-          {
-            "issue_ref": "${{ inputs.issue_ref }}",
-            "run_dir": "",
-            "route": "${{ inputs.route }}",
-            "scenario_seed": "${{ inputs.scenario_seed }}",
-            "checkpoint_id": "${{ inputs.checkpoint_id }}",
-            "qa_recipe": "${{ inputs.qa_recipe }}",
-            "no_auto_evidence_upload": ${{ inputs.no_auto_evidence_upload }}
-          }
-          ```
-          EOF
+        id: pr_body
+        env:
+          INPUT_PR_TITLE: ${{ inputs.pr_title }}
+          INPUT_BRANCH: ${{ inputs.branch }}
+          INPUT_PR_BODY: ${{ inputs.pr_body }}
+          INPUT_ISSUE_REF: ${{ inputs.issue_ref }}
+          INPUT_ROUTE: ${{ inputs.route }}
+          INPUT_SCENARIO_SEED: ${{ inputs.scenario_seed }}
+          INPUT_CHECKPOINT_ID: ${{ inputs.checkpoint_id }}
+          INPUT_QA_RECIPE: ${{ inputs.qa_recipe }}
+          INPUT_NO_AUTO_EVIDENCE_UPLOAD: ${{ inputs.no_auto_evidence_upload }}
+        run: node scripts/write_pr_body_with_qa_request.mjs --body-path "$RUNNER_TEMP/pr-body.md"
 
       - name: Create Pull Request
         id: cpr
         uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: ${{ inputs.pr_title }}
+          commit-message: ${{ inputs.commit-message }}
           title: ${{ inputs.pr_title }}
           body-path: ${{ runner.temp }}/pr-body.md
           branch: ${{ inputs.branch }}
@@ -143,7 +137,10 @@ jobs:
             echo "## Codex Headless PR"
             echo
             echo "- PR: ${{ steps.cpr.outputs.pull-request-url }}"
-            echo "- QA recipe: \`${{ inputs.qa_recipe }}\`"
+            echo "- Issue ref: \`${{ steps.pr_body.outputs.issue_ref }}\`"
+            echo "- Route: \`${{ steps.pr_body.outputs.route }}\`"
+            echo "- Scenario seed: \`${{ steps.pr_body.outputs.scenario_seed }}\`"
+            echo "- QA recipe: \`${{ steps.pr_body.outputs.qa_recipe }}\`"
             echo "- Auto QA publish: \`${{ inputs.auto_qa_publish }}\`"
             echo "- Codex final message present: \`${{ steps.codex.outputs.final_message != '' }}\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/lib/qa_publish_defaults.mjs
+++ b/scripts/lib/qa_publish_defaults.mjs
@@ -78,6 +78,7 @@ function defaultPublishRequest({ issueRef = "", title = "", headRef = "" }) {
     case "50":
       return {
         route: "/game",
+        qa_recipe: "issue_49_checkpoint_resume",
       };
     default:
       if (dashboardValidatorSignature) {

--- a/scripts/lib/qa_publish_request.mjs
+++ b/scripts/lib/qa_publish_request.mjs
@@ -1,0 +1,100 @@
+function escapeRegex(text) {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function normalizeQaPublishRequest(request = {}) {
+  return {
+    issue_ref: typeof request.issue_ref === "string" ? request.issue_ref.trim() : "",
+    run_dir: typeof request.run_dir === "string" ? request.run_dir.trim() : "",
+    route: typeof request.route === "string" ? request.route.trim() : "",
+    scenario_seed: typeof request.scenario_seed === "string" ? request.scenario_seed.trim() : "",
+    checkpoint_id: typeof request.checkpoint_id === "string" ? request.checkpoint_id.trim() : "",
+    qa_recipe: typeof request.qa_recipe === "string" ? request.qa_recipe.trim() : "",
+    no_auto_evidence_upload: request.no_auto_evidence_upload === true,
+  };
+}
+
+function mergeQaPublishRequest(defaults = {}, request = {}) {
+  const normalizedDefaults = normalizeQaPublishRequest(defaults);
+  const normalizedRequest = normalizeQaPublishRequest(request);
+  return {
+    issue_ref: normalizedRequest.issue_ref || normalizedDefaults.issue_ref,
+    run_dir: normalizedRequest.run_dir || normalizedDefaults.run_dir,
+    route: normalizedRequest.route || normalizedDefaults.route,
+    scenario_seed: normalizedRequest.scenario_seed || normalizedDefaults.scenario_seed,
+    checkpoint_id: normalizedRequest.checkpoint_id || normalizedDefaults.checkpoint_id,
+    qa_recipe: normalizedRequest.qa_recipe || normalizedDefaults.qa_recipe,
+    no_auto_evidence_upload:
+      normalizedRequest.no_auto_evidence_upload || normalizedDefaults.no_auto_evidence_upload,
+  };
+}
+
+function findHeadingRange(body, heading) {
+  const source = body || "";
+  const headingRegex = new RegExp(`^##\\s*${escapeRegex(heading)}\\s*$`, "im");
+  const match = headingRegex.exec(source);
+  if (!match) return null;
+
+  const start = match.index;
+  const contentStart = match.index + match[0].length;
+  const nextHeadingRegex = /^##\s+/gm;
+  nextHeadingRegex.lastIndex = contentStart;
+  const nextMatch = nextHeadingRegex.exec(source);
+
+  return {
+    start,
+    contentStart,
+    end: nextMatch ? nextMatch.index : source.length,
+  };
+}
+
+function parseJsonFence(section) {
+  const match = (section || "").match(/```json\s*([\s\S]*?)```/i);
+  if (!match) return {};
+
+  try {
+    const parsed = JSON.parse(match[1]);
+    return typeof parsed === "object" && parsed ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function parseQaPublishRequest(body) {
+  const range = findHeadingRange(body, "QA Publish Request");
+  if (!range) return {};
+
+  const parsed = parseJsonFence((body || "").slice(range.contentStart, range.end));
+  return Object.keys(parsed).length > 0 ? normalizeQaPublishRequest(parsed) : {};
+}
+
+function stripQaPublishRequestBlock(body) {
+  const range = findHeadingRange(body, "QA Publish Request");
+  if (!range) return body || "";
+
+  const before = (body || "").slice(0, range.start).trimEnd();
+  const after = (body || "").slice(range.end).trimStart();
+  if (before && after) {
+    return `${before}\n\n${after}`;
+  }
+  return before || after || "";
+}
+
+function renderQaPublishRequestBlock(request = {}) {
+  const normalized = normalizeQaPublishRequest(request);
+  return [
+    "## QA Publish Request",
+    "",
+    "```json",
+    JSON.stringify(normalized, null, 2),
+    "```",
+  ].join("\n");
+}
+
+export {
+  mergeQaPublishRequest,
+  normalizeQaPublishRequest,
+  parseQaPublishRequest,
+  renderQaPublishRequestBlock,
+  stripQaPublishRequestBlock,
+};

--- a/scripts/resolve_codex_create_pr_request.mjs
+++ b/scripts/resolve_codex_create_pr_request.mjs
@@ -2,6 +2,12 @@
 
 import fs from "node:fs";
 import process from "node:process";
+import { defaultPublishRequest } from "./lib/qa_publish_defaults.mjs";
+import {
+  mergeQaPublishRequest,
+  renderQaPublishRequestBlock,
+  stripQaPublishRequestBlock,
+} from "./lib/qa_publish_request.mjs";
 
 const MAINTAINER_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
 const TRUE_VALUES = new Set(["1", "true", "yes", "on"]);
@@ -57,18 +63,6 @@ function ensureCodexBranch(name) {
   const trimmed = (name || "").trim();
   if (!trimmed) return "";
   return trimmed.startsWith("codex/") ? trimmed : `codex/${trimmed.replace(/^\/+/, "")}`;
-}
-
-function renderQaPublishBlock(request) {
-  if (!request || typeof request !== "object" || Object.keys(request).length === 0) return "";
-  return [
-    "## QA Publish Request",
-    "",
-    "```json",
-    JSON.stringify(request, null, 2),
-    "```",
-    "",
-  ].join("\n");
 }
 
 function main() {
@@ -150,9 +144,15 @@ function main() {
   if (!request.issue_ref && repo && sourceIssueNumber) {
     request.issue_ref = `${repo}#${sourceIssueNumber}`;
   }
-  if (!request.qa_publish_request.issue_ref && request.issue_ref) {
-    request.qa_publish_request.issue_ref = request.issue_ref;
-  }
+  const qaDefaults = defaultPublishRequest({
+    issueRef: request.qa_publish_request.issue_ref || request.issue_ref,
+    title: request.pr_title,
+    headRef: request.new_branch,
+  });
+  request.qa_publish_request = mergeQaPublishRequest(qaDefaults, {
+    ...request.qa_publish_request,
+    issue_ref: request.qa_publish_request.issue_ref || request.issue_ref,
+  });
 
   if (!request.new_branch) {
     shouldRun = false;
@@ -170,15 +170,16 @@ function main() {
   }
 
   const prBodySections = [];
-  if (request.pr_body.trim()) {
-    prBodySections.push(request.pr_body.trim(), "");
+  const trimmedPrBody = stripQaPublishRequestBlock(request.pr_body).trim();
+  if (trimmedPrBody) {
+    prBodySections.push(trimmedPrBody, "");
   }
   if (request.issue_ref) {
     prBodySections.push(`Fix context: \`${request.issue_ref}\``, "");
   } else if (sourceIssueNumber) {
     prBodySections.push(`Source issue thread: #${sourceIssueNumber}`, "");
   }
-  const qaBlock = renderQaPublishBlock(request.qa_publish_request);
+  const qaBlock = renderQaPublishRequestBlock(request.qa_publish_request);
   if (qaBlock) {
     prBodySections.push(qaBlock.trim(), "");
   }

--- a/scripts/resolve_qa_publish_request.mjs
+++ b/scripts/resolve_qa_publish_request.mjs
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import process from "node:process";
 import { spawnSync } from "node:child_process";
 import { defaultPublishRequest, inferIssueRef } from "./lib/qa_publish_defaults.mjs";
+import { parseQaPublishRequest } from "./lib/qa_publish_request.mjs";
 
 const MAINTAINER_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
 const TRUE_VALUES = new Set(["1", "true", "yes", "on"]);
@@ -106,15 +107,7 @@ function parseCommandFlags(body) {
 }
 
 function parsePrMetadata(body) {
-  const match = (body || "").match(/##\s*QA Publish Request\s*```json\s*([\s\S]*?)```/i);
-  if (!match) return {};
-
-  try {
-    const parsed = JSON.parse(match[1]);
-    return typeof parsed === "object" && parsed ? parsed : {};
-  } catch {
-    return {};
-  }
+  return parseQaPublishRequest(body);
 }
 
 function output(name, value) {
@@ -250,6 +243,11 @@ function main() {
       commentFlags.dry_run ||
       parseBoolean(String(prMetadata.dry_run || "")),
   };
+
+  if (shouldRun && !merged.run_dir && !merged.qa_recipe) {
+    shouldRun = false;
+    reason = "No repo-visible run_dir or qa_recipe was resolved for this request.";
+  }
 
   const headRepo = pr?.head?.repo?.full_name || "";
   const baseRepo = pr?.base?.repo?.full_name || repo;

--- a/scripts/write_pr_body_with_qa_request.mjs
+++ b/scripts/write_pr_body_with_qa_request.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import process from "node:process";
+import { defaultPublishRequest, inferIssueRef } from "./lib/qa_publish_defaults.mjs";
+import {
+  mergeQaPublishRequest,
+  normalizeQaPublishRequest,
+  renderQaPublishRequestBlock,
+  stripQaPublishRequestBlock,
+} from "./lib/qa_publish_request.mjs";
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+function parseArgs(argv) {
+  const args = {
+    bodyPath: "",
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    const next = argv[index + 1];
+    switch (token) {
+      case "--body-path":
+        args.bodyPath = next || "";
+        index += 1;
+        break;
+      default:
+        fail(`Unknown argument: ${token}`);
+    }
+  }
+
+  if (!args.bodyPath) fail("--body-path is required.");
+  return args;
+}
+
+function output(name, value) {
+  const rendered = value == null ? "" : String(value);
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (!outputPath) return;
+  fs.appendFileSync(outputPath, `${name}<<__CODEX__\n${rendered}\n__CODEX__\n`);
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const repo = process.env.GITHUB_REPOSITORY || "";
+  const prTitle = (process.env.INPUT_PR_TITLE || "").trim();
+  const branch = (process.env.INPUT_BRANCH || "").trim();
+  const prBody = process.env.INPUT_PR_BODY || "";
+  const requested = normalizeQaPublishRequest({
+    issue_ref: process.env.INPUT_ISSUE_REF || "",
+    route: process.env.INPUT_ROUTE || "",
+    scenario_seed: process.env.INPUT_SCENARIO_SEED || "",
+    checkpoint_id: process.env.INPUT_CHECKPOINT_ID || "",
+    qa_recipe: process.env.INPUT_QA_RECIPE || "",
+    no_auto_evidence_upload: (process.env.INPUT_NO_AUTO_EVIDENCE_UPLOAD || "").trim() === "true",
+  });
+
+  const inferredIssueRef =
+    requested.issue_ref ||
+    inferIssueRef({
+      repo,
+      title: prTitle,
+      body: prBody,
+      headRef: branch,
+    });
+  const defaults = defaultPublishRequest({
+    issueRef: inferredIssueRef,
+    title: prTitle,
+    headRef: branch,
+  });
+  const resolved = mergeQaPublishRequest(defaults, {
+    ...requested,
+    issue_ref: requested.issue_ref || inferredIssueRef,
+  });
+
+  const bodySections = [];
+  const trimmedBody = stripQaPublishRequestBlock(prBody).trim();
+  if (trimmedBody) {
+    bodySections.push(trimmedBody, "");
+  }
+  bodySections.push(renderQaPublishRequestBlock(resolved));
+
+  fs.writeFileSync(args.bodyPath, `${bodySections.join("\n").trim()}\n`, "utf8");
+
+  output("issue_ref", resolved.issue_ref);
+  output("route", resolved.route);
+  output("scenario_seed", resolved.scenario_seed);
+  output("checkpoint_id", resolved.checkpoint_id);
+  output("qa_recipe", resolved.qa_recipe);
+  output("no_auto_evidence_upload", resolved.no_auto_evidence_upload ? "true" : "false");
+}
+
+main();


### PR DESCRIPTION
## Summary
- parse `QA Publish Request` blocks even when prose appears between the section heading and the fenced JSON
- stop `Trusted QA Publish` from going red on PR events when neither a repo-visible `run_dir` nor a resolvable `qa_recipe` exists
- share canonical QA block rendering/default merging across trusted PR creation and headless PR creation, including the missing checkpoint-resume default recipe mapping

## How to test
- run the resolver against a PR body whose `QA Publish Request` section contains explanatory prose before the JSON block and confirm it still resolves `route` and `qa_recipe`
- run the resolver against a PR with no `run_dir` and no `qa_recipe` and confirm it cleanly resolves to `should_run=false`
- run the trusted PR-body generators for the checkpoint-resume route and confirm they emit a single canonical `QA Publish Request` block with the expected recipe
