### PR TITLE
Add starter-pack registry, Seoul starter packs, and surface pack resolution in graph APIs

### DIFF
--- a/apps/server/src/curriculum-graph.mjs
+++ b/apps/server/src/curriculum-graph.mjs
@@ -1,6 +1,12 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import {
+  inferCityFromLocation,
+  listWorldMapLocationIds,
+  resolveStarterPack,
+  resolveWorldMapLocation,
+} from './starter-pack-registry.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -14,14 +20,6 @@ const CITY_LABELS = {
   shanghai: 'Shanghai',
 };
 
-const LOCATION_LABELS = {
-  food_street: 'Food Street',
-  cafe: 'Cafe',
-  convenience_store: 'Convenience Store',
-  subway_hub: 'Subway Hub',
-  practice_studio: 'Practice Studio',
-};
-
 const CITY_LANG = {
   seoul: 'ko',
   tokyo: 'ja',
@@ -30,8 +28,8 @@ const CITY_LANG = {
 
 const DEFAULT_LOCATION_BY_CITY = {
   seoul: 'food_street',
-  tokyo: 'food_street',
-  shanghai: 'practice_studio',
+  tokyo: 'train_station',
+  shanghai: 'milk_tea_shop',
 };
 
 const LEGACY_SHARED_LOCATIONS = [
@@ -43,7 +41,7 @@ const LEGACY_SHARED_LOCATIONS = [
 ];
 
 const VALID_CITIES = new Set(Object.keys(CITY_LABELS));
-const VALID_LOCATIONS = new Set(Object.keys(LOCATION_LABELS));
+const VALID_LOCATIONS = new Set(listWorldMapLocationIds());
 const LESSON_STATUSES = new Set(['available', 'due', 'learning']);
 const COMPLETED_STATUSES = new Set(['validated', 'mastered']);
 const BLOCKER_CLEAR_STATUSES = new Set(['due', 'validated', 'mastered']);
@@ -59,8 +57,6 @@ const LESSON_CATEGORY_PRIORITY = {
 function loadJson(relativePath) {
   return JSON.parse(fs.readFileSync(path.join(repoRoot, relativePath), 'utf8'));
 }
-
-const WORLD_MAP_REGISTRY = loadJson('packages/contracts/world-map-registry.sample.json');
 
 function cloneJson(value) {
   return JSON.parse(JSON.stringify(value));
@@ -88,49 +84,6 @@ function stableHashNumber(value) {
 
 function unique(values) {
   return [...new Set(values.filter(Boolean))];
-}
-
-function getWorldMapCityRegistry(cityId) {
-  return (WORLD_MAP_REGISTRY.cities || []).find((city) => city.cityId === cityId) || null;
-}
-
-function resolveWorldMapLocation(cityId, locationId = null) {
-  const cityRegistry = getWorldMapCityRegistry(cityId);
-  const fallbackLocationId = locationId || DEFAULT_LOCATION_BY_CITY[cityId] || 'food_street';
-
-  if (!cityRegistry) {
-    return {
-      cityId,
-      mapLocationId: fallbackLocationId,
-      dagLocationSlot: fallbackLocationId,
-      label: LOCATION_LABELS[fallbackLocationId] || fallbackLocationId.replace(/_/g, ' '),
-      legacyLocationIds: [fallbackLocationId],
-    };
-  }
-
-  const requestedLocationId = locationId || cityRegistry.defaultMapLocationId;
-  const normalized = cityRegistry.locations.find(
-    (entry) =>
-      entry.mapLocationId === requestedLocationId ||
-      entry.dagLocationSlot === requestedLocationId ||
-      (entry.legacyLocationIds || []).includes(requestedLocationId),
-  );
-  const fallback = cityRegistry.locations.find((entry) => entry.mapLocationId === cityRegistry.defaultMapLocationId)
-    || cityRegistry.locations[0];
-  const mapLocationId = normalized?.mapLocationId || fallback?.mapLocationId || fallbackLocationId;
-  const dagLocationSlot = normalized?.dagLocationSlot || fallback?.dagLocationSlot || fallbackLocationId;
-
-  return {
-    cityId,
-    mapLocationId,
-    dagLocationSlot,
-    label:
-      normalized?.label ||
-      fallback?.label ||
-      LOCATION_LABELS[dagLocationSlot] ||
-      mapLocationId.replace(/_/g, ' '),
-    legacyLocationIds: unique([dagLocationSlot, ...((normalized?.legacyLocationIds || []))]),
-  };
 }
 
 function keyFor(cityId, locationId) {
@@ -168,7 +121,8 @@ const SEOUL_FOOD_STREET_PACK = loadJson(
 
 function buildStubPack(cityId, locationId) {
   const cityLabel = CITY_LABELS[cityId];
-  const locationLabel = LOCATION_LABELS[locationId];
+  const resolvedLocation = resolveWorldMapLocation(cityId, locationId);
+  const locationLabel = resolvedLocation.label;
   const summaries = {
     [keyFor('tokyo', 'food_street')]:
       'Starter Japanese scaffold for the Tokyo food-street route. The canonical pack is still pending authoring.',
@@ -598,12 +552,6 @@ function normalizeLocation(value) {
     });
   }
   return value;
-}
-
-function inferCityFromLocation(locationId) {
-  if (!locationId) return null;
-  if (locationId === 'practice_studio') return 'shanghai';
-  return 'seoul';
 }
 
 function resolveSelection(args = {}) {
@@ -1585,12 +1533,23 @@ function buildLegacyWorldRoadmap(persona, foundationEvaluation, overlayCandidate
 function buildLegacyLocationSkillTree(runtime) {
   const { selection, selectedEvaluation, missionGate } = runtime;
   const pack = selection.pack;
+  const starterPackResolution = resolveStarterPack(selection.cityId, selection.locationId);
 
   return {
     packId: pack.packId,
     cityId: pack.cityId,
     locationId: pack.locationId,
     title: pack.title,
+    starterPackResolution: cloneJson({
+      packId: starterPackResolution.packId,
+      mapLocationId: starterPackResolution.mapLocationId,
+      dagLocationSlot: starterPackResolution.dagLocationSlot,
+      registryLabel: starterPackResolution.registryLabel,
+      playerFacingLabel: starterPackResolution.playerFacingLabel,
+      slotRosterId: starterPackResolution.slotRosterId,
+      rosterRegistrySource: starterPackResolution.rosterRegistrySource,
+      registryResolved: starterPackResolution.registryResolved,
+    }),
     levels: (pack.levels || []).map((level) => {
       const levelNodeIds = new Set(level.objectiveNodeIds || []);
       const levelEntries = selectedEvaluation.nodeEntries.filter((entry) => levelNodeIds.has(entry.node.nodeId));
@@ -2535,6 +2494,7 @@ export function listGraphPersonas() {
 
 export function getGraphDashboard(args = {}) {
   const runtime = buildRuntimeState(args);
+  const selectedStarterPack = resolveStarterPack(runtime.selection.cityId, runtime.selection.locationId);
   const legacyPersona = buildLegacyPersona(runtime.persona);
   const roadmap = buildRoadmap(
     runtime.persona,
@@ -2578,6 +2538,16 @@ export function getGraphDashboard(args = {}) {
     nextUnlocks: cloneJson(runtime.nextUnlocks),
     selectedPack: {
       pack: cloneJson(runtime.selection.pack),
+      starterPackResolution: cloneJson({
+        packId: selectedStarterPack.packId,
+        mapLocationId: selectedStarterPack.mapLocationId,
+        dagLocationSlot: selectedStarterPack.dagLocationSlot,
+        registryLabel: selectedStarterPack.registryLabel,
+        playerFacingLabel: selectedStarterPack.playerFacingLabel,
+        slotRosterId: selectedStarterPack.slotRosterId,
+        rosterRegistrySource: selectedStarterPack.rosterRegistrySource,
+        registryResolved: selectedStarterPack.registryResolved,
+      }),
       nodes: cloneJson(runtime.selectedEvaluation.nodeEntries),
       missionGate: cloneJson(runtime.missionGate),
       lessonBundle: cloneJson(runtime.lessonBundle),

--- a/apps/server/src/index.mjs
+++ b/apps/server/src/index.mjs
@@ -48,6 +48,10 @@ import {
   resolveObjectiveIdentity,
   withObjectiveIdentity,
 } from './objective-identity.mjs';
+import {
+  resolveStarterPack,
+  resolveWorldMapLocation,
+} from './starter-pack-registry.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -78,7 +82,6 @@ const FIXTURES = {
   youtubeStatus: loadJson('packages/contracts/fixtures/youtube.status.sample.json'),
 };
 const WORLD_MAP_REGISTRY = loadJson('packages/contracts/world-map-registry.sample.json');
-
 const mockMediaWindowPath = path.join(repoRoot, 'apps/server/data/mock-media-window.json');
 const DEFAULT_USER_ID = 'demo-user-1';
 const PROFICIENCY_RANK = {
@@ -120,38 +123,6 @@ const DEFAULT_OBJECTIVE_BY_LANG = {
   zh: defaultObjectiveIdForLang('zh', 'zh-mission-stage-texting'),
 };
 
-function getWorldMapCityRegistry(cityId) {
-  return (WORLD_MAP_REGISTRY.cities || []).find((city) => city.cityId === cityId) || null;
-}
-
-function resolveWorldMapLocation(cityId, locationId = null) {
-  const cityRegistry = getWorldMapCityRegistry(cityId);
-  if (!cityRegistry) {
-    return {
-      cityId,
-      mapLocationId: locationId || 'food_street',
-      dagLocationSlot: locationId || 'food_street',
-      legacyLocationIds: [locationId || 'food_street'],
-    };
-  }
-
-  const requestedLocationId = locationId || cityRegistry.defaultMapLocationId;
-  const normalized = cityRegistry.locations.find(
-    (entry) =>
-      entry.mapLocationId === requestedLocationId ||
-      entry.dagLocationSlot === requestedLocationId ||
-      (entry.legacyLocationIds || []).includes(requestedLocationId),
-  );
-  const fallback = cityRegistry.locations.find((entry) => entry.mapLocationId === cityRegistry.defaultMapLocationId)
-    || cityRegistry.locations[0];
-
-  return {
-    cityId,
-    mapLocationId: normalized?.mapLocationId || fallback?.mapLocationId || 'food_street',
-    dagLocationSlot: normalized?.dagLocationSlot || fallback?.dagLocationSlot || 'food_street',
-    legacyLocationIds: [...new Set([normalized?.dagLocationSlot, ...((normalized?.legacyLocationIds || []))].filter(Boolean))],
-  };
-}
 const OBJECTIVE_RUNTIME_CONFIG = new Map([
   ['ko-vocab-food-items', {
     fallbackTerms: ['주문', '메뉴', '떡볶이'],
@@ -191,6 +162,31 @@ const OBJECTIVE_RUNTIME_CONFIG = new Map([
       nextTurnEven: '好，那你再说一下想几点见面。',
       nextTurnOdd: '不错，下一句用中文说明你想点什么吧。',
     },
+  }],
+  ['ko-seoul-food-street-basics', {
+    fallbackTerms: ['주문', '메뉴', '치즈'],
+    placementReason: 'Food-street ordering language stays mapped to the live Seoul food_street pin.',
+    summary: 'Practice starter Seoul food-street ordering language.',
+  }],
+  ['ko-seoul-cafe-study-session', {
+    fallbackTerms: ['공부', '자리', '추천'],
+    placementReason: 'Cafe small talk and study requests resolve through the Seoul cafe registry pin.',
+    summary: 'Handle a Seoul cafe study meetup in Korean.',
+  }],
+  ['ko-seoul-convenience-store-run', {
+    fallbackTerms: ['봉투', '영수증', '간식'],
+    placementReason: 'Convenience-store errands and checkout phrases fit the Seoul convenience_store pin.',
+    summary: 'Run a quick Seoul convenience-store errand in Korean.',
+  }],
+  ['ko-seoul-subway-meetup', {
+    fallbackTerms: ['출구', '환승', '도착'],
+    placementReason: 'Transit coordination resolves through the Seoul subway_hub registry pin.',
+    summary: 'Coordinate a Seoul subway meetup in Korean.',
+  }],
+  ['ko-seoul-chimaek-hangout', {
+    fallbackTerms: ['치맥', '한잔', '같이'],
+    placementReason: 'The visible Seoul Chimaek Place pin resolves internally through the practice_studio mapLocationId.',
+    summary: 'Handle a Seoul Chimaek Place hangout in Korean.',
   }],
 ]);
 const HANGOUT_MATCH_PATTERNS = {
@@ -1272,6 +1268,8 @@ function buildPersonalizedObjective({
   location = 'food_street',
 }) {
   const resolvedMapLocation = resolveWorldMapLocation(city, location);
+  const starterPackResolution = resolveStarterPack(city, resolvedMapLocation.mapLocationId);
+  const starterObjectiveSeed = starterPackResolution.pack?.objectiveSeed || null;
   const dagLocationSlot = resolvedMapLocation.dagLocationSlot;
   const ingestion = ensureIngestionForUser(userId);
   const baseObjective = cloneJson(FIXTURES.objectivesNext);
@@ -1279,7 +1277,7 @@ function buildPersonalizedObjective({
   const dominantCluster =
     ingestion?.insights?.clusters?.find((cluster) => cluster.clusterId === dominantClusterId) ||
     ingestion?.insights?.clusters?.[0];
-  const runtimeObjectiveConfig = getRuntimeObjectiveConfig({ lang, cityId: city });
+  const cityRuntimeObjectiveConfig = getRuntimeObjectiveConfig({ lang, cityId: city });
   const placementCandidates = Array.isArray(ingestion?.mediaProfile?.learningSignals?.placementCandidates)
     ? ingestion.mediaProfile.learningSignals.placementCandidates
     : [];
@@ -1291,7 +1289,7 @@ function buildPersonalizedObjective({
         candidate.mode === mode &&
         (
           objectiveMatchesLanguage(candidate.objectiveId, lang) ||
-          resolveObjectiveIdentity(candidate.objectiveId).canonicalObjectiveId === runtimeObjectiveConfig?.objectiveId
+          resolveObjectiveIdentity(candidate.objectiveId).canonicalObjectiveId === cityRuntimeObjectiveConfig?.objectiveId
         ),
     ) ||
     placementCandidates.find(
@@ -1311,7 +1309,8 @@ function buildPersonalizedObjective({
 
   let objectiveId =
     selectedPlacement?.objectiveId ||
-    runtimeObjectiveConfig?.objectiveId ||
+    starterObjectiveSeed?.objectiveId ||
+    cityRuntimeObjectiveConfig?.objectiveId ||
     scopedClusterItems[0]?.objectiveLinks?.[0]?.objectiveId ||
     scopedItems[0]?.objectiveLinks?.[0]?.objectiveId ||
     baseObjective.objectiveId ||
@@ -1327,11 +1326,12 @@ function buildPersonalizedObjective({
     }
   }
 
+  const runtimeObjectiveConfig = getRuntimeObjectiveConfig({ objectiveId }) || cityRuntimeObjectiveConfig;
   const termBundle = buildObjectiveTermBundle({
     ingestion,
     lang,
     objectiveId,
-    objectiveConfig: runtimeObjectiveConfig || getRuntimeObjectiveConfig({ objectiveId }),
+    objectiveConfig: runtimeObjectiveConfig,
     dominantCluster,
   });
   const vocabulary = termBundle.vocabulary;
@@ -1385,6 +1385,15 @@ function buildPersonalizedObjective({
         ? personalizedTargets
         : cloneJson(baseObjective.personalizedTargets || []),
     recentMediaRationale,
+    starterPack: starterPackResolution.pack
+      ? {
+          packId: starterPackResolution.packId,
+          mapLocationId: starterPackResolution.mapLocationId,
+          dagLocationSlot: starterPackResolution.dagLocationSlot,
+          registryLabel: starterPackResolution.registryLabel,
+          playerFacingLabel: starterPackResolution.playerFacingLabel,
+        }
+      : null,
     placementHints: cloneJson(recentMediaRationale.placementHints || []),
     completionCriteria: {
       ...(baseObjective.completionCriteria || {}),

--- a/apps/server/src/starter-pack-registry.mjs
+++ b/apps/server/src/starter-pack-registry.mjs
@@ -1,0 +1,132 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '../../..');
+
+function loadJson(relativePath) {
+  return JSON.parse(fs.readFileSync(path.join(repoRoot, relativePath), 'utf8'));
+}
+
+const WORLD_MAP_REGISTRY = loadJson('packages/contracts/world-map-registry.sample.json');
+const STARTER_CAST_REGISTRY = loadJson('assets/manifest/starter-cast-registry.json');
+
+const STARTER_PACK_DIR = path.join(repoRoot, 'assets/content-packs');
+const STARTER_PACKS = fs.readdirSync(STARTER_PACK_DIR)
+  .filter((filename) => filename.endsWith('.starter.json') && !filename.includes('.template.'))
+  .map((filename) => loadJson(path.join('assets/content-packs', filename)));
+
+const STARTER_PACK_BY_ID = new Map(STARTER_PACKS.map((pack) => [pack.packId, pack]));
+const PLAYER_FACING_LABEL_OVERRIDES = new Map([
+  ['seoul:practice_studio', 'Chimaek Place'],
+]);
+
+function unique(values) {
+  return [...new Set(values.filter(Boolean))];
+}
+
+export function getWorldMapCityRegistry(cityId) {
+  return (WORLD_MAP_REGISTRY.cities || []).find((city) => city.cityId === cityId) || null;
+}
+
+export function listWorldMapLocationIds() {
+  const ids = new Set();
+  for (const city of WORLD_MAP_REGISTRY.cities || []) {
+    ids.add(city.defaultMapLocationId);
+    for (const location of city.locations || []) {
+      ids.add(location.mapLocationId);
+      ids.add(location.dagLocationSlot);
+      for (const legacyLocationId of location.legacyLocationIds || []) ids.add(legacyLocationId);
+    }
+  }
+  return [...ids];
+}
+
+export function resolveWorldMapLocation(cityId, locationId = null) {
+  const cityRegistry = getWorldMapCityRegistry(cityId);
+  const fallbackLocationId = locationId || cityRegistry?.defaultMapLocationId || 'food_street';
+
+  if (!cityRegistry) {
+    return {
+      cityId,
+      mapLocationId: fallbackLocationId,
+      dagLocationSlot: fallbackLocationId,
+      label: fallbackLocationId.replace(/_/g, ' '),
+      legacyLocationIds: [fallbackLocationId],
+    };
+  }
+
+  const requestedLocationId = locationId || cityRegistry.defaultMapLocationId;
+  const normalized = (cityRegistry.locations || []).find(
+    (entry) =>
+      entry.mapLocationId === requestedLocationId ||
+      entry.dagLocationSlot === requestedLocationId ||
+      (entry.legacyLocationIds || []).includes(requestedLocationId),
+  );
+  const fallback = (cityRegistry.locations || []).find(
+    (entry) => entry.mapLocationId === cityRegistry.defaultMapLocationId,
+  ) || cityRegistry.locations?.[0];
+  const mapLocationId = normalized?.mapLocationId || fallback?.mapLocationId || fallbackLocationId;
+  const dagLocationSlot = normalized?.dagLocationSlot || fallback?.dagLocationSlot || fallbackLocationId;
+
+  return {
+    cityId,
+    mapLocationId,
+    dagLocationSlot,
+    label:
+      normalized?.label ||
+      fallback?.label ||
+      dagLocationSlot.replace(/_/g, ' '),
+    legacyLocationIds: unique([dagLocationSlot, ...((normalized?.legacyLocationIds || []))]),
+  };
+}
+
+export function inferCityFromLocation(locationId) {
+  if (!locationId) return null;
+  const matches = [];
+  for (const city of WORLD_MAP_REGISTRY.cities || []) {
+    if ((city.locations || []).some((entry) =>
+      entry.mapLocationId === locationId ||
+      entry.dagLocationSlot === locationId ||
+      (entry.legacyLocationIds || []).includes(locationId))) {
+      matches.push(city.cityId);
+    }
+  }
+  return matches.length === 1 ? matches[0] : null;
+}
+
+function getStarterCastCityRegistry(cityId) {
+  return (STARTER_CAST_REGISTRY.cities || []).find((city) => city.cityId === cityId) || null;
+}
+
+function getPlayerFacingLabel(cityId, mapLocationId, fallbackLabel) {
+  return PLAYER_FACING_LABEL_OVERRIDES.get(`${cityId}:${mapLocationId}`) || fallbackLabel;
+}
+
+export function resolveStarterPack(cityId, locationId = null) {
+  const resolvedLocation = resolveWorldMapLocation(cityId, locationId);
+  const castCityRegistry = getStarterCastCityRegistry(cityId);
+  const pinEntry = (castCityRegistry?.mapPins || []).find(
+    (entry) => entry.mapLocationId === resolvedLocation.mapLocationId,
+  ) || null;
+  const slotRoster = (castCityRegistry?.slotRosters || []).find(
+    (entry) => entry.slotRosterId === pinEntry?.slotRosterId,
+  ) || null;
+  const pack = pinEntry ? STARTER_PACK_BY_ID.get(pinEntry.packId) || null : null;
+
+  return {
+    cityId,
+    mapLocationId: resolvedLocation.mapLocationId,
+    dagLocationSlot: resolvedLocation.dagLocationSlot,
+    registryLabel: resolvedLocation.label,
+    playerFacingLabel: getPlayerFacingLabel(cityId, resolvedLocation.mapLocationId, resolvedLocation.label),
+    rosterRegistrySource: pack?.rosterRegistrySource || 'assets/manifest/starter-cast-registry.json',
+    slotRosterId: pinEntry?.slotRosterId || null,
+    packId: pinEntry?.packId || pack?.packId || null,
+    pack,
+    slotRoster,
+    registryResolved: Boolean(pinEntry && pack),
+  };
+}

--- a/artifacts/issue62-seoul-pack-resolution-trace.json
+++ b/artifacts/issue62-seoul-pack-resolution-trace.json
@@ -1,0 +1,23 @@
+{
+  "request": "http://127.0.0.1:8787/api/v1/graph/dashboard?city=seoul&location=practice_studio",
+  "selectedPack": {
+    "packId": "pack.seoul.practice_studio.starter",
+    "mapLocationId": "practice_studio",
+    "dagLocationSlot": "practice_studio",
+    "registryLabel": "Practice Studio",
+    "playerFacingLabel": "Chimaek Place",
+    "slotRosterId": "slot.seoul.practice_studio.starter",
+    "rosterRegistrySource": "assets/manifest/starter-cast-registry.json",
+    "registryResolved": true
+  },
+  "locationSkillTree": {
+    "packId": "pack.seoul.practice_studio.starter",
+    "mapLocationId": "practice_studio",
+    "dagLocationSlot": "practice_studio",
+    "registryLabel": "Practice Studio",
+    "playerFacingLabel": "Chimaek Place",
+    "slotRosterId": "slot.seoul.practice_studio.starter",
+    "rosterRegistrySource": "assets/manifest/starter-cast-registry.json",
+    "registryResolved": true
+  }
+}

--- a/assets/content-packs/seoul-cafe.starter.json
+++ b/assets/content-packs/seoul-cafe.starter.json
@@ -1,0 +1,88 @@
+{
+  "templateVersion": "1.1.0",
+  "packType": "city-location-character-starter",
+  "packId": "pack.seoul.cafe.starter",
+  "city": "seoul",
+  "mapLocationId": "cafe",
+  "location": {
+    "id": "cafe",
+    "assetSlug": "cafe",
+    "modes": [
+      "learn",
+      "hangout"
+    ]
+  },
+  "characterRoster": [
+    {
+      "id": "char.seoul.cafe.sora",
+      "role": "lead",
+      "relationshipTrack": "rp",
+      "requiredManifestKeys": [
+        "character.seoul.cafe.sora.portrait.default",
+        "character.seoul.cafe.sora.sprite.default",
+        "character.seoul.cafe.sora.scene.default",
+        "character.seoul.cafe.sora.voice.reference"
+      ],
+      "optionalManifestKeys": [
+        "character.seoul.cafe.sora.sprite.expression-set"
+      ]
+    },
+    {
+      "id": "char.seoul.cafe.donghyun",
+      "role": "support",
+      "relationshipTrack": "rp",
+      "requiredManifestKeys": [
+        "character.seoul.cafe.donghyun.portrait.default",
+        "character.seoul.cafe.donghyun.sprite.default",
+        "character.seoul.cafe.donghyun.scene.default",
+        "character.seoul.cafe.donghyun.voice.reference"
+      ],
+      "optionalManifestKeys": [
+        "character.seoul.cafe.donghyun.intro.video"
+      ]
+    },
+    {
+      "id": "tong",
+      "role": "assistant",
+      "relationshipTrack": "rp",
+      "requiredManifestKeys": [
+        "character.tong.expression.neutral"
+      ],
+      "optionalManifestKeys": [
+        "character.tong.expression.cheerful",
+        "character.tong.expression.thinking"
+      ]
+    }
+  ],
+  "objectiveSeed": {
+    "objectiveId": "ko-seoul-cafe-study-session",
+    "targetTypes": [
+      "vocabulary",
+      "grammar",
+      "sentenceStructures"
+    ],
+    "missionGate": {
+      "validatedHangoutsRequired": 2,
+      "masteryTierUnlock": "A1.2"
+    }
+  },
+  "manifestKeys": [
+    "city.seoul.location.cafe.backdrop.default",
+    "city.seoul.location.cafe.ambience.default",
+    "character.seoul.cafe.sora.portrait.default",
+    "character.seoul.cafe.sora.sprite.default",
+    "character.seoul.cafe.sora.scene.default",
+    "character.seoul.cafe.sora.voice.reference",
+    "character.seoul.cafe.donghyun.portrait.default",
+    "character.seoul.cafe.donghyun.sprite.default",
+    "character.seoul.cafe.donghyun.scene.default",
+    "character.seoul.cafe.donghyun.voice.reference",
+    "character.tong.expression.neutral"
+  ],
+  "rewardHooks": {
+    "videoCallRewardKey": null,
+    "polaroidRewardKey": null
+  },
+  "status": "draft",
+  "rosterRegistrySource": "assets/manifest/starter-cast-registry.json"
+}

--- a/assets/content-packs/seoul-convenience-store.starter.json
+++ b/assets/content-packs/seoul-convenience-store.starter.json
@@ -1,0 +1,88 @@
+{
+  "templateVersion": "1.1.0",
+  "packType": "city-location-character-starter",
+  "packId": "pack.seoul.convenience_store.starter",
+  "city": "seoul",
+  "mapLocationId": "convenience_store",
+  "location": {
+    "id": "convenience_store",
+    "assetSlug": "convenience-store",
+    "modes": [
+      "learn",
+      "hangout"
+    ]
+  },
+  "characterRoster": [
+    {
+      "id": "char.seoul.convenience_store.eunji",
+      "role": "lead",
+      "relationshipTrack": "rp",
+      "requiredManifestKeys": [
+        "character.seoul.convenience_store.eunji.portrait.default",
+        "character.seoul.convenience_store.eunji.sprite.default",
+        "character.seoul.convenience_store.eunji.scene.default",
+        "character.seoul.convenience_store.eunji.voice.reference"
+      ],
+      "optionalManifestKeys": [
+        "character.seoul.convenience_store.eunji.sprite.expression-set"
+      ]
+    },
+    {
+      "id": "char.seoul.convenience_store.hyunwoo",
+      "role": "support",
+      "relationshipTrack": "rp",
+      "requiredManifestKeys": [
+        "character.seoul.convenience_store.hyunwoo.portrait.default",
+        "character.seoul.convenience_store.hyunwoo.sprite.default",
+        "character.seoul.convenience_store.hyunwoo.scene.default",
+        "character.seoul.convenience_store.hyunwoo.voice.reference"
+      ],
+      "optionalManifestKeys": [
+        "character.seoul.convenience_store.hyunwoo.reward.polaroid"
+      ]
+    },
+    {
+      "id": "tong",
+      "role": "assistant",
+      "relationshipTrack": "rp",
+      "requiredManifestKeys": [
+        "character.tong.expression.neutral"
+      ],
+      "optionalManifestKeys": [
+        "character.tong.expression.cheerful",
+        "character.tong.expression.thinking"
+      ]
+    }
+  ],
+  "objectiveSeed": {
+    "objectiveId": "ko-seoul-convenience-store-run",
+    "targetTypes": [
+      "vocabulary",
+      "grammar",
+      "sentenceStructures"
+    ],
+    "missionGate": {
+      "validatedHangoutsRequired": 2,
+      "masteryTierUnlock": "A1.2"
+    }
+  },
+  "manifestKeys": [
+    "city.seoul.location.convenience-store.backdrop.default",
+    "city.seoul.location.convenience-store.ambience.default",
+    "character.seoul.convenience_store.eunji.portrait.default",
+    "character.seoul.convenience_store.eunji.sprite.default",
+    "character.seoul.convenience_store.eunji.scene.default",
+    "character.seoul.convenience_store.eunji.voice.reference",
+    "character.seoul.convenience_store.hyunwoo.portrait.default",
+    "character.seoul.convenience_store.hyunwoo.sprite.default",
+    "character.seoul.convenience_store.hyunwoo.scene.default",
+    "character.seoul.convenience_store.hyunwoo.voice.reference",
+    "character.tong.expression.neutral"
+  ],
+  "rewardHooks": {
+    "videoCallRewardKey": null,
+    "polaroidRewardKey": null
+  },
+  "status": "draft",
+  "rosterRegistrySource": "assets/manifest/starter-cast-registry.json"
+}

--- a/assets/content-packs/seoul-food-street.starter.json
+++ b/assets/content-packs/seoul-food-street.starter.json
@@ -1,8 +1,9 @@
 {
-  "templateVersion": "1.0.0",
+  "templateVersion": "1.1.0",
   "packType": "city-location-character-starter",
-  "packId": "seoul-food-street-starter",
+  "packId": "pack.seoul.food_street.starter",
   "city": "seoul",
+  "mapLocationId": "food_street",
   "location": {
     "id": "food_street",
     "assetSlug": "food-street",
@@ -13,19 +14,32 @@
   },
   "characterRoster": [
     {
-      "id": "haeun",
+      "id": "char.seoul.food_street.minseo",
       "role": "lead",
       "relationshipTrack": "rp",
       "requiredManifestKeys": [
-        "character.haeun.portrait.default"
+        "character.seoul.food_street.minseo.portrait.default",
+        "character.seoul.food_street.minseo.sprite.default",
+        "character.seoul.food_street.minseo.scene.default",
+        "character.seoul.food_street.minseo.voice.reference"
+      ],
+      "optionalManifestKeys": [
+        "character.seoul.food_street.minseo.sprite.expression-set",
+        "character.seoul.food_street.minseo.reward.polaroid"
       ]
     },
     {
-      "id": "jin",
+      "id": "char.seoul.food_street.jiho",
       "role": "support",
       "relationshipTrack": "rp",
       "requiredManifestKeys": [
-        "character.jin.portrait.default"
+        "character.seoul.food_street.jiho.portrait.default",
+        "character.seoul.food_street.jiho.sprite.default",
+        "character.seoul.food_street.jiho.scene.default",
+        "character.seoul.food_street.jiho.voice.reference"
+      ],
+      "optionalManifestKeys": [
+        "character.seoul.food_street.jiho.sprite.expression-set"
       ]
     },
     {
@@ -34,11 +48,15 @@
       "relationshipTrack": "rp",
       "requiredManifestKeys": [
         "character.tong.expression.neutral"
+      ],
+      "optionalManifestKeys": [
+        "character.tong.expression.cheerful",
+        "character.tong.expression.thinking"
       ]
     }
   ],
   "objectiveSeed": {
-    "objectiveId": "seoul-food-street-v1",
+    "objectiveId": "ko-seoul-food-street-basics",
     "targetTypes": [
       "vocabulary",
       "grammar",
@@ -51,9 +69,21 @@
   },
   "manifestKeys": [
     "city.seoul.location.food-street.backdrop.default",
-    "character.haeun.portrait.default",
-    "character.jin.portrait.default",
+    "city.seoul.location.food-street.ambience.default",
+    "character.seoul.food_street.minseo.portrait.default",
+    "character.seoul.food_street.minseo.sprite.default",
+    "character.seoul.food_street.minseo.scene.default",
+    "character.seoul.food_street.minseo.voice.reference",
+    "character.seoul.food_street.jiho.portrait.default",
+    "character.seoul.food_street.jiho.sprite.default",
+    "character.seoul.food_street.jiho.scene.default",
+    "character.seoul.food_street.jiho.voice.reference",
     "character.tong.expression.neutral"
   ],
-  "status": "draft"
+  "rewardHooks": {
+    "videoCallRewardKey": null,
+    "polaroidRewardKey": null
+  },
+  "status": "draft",
+  "rosterRegistrySource": "assets/manifest/starter-cast-registry.json"
 }

--- a/assets/content-packs/seoul-practice-studio.starter.json
+++ b/assets/content-packs/seoul-practice-studio.starter.json
@@ -1,0 +1,88 @@
+{
+  "templateVersion": "1.1.0",
+  "packType": "city-location-character-starter",
+  "packId": "pack.seoul.practice_studio.starter",
+  "city": "seoul",
+  "mapLocationId": "practice_studio",
+  "location": {
+    "id": "practice_studio",
+    "assetSlug": "practice-studio",
+    "modes": [
+      "learn",
+      "hangout"
+    ]
+  },
+  "characterRoster": [
+    {
+      "id": "char.seoul.practice_studio.yujin",
+      "role": "lead",
+      "relationshipTrack": "rp",
+      "requiredManifestKeys": [
+        "character.seoul.practice_studio.yujin.portrait.default",
+        "character.seoul.practice_studio.yujin.sprite.default",
+        "character.seoul.practice_studio.yujin.scene.default",
+        "character.seoul.practice_studio.yujin.voice.reference"
+      ],
+      "optionalManifestKeys": [
+        "character.seoul.practice_studio.yujin.sprite.expression-set"
+      ]
+    },
+    {
+      "id": "char.seoul.practice_studio.seungwoo",
+      "role": "support",
+      "relationshipTrack": "rp",
+      "requiredManifestKeys": [
+        "character.seoul.practice_studio.seungwoo.portrait.default",
+        "character.seoul.practice_studio.seungwoo.sprite.default",
+        "character.seoul.practice_studio.seungwoo.scene.default",
+        "character.seoul.practice_studio.seungwoo.voice.reference"
+      ],
+      "optionalManifestKeys": [
+        "character.seoul.practice_studio.seungwoo.reward.polaroid"
+      ]
+    },
+    {
+      "id": "tong",
+      "role": "assistant",
+      "relationshipTrack": "rp",
+      "requiredManifestKeys": [
+        "character.tong.expression.neutral"
+      ],
+      "optionalManifestKeys": [
+        "character.tong.expression.cheerful",
+        "character.tong.expression.thinking"
+      ]
+    }
+  ],
+  "objectiveSeed": {
+    "objectiveId": "ko-seoul-chimaek-hangout",
+    "targetTypes": [
+      "vocabulary",
+      "grammar",
+      "sentenceStructures"
+    ],
+    "missionGate": {
+      "validatedHangoutsRequired": 2,
+      "masteryTierUnlock": "A1.2"
+    }
+  },
+  "manifestKeys": [
+    "city.seoul.location.practice-studio.backdrop.default",
+    "city.seoul.location.practice-studio.ambience.default",
+    "character.seoul.practice_studio.yujin.portrait.default",
+    "character.seoul.practice_studio.yujin.sprite.default",
+    "character.seoul.practice_studio.yujin.scene.default",
+    "character.seoul.practice_studio.yujin.voice.reference",
+    "character.seoul.practice_studio.seungwoo.portrait.default",
+    "character.seoul.practice_studio.seungwoo.sprite.default",
+    "character.seoul.practice_studio.seungwoo.scene.default",
+    "character.seoul.practice_studio.seungwoo.voice.reference",
+    "character.tong.expression.neutral"
+  ],
+  "rewardHooks": {
+    "videoCallRewardKey": null,
+    "polaroidRewardKey": null
+  },
+  "status": "draft",
+  "rosterRegistrySource": "assets/manifest/starter-cast-registry.json"
+}

--- a/assets/content-packs/seoul-subway-hub.starter.json
+++ b/assets/content-packs/seoul-subway-hub.starter.json
@@ -1,0 +1,88 @@
+{
+  "templateVersion": "1.1.0",
+  "packType": "city-location-character-starter",
+  "packId": "pack.seoul.subway_hub.starter",
+  "city": "seoul",
+  "mapLocationId": "subway_hub",
+  "location": {
+    "id": "subway_hub",
+    "assetSlug": "subway-hub",
+    "modes": [
+      "learn",
+      "hangout"
+    ]
+  },
+  "characterRoster": [
+    {
+      "id": "char.seoul.subway_hub.nari",
+      "role": "lead",
+      "relationshipTrack": "rp",
+      "requiredManifestKeys": [
+        "character.seoul.subway_hub.nari.portrait.default",
+        "character.seoul.subway_hub.nari.sprite.default",
+        "character.seoul.subway_hub.nari.scene.default",
+        "character.seoul.subway_hub.nari.voice.reference"
+      ],
+      "optionalManifestKeys": [
+        "character.seoul.subway_hub.nari.sprite.expression-set"
+      ]
+    },
+    {
+      "id": "char.seoul.subway_hub.taemin",
+      "role": "support",
+      "relationshipTrack": "rp",
+      "requiredManifestKeys": [
+        "character.seoul.subway_hub.taemin.portrait.default",
+        "character.seoul.subway_hub.taemin.sprite.default",
+        "character.seoul.subway_hub.taemin.scene.default",
+        "character.seoul.subway_hub.taemin.voice.reference"
+      ],
+      "optionalManifestKeys": [
+        "character.seoul.subway_hub.taemin.intro.video"
+      ]
+    },
+    {
+      "id": "tong",
+      "role": "assistant",
+      "relationshipTrack": "rp",
+      "requiredManifestKeys": [
+        "character.tong.expression.neutral"
+      ],
+      "optionalManifestKeys": [
+        "character.tong.expression.cheerful",
+        "character.tong.expression.thinking"
+      ]
+    }
+  ],
+  "objectiveSeed": {
+    "objectiveId": "ko-seoul-subway-meetup",
+    "targetTypes": [
+      "vocabulary",
+      "grammar",
+      "sentenceStructures"
+    ],
+    "missionGate": {
+      "validatedHangoutsRequired": 2,
+      "masteryTierUnlock": "A1.2"
+    }
+  },
+  "manifestKeys": [
+    "city.seoul.location.subway-hub.backdrop.default",
+    "city.seoul.location.subway-hub.ambience.default",
+    "character.seoul.subway_hub.nari.portrait.default",
+    "character.seoul.subway_hub.nari.sprite.default",
+    "character.seoul.subway_hub.nari.scene.default",
+    "character.seoul.subway_hub.nari.voice.reference",
+    "character.seoul.subway_hub.taemin.portrait.default",
+    "character.seoul.subway_hub.taemin.sprite.default",
+    "character.seoul.subway_hub.taemin.scene.default",
+    "character.seoul.subway_hub.taemin.voice.reference",
+    "character.tong.expression.neutral"
+  ],
+  "rewardHooks": {
+    "videoCallRewardKey": null,
+    "polaroidRewardKey": null
+  },
+  "status": "draft",
+  "rosterRegistrySource": "assets/manifest/starter-cast-registry.json"
+}

--- a/assets/content-packs/starter-cast-roster.spec.md
+++ b/assets/content-packs/starter-cast-roster.spec.md
@@ -5,7 +5,7 @@ This file is the repo-visible source of truth for issue `#69`. It defines the ap
 ## Contract decisions
 
 1. **Canonical identity source**: downstream packs must resolve each live `mapLocationId` through `packages/contracts/world-map-registry.sample.json` before choosing characters or rewards.
-2. **Starter roster coverage target**: each shared `dagLocationSlot` gets **two local starter characters per city**. When multiple live map pins in a city map to the same shared slot, they intentionally reuse the same two-character roster. If a city does not yet expose a live map pin for one shared slot, the roster still exists as a reserved starter pair so downstream pack planning stays aligned with the five-slot world model.
+2. **Starter roster coverage target**: each shared `dagLocationSlot` gets **two local starter characters per city when that slot is backed by a current live map pin**. When multiple live map pins in a city map to the same shared slot, they intentionally reuse the same two-character roster. Do not keep reserved starter pairs for non-live map pins in checked-in roster sources unless the canonical world-map registry exposes a live backing pin.
 3. **Tong remains global**: Tong is still available as the assistant guide in every session, but Tong is not counted toward the two-character local starter roster.
 4. **Stable logical IDs**:
    - Character ID: `char.<city>.<dagLocationSlot>.<name>`
@@ -36,7 +36,7 @@ This file is the repo-visible source of truth for issue `#69`. It defines the ap
 | Seoul | `cafe` | `cafe` | `char.seoul.cafe.sora`, `char.seoul.cafe.donghyun` | `pack.seoul.cafe.starter` | Study / cafe social pair |
 | Seoul | `convenience_store` | `convenience_store` | `char.seoul.convenience_store.eunji`, `char.seoul.convenience_store.hyunwoo` | `pack.seoul.convenience_store.starter` | Quick errand + slang practice |
 | Seoul | `subway_hub` | `subway_hub` | `char.seoul.subway_hub.nari`, `char.seoul.subway_hub.taemin` | `pack.seoul.subway_hub.starter` | Transit navigation + commute talk |
-| Seoul | `practice_studio` | `practice_studio` | `char.seoul.practice_studio.yujin`, `char.seoul.practice_studio.seungwoo` | `pack.seoul.practice_studio.starter` | Performance / rehearsal lane |
+| Seoul | `practice_studio` | `practice_studio` | `char.seoul.practice_studio.yujin`, `char.seoul.practice_studio.seungwoo` | `pack.seoul.practice_studio.starter` | Live pin is displayed to players as **Chimaek Place** while the registry-backed internal `mapLocationId` remains `practice_studio` |
 | Tokyo | `train_station` | `subway_hub` | `char.tokyo.subway_hub.akira`, `char.tokyo.subway_hub.mei` | `pack.tokyo.train_station.starter` | Reuses shared subway-hub slot |
 | Tokyo | `izakaya` | `food_street` | `char.tokyo.food_street.rin`, `char.tokyo.food_street.daichi` | `pack.tokyo.izakaya.starter` | Same slot pair reused across Tokyo food pins |
 | Tokyo | `konbini` | `convenience_store` | `char.tokyo.convenience_store.yui`, `char.tokyo.convenience_store.kaito` | `pack.tokyo.konbini.starter` | Konbini-specific wrapper on shared slot |
@@ -53,7 +53,6 @@ This file is the repo-visible source of truth for issue `#69`. It defines the ap
 The machine-readable roster lives in `assets/manifest/starter-cast-registry.json`. Downstream packs should reference that file instead of duplicating names, IDs, or asset key shapes.
 
 ### Reserved shared-slot rosters without a current live map pin
-- Tokyo `practice_studio` still gets an approved starter pair even though the current live Tokyo map pins do not expose that slot yet.
 - Shanghai `cafe` still gets an approved starter pair even though the current live Shanghai map pins do not expose that slot yet.
 
 ### Seoul
@@ -77,8 +76,6 @@ The machine-readable roster lives in `assets/manifest/starter-cast-registry.json
 - `char.tokyo.convenience_store.kaito` — after-school gamer, support
 - `char.tokyo.cafe.hina` — tea house host, lead
 - `char.tokyo.cafe.ren` — calligrapher regular, support
-- `char.tokyo.practice_studio.noa` — underground dance coach, lead
-- `char.tokyo.practice_studio.shin` — rehearsal pianist, support
 
 ### Shanghai
 - `char.shanghai.subway_hub.lin` — metro navigator, lead
@@ -94,7 +91,7 @@ The machine-readable roster lives in `assets/manifest/starter-cast-registry.json
 
 ## Downstream issue guidance
 
-- `#62` should cite this file and `assets/manifest/starter-cast-registry.json` as the approved Seoul roster/bundle source.
+- `#62` should cite this file and `assets/manifest/starter-cast-registry.json` as the approved Seoul roster/bundle source, and should explicitly call out the player-facing **Chimaek Place** label versus the internal `practice_studio` pin ID.
 - `#63` should cite the same sources for Tokyo, especially the dual-pin reuse of the `food_street` slot pair across `izakaya` and `ramen_shop`.
 - `#64` should cite the same sources for Shanghai, especially the `milk_tea_shop -> practice_studio` mapping and reward hooks for the advanced texting mission.
 - Runtime-assets can treat the required asset keys in the registry as the coverage checklist for future manifest entries.

--- a/assets/manifest/canonical-asset-manifest.json
+++ b/assets/manifest/canonical-asset-manifest.json
@@ -125,6 +125,536 @@
       "uri": "assets/content-packs/seoul-food-street.starter.json"
     },
     {
+      "key": "city.seoul.location.cafe.pack.starter",
+      "type": "content-pack",
+      "usage": "scene-authoring",
+      "source": "repo",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "status": "draft",
+      "uri": "assets/content-packs/seoul-cafe.starter.json"
+    },
+    {
+      "key": "city.seoul.location.convenience-store.pack.starter",
+      "type": "content-pack",
+      "usage": "scene-authoring",
+      "source": "repo",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "status": "draft",
+      "uri": "assets/content-packs/seoul-convenience-store.starter.json"
+    },
+    {
+      "key": "city.seoul.location.subway-hub.pack.starter",
+      "type": "content-pack",
+      "usage": "scene-authoring",
+      "source": "repo",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "status": "draft",
+      "uri": "assets/content-packs/seoul-subway-hub.starter.json"
+    },
+    {
+      "key": "city.seoul.location.practice-studio.pack.starter",
+      "type": "content-pack",
+      "usage": "scene-authoring",
+      "source": "repo",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "status": "draft",
+      "uri": "assets/content-packs/seoul-practice-studio.starter.json"
+    },
+    {
+      "key": "character.seoul.cafe.donghyun.portrait.default",
+      "source": "repo",
+      "status": "draft",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "uri": "/assets/characters/haeun/haeun.png"
+    },
+    {
+      "key": "character.seoul.cafe.donghyun.scene.default",
+      "source": "repo",
+      "status": "draft",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "type": "image",
+      "usage": "scene-still",
+      "uri": "/assets/characters/haeun/scene.png"
+    },
+    {
+      "key": "character.seoul.cafe.donghyun.sprite.default",
+      "source": "repo",
+      "status": "draft",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "type": "image",
+      "usage": "runtime-sprite",
+      "uri": "/assets/characters/haeun/eye_front_casual.png"
+    },
+    {
+      "key": "character.seoul.cafe.donghyun.voice.reference",
+      "source": "repo",
+      "status": "draft",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "type": "text",
+      "usage": "voice-reference",
+      "uri": "assets/content-packs/starter-cast-roster.spec.md"
+    },
+    {
+      "key": "character.seoul.cafe.sora.portrait.default",
+      "source": "repo",
+      "status": "draft",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "uri": "/assets/characters/haeun/haeun.png"
+    },
+    {
+      "key": "character.seoul.cafe.sora.scene.default",
+      "source": "repo",
+      "status": "draft",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "type": "image",
+      "usage": "scene-still",
+      "uri": "/assets/characters/haeun/scene.png"
+    },
+    {
+      "key": "character.seoul.cafe.sora.sprite.default",
+      "source": "repo",
+      "status": "draft",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "type": "image",
+      "usage": "runtime-sprite",
+      "uri": "/assets/characters/haeun/eye_front_casual.png"
+    },
+    {
+      "key": "character.seoul.cafe.sora.voice.reference",
+      "source": "repo",
+      "status": "draft",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "type": "text",
+      "usage": "voice-reference",
+      "uri": "assets/content-packs/starter-cast-roster.spec.md"
+    },
+    {
+      "key": "character.seoul.convenience_store.eunji.portrait.default",
+      "source": "repo",
+      "status": "draft",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "uri": "/assets/characters/haeun/haeun.png"
+    },
+    {
+      "key": "character.seoul.convenience_store.eunji.scene.default",
+      "source": "repo",
+      "status": "draft",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "type": "image",
+      "usage": "scene-still",
+      "uri": "/assets/characters/haeun/scene.png"
+    },
+    {
+      "key": "character.seoul.convenience_store.eunji.sprite.default",
+      "source": "repo",
+      "status": "draft",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "type": "image",
+      "usage": "runtime-sprite",
+      "uri": "/assets/characters/haeun/eye_front_casual.png"
+    },
+    {
+      "key": "character.seoul.convenience_store.eunji.voice.reference",
+      "source": "repo",
+      "status": "draft",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "type": "text",
+      "usage": "voice-reference",
+      "uri": "assets/content-packs/starter-cast-roster.spec.md"
+    },
+    {
+      "key": "character.seoul.convenience_store.hyunwoo.portrait.default",
+      "source": "repo",
+      "status": "draft",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "uri": "/assets/characters/haeun/haeun.png"
+    },
+    {
+      "key": "character.seoul.convenience_store.hyunwoo.scene.default",
+      "source": "repo",
+      "status": "draft",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "type": "image",
+      "usage": "scene-still",
+      "uri": "/assets/characters/haeun/scene.png"
+    },
+    {
+      "key": "character.seoul.convenience_store.hyunwoo.sprite.default",
+      "source": "repo",
+      "status": "draft",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "type": "image",
+      "usage": "runtime-sprite",
+      "uri": "/assets/characters/haeun/eye_front_casual.png"
+    },
+    {
+      "key": "character.seoul.convenience_store.hyunwoo.voice.reference",
+      "source": "repo",
+      "status": "draft",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "type": "text",
+      "usage": "voice-reference",
+      "uri": "assets/content-packs/starter-cast-roster.spec.md"
+    },
+    {
+      "key": "character.seoul.food_street.jiho.portrait.default",
+      "source": "repo",
+      "status": "draft",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "uri": "/assets/characters/haeun/haeun.png"
+    },
+    {
+      "key": "character.seoul.food_street.jiho.scene.default",
+      "source": "repo",
+      "status": "draft",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "type": "image",
+      "usage": "scene-still",
+      "uri": "/assets/characters/haeun/scene.png"
+    },
+    {
+      "key": "character.seoul.food_street.jiho.sprite.default",
+      "source": "repo",
+      "status": "draft",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "type": "image",
+      "usage": "runtime-sprite",
+      "uri": "/assets/characters/haeun/eye_front_casual.png"
+    },
+    {
+      "key": "character.seoul.food_street.jiho.voice.reference",
+      "source": "repo",
+      "status": "draft",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "type": "text",
+      "usage": "voice-reference",
+      "uri": "assets/content-packs/starter-cast-roster.spec.md"
+    },
+    {
+      "key": "character.seoul.food_street.minseo.portrait.default",
+      "source": "repo",
+      "status": "draft",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "uri": "/assets/characters/haeun/haeun.png"
+    },
+    {
+      "key": "character.seoul.food_street.minseo.scene.default",
+      "source": "repo",
+      "status": "draft",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "type": "image",
+      "usage": "scene-still",
+      "uri": "/assets/characters/haeun/scene.png"
+    },
+    {
+      "key": "character.seoul.food_street.minseo.sprite.default",
+      "source": "repo",
+      "status": "draft",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "type": "image",
+      "usage": "runtime-sprite",
+      "uri": "/assets/characters/haeun/eye_front_casual.png"
+    },
+    {
+      "key": "character.seoul.food_street.minseo.voice.reference",
+      "source": "repo",
+      "status": "draft",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "type": "text",
+      "usage": "voice-reference",
+      "uri": "assets/content-packs/starter-cast-roster.spec.md"
+    },
+    {
+      "key": "character.seoul.practice_studio.seungwoo.portrait.default",
+      "source": "repo",
+      "status": "draft",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "uri": "/assets/characters/haeun/haeun.png"
+    },
+    {
+      "key": "character.seoul.practice_studio.seungwoo.scene.default",
+      "source": "repo",
+      "status": "draft",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "type": "image",
+      "usage": "scene-still",
+      "uri": "/assets/characters/haeun/scene.png"
+    },
+    {
+      "key": "character.seoul.practice_studio.seungwoo.sprite.default",
+      "source": "repo",
+      "status": "draft",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "type": "image",
+      "usage": "runtime-sprite",
+      "uri": "/assets/characters/haeun/eye_front_casual.png"
+    },
+    {
+      "key": "character.seoul.practice_studio.seungwoo.voice.reference",
+      "source": "repo",
+      "status": "draft",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "type": "text",
+      "usage": "voice-reference",
+      "uri": "assets/content-packs/starter-cast-roster.spec.md"
+    },
+    {
+      "key": "character.seoul.practice_studio.yujin.portrait.default",
+      "source": "repo",
+      "status": "draft",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "uri": "/assets/characters/haeun/haeun.png"
+    },
+    {
+      "key": "character.seoul.practice_studio.yujin.scene.default",
+      "source": "repo",
+      "status": "draft",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "type": "image",
+      "usage": "scene-still",
+      "uri": "/assets/characters/haeun/scene.png"
+    },
+    {
+      "key": "character.seoul.practice_studio.yujin.sprite.default",
+      "source": "repo",
+      "status": "draft",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "type": "image",
+      "usage": "runtime-sprite",
+      "uri": "/assets/characters/haeun/eye_front_casual.png"
+    },
+    {
+      "key": "character.seoul.practice_studio.yujin.voice.reference",
+      "source": "repo",
+      "status": "draft",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "type": "text",
+      "usage": "voice-reference",
+      "uri": "assets/content-packs/starter-cast-roster.spec.md"
+    },
+    {
+      "key": "character.seoul.subway_hub.nari.portrait.default",
+      "source": "repo",
+      "status": "draft",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "uri": "/assets/characters/haeun/haeun.png"
+    },
+    {
+      "key": "character.seoul.subway_hub.nari.scene.default",
+      "source": "repo",
+      "status": "draft",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "type": "image",
+      "usage": "scene-still",
+      "uri": "/assets/characters/haeun/scene.png"
+    },
+    {
+      "key": "character.seoul.subway_hub.nari.sprite.default",
+      "source": "repo",
+      "status": "draft",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "type": "image",
+      "usage": "runtime-sprite",
+      "uri": "/assets/characters/haeun/eye_front_casual.png"
+    },
+    {
+      "key": "character.seoul.subway_hub.nari.voice.reference",
+      "source": "repo",
+      "status": "draft",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "type": "text",
+      "usage": "voice-reference",
+      "uri": "assets/content-packs/starter-cast-roster.spec.md"
+    },
+    {
+      "key": "character.seoul.subway_hub.taemin.portrait.default",
+      "source": "repo",
+      "status": "draft",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "uri": "/assets/characters/haeun/haeun.png"
+    },
+    {
+      "key": "character.seoul.subway_hub.taemin.scene.default",
+      "source": "repo",
+      "status": "draft",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "type": "image",
+      "usage": "scene-still",
+      "uri": "/assets/characters/haeun/scene.png"
+    },
+    {
+      "key": "character.seoul.subway_hub.taemin.sprite.default",
+      "source": "repo",
+      "status": "draft",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "type": "image",
+      "usage": "runtime-sprite",
+      "uri": "/assets/characters/haeun/eye_front_casual.png"
+    },
+    {
+      "key": "character.seoul.subway_hub.taemin.voice.reference",
+      "source": "repo",
+      "status": "draft",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "type": "text",
+      "usage": "voice-reference",
+      "uri": "assets/content-packs/starter-cast-roster.spec.md"
+    },
+    {
+      "key": "city.seoul.location.cafe.ambience.default",
+      "source": "repo",
+      "status": "draft",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "type": "audio",
+      "usage": "scene-ambience",
+      "uri": "/assets/locations/seoul.mp4"
+    },
+    {
+      "key": "city.seoul.location.cafe.backdrop.default",
+      "source": "repo",
+      "status": "draft",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "type": "image",
+      "usage": "scene-backdrop",
+      "uri": "/assets/backdrops/seoul/pojangmacha.png"
+    },
+    {
+      "key": "city.seoul.location.convenience-store.ambience.default",
+      "source": "repo",
+      "status": "draft",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "type": "audio",
+      "usage": "scene-ambience",
+      "uri": "/assets/locations/seoul.mp4"
+    },
+    {
+      "key": "city.seoul.location.convenience-store.backdrop.default",
+      "source": "repo",
+      "status": "draft",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "type": "image",
+      "usage": "scene-backdrop",
+      "uri": "/assets/backdrops/seoul/pojangmacha.png"
+    },
+    {
+      "key": "city.seoul.location.food-street.ambience.default",
+      "source": "repo",
+      "status": "draft",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "type": "audio",
+      "usage": "scene-ambience",
+      "uri": "/assets/locations/seoul.mp4"
+    },
+    {
+      "key": "city.seoul.location.practice-studio.ambience.default",
+      "source": "repo",
+      "status": "draft",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "type": "audio",
+      "usage": "scene-ambience",
+      "uri": "/assets/locations/seoul.mp4"
+    },
+    {
+      "key": "city.seoul.location.practice-studio.backdrop.default",
+      "source": "repo",
+      "status": "draft",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "type": "image",
+      "usage": "scene-backdrop",
+      "uri": "/assets/backdrops/seoul/pojangmacha.png"
+    },
+    {
+      "key": "city.seoul.location.subway-hub.ambience.default",
+      "source": "repo",
+      "status": "draft",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "type": "audio",
+      "usage": "scene-ambience",
+      "uri": "/assets/locations/seoul.mp4"
+    },
+    {
+      "key": "city.seoul.location.subway-hub.backdrop.default",
+      "source": "repo",
+      "status": "draft",
+      "rights": "internal-demo",
+      "promptTemplate": null,
+      "type": "image",
+      "usage": "scene-backdrop",
+      "uri": "/assets/backdrops/seoul/pojangmacha.png"
+    },
+    {
       "key": "character.ding-man.portrait.default",
       "type": "image",
       "usage": "dialogue-avatar",

--- a/assets/manifest/runtime-asset-manifest.json
+++ b/assets/manifest/runtime-asset-manifest.json
@@ -94,6 +94,430 @@
       "uri": "assets/content-packs/seoul-food-street.starter.json"
     },
     {
+      "key": "city.seoul.location.cafe.pack.starter",
+      "type": "content-pack",
+      "usage": "scene-authoring",
+      "source": "repo",
+      "status": "draft",
+      "uri": "assets/content-packs/seoul-cafe.starter.json"
+    },
+    {
+      "key": "city.seoul.location.convenience-store.pack.starter",
+      "type": "content-pack",
+      "usage": "scene-authoring",
+      "source": "repo",
+      "status": "draft",
+      "uri": "assets/content-packs/seoul-convenience-store.starter.json"
+    },
+    {
+      "key": "city.seoul.location.subway-hub.pack.starter",
+      "type": "content-pack",
+      "usage": "scene-authoring",
+      "source": "repo",
+      "status": "draft",
+      "uri": "assets/content-packs/seoul-subway-hub.starter.json"
+    },
+    {
+      "key": "city.seoul.location.practice-studio.pack.starter",
+      "type": "content-pack",
+      "usage": "scene-authoring",
+      "source": "repo",
+      "status": "draft",
+      "uri": "assets/content-packs/seoul-practice-studio.starter.json"
+    },
+    {
+      "key": "character.seoul.cafe.donghyun.portrait.default",
+      "source": "repo",
+      "status": "draft",
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "uri": "/assets/characters/haeun/haeun.png"
+    },
+    {
+      "key": "character.seoul.cafe.donghyun.scene.default",
+      "source": "repo",
+      "status": "draft",
+      "type": "image",
+      "usage": "scene-still",
+      "uri": "/assets/characters/haeun/scene.png"
+    },
+    {
+      "key": "character.seoul.cafe.donghyun.sprite.default",
+      "source": "repo",
+      "status": "draft",
+      "type": "image",
+      "usage": "runtime-sprite",
+      "uri": "/assets/characters/haeun/eye_front_casual.png"
+    },
+    {
+      "key": "character.seoul.cafe.donghyun.voice.reference",
+      "source": "repo",
+      "status": "draft",
+      "type": "text",
+      "usage": "voice-reference",
+      "uri": "assets/content-packs/starter-cast-roster.spec.md"
+    },
+    {
+      "key": "character.seoul.cafe.sora.portrait.default",
+      "source": "repo",
+      "status": "draft",
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "uri": "/assets/characters/haeun/haeun.png"
+    },
+    {
+      "key": "character.seoul.cafe.sora.scene.default",
+      "source": "repo",
+      "status": "draft",
+      "type": "image",
+      "usage": "scene-still",
+      "uri": "/assets/characters/haeun/scene.png"
+    },
+    {
+      "key": "character.seoul.cafe.sora.sprite.default",
+      "source": "repo",
+      "status": "draft",
+      "type": "image",
+      "usage": "runtime-sprite",
+      "uri": "/assets/characters/haeun/eye_front_casual.png"
+    },
+    {
+      "key": "character.seoul.cafe.sora.voice.reference",
+      "source": "repo",
+      "status": "draft",
+      "type": "text",
+      "usage": "voice-reference",
+      "uri": "assets/content-packs/starter-cast-roster.spec.md"
+    },
+    {
+      "key": "character.seoul.convenience_store.eunji.portrait.default",
+      "source": "repo",
+      "status": "draft",
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "uri": "/assets/characters/haeun/haeun.png"
+    },
+    {
+      "key": "character.seoul.convenience_store.eunji.scene.default",
+      "source": "repo",
+      "status": "draft",
+      "type": "image",
+      "usage": "scene-still",
+      "uri": "/assets/characters/haeun/scene.png"
+    },
+    {
+      "key": "character.seoul.convenience_store.eunji.sprite.default",
+      "source": "repo",
+      "status": "draft",
+      "type": "image",
+      "usage": "runtime-sprite",
+      "uri": "/assets/characters/haeun/eye_front_casual.png"
+    },
+    {
+      "key": "character.seoul.convenience_store.eunji.voice.reference",
+      "source": "repo",
+      "status": "draft",
+      "type": "text",
+      "usage": "voice-reference",
+      "uri": "assets/content-packs/starter-cast-roster.spec.md"
+    },
+    {
+      "key": "character.seoul.convenience_store.hyunwoo.portrait.default",
+      "source": "repo",
+      "status": "draft",
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "uri": "/assets/characters/haeun/haeun.png"
+    },
+    {
+      "key": "character.seoul.convenience_store.hyunwoo.scene.default",
+      "source": "repo",
+      "status": "draft",
+      "type": "image",
+      "usage": "scene-still",
+      "uri": "/assets/characters/haeun/scene.png"
+    },
+    {
+      "key": "character.seoul.convenience_store.hyunwoo.sprite.default",
+      "source": "repo",
+      "status": "draft",
+      "type": "image",
+      "usage": "runtime-sprite",
+      "uri": "/assets/characters/haeun/eye_front_casual.png"
+    },
+    {
+      "key": "character.seoul.convenience_store.hyunwoo.voice.reference",
+      "source": "repo",
+      "status": "draft",
+      "type": "text",
+      "usage": "voice-reference",
+      "uri": "assets/content-packs/starter-cast-roster.spec.md"
+    },
+    {
+      "key": "character.seoul.food_street.jiho.portrait.default",
+      "source": "repo",
+      "status": "draft",
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "uri": "/assets/characters/haeun/haeun.png"
+    },
+    {
+      "key": "character.seoul.food_street.jiho.scene.default",
+      "source": "repo",
+      "status": "draft",
+      "type": "image",
+      "usage": "scene-still",
+      "uri": "/assets/characters/haeun/scene.png"
+    },
+    {
+      "key": "character.seoul.food_street.jiho.sprite.default",
+      "source": "repo",
+      "status": "draft",
+      "type": "image",
+      "usage": "runtime-sprite",
+      "uri": "/assets/characters/haeun/eye_front_casual.png"
+    },
+    {
+      "key": "character.seoul.food_street.jiho.voice.reference",
+      "source": "repo",
+      "status": "draft",
+      "type": "text",
+      "usage": "voice-reference",
+      "uri": "assets/content-packs/starter-cast-roster.spec.md"
+    },
+    {
+      "key": "character.seoul.food_street.minseo.portrait.default",
+      "source": "repo",
+      "status": "draft",
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "uri": "/assets/characters/haeun/haeun.png"
+    },
+    {
+      "key": "character.seoul.food_street.minseo.scene.default",
+      "source": "repo",
+      "status": "draft",
+      "type": "image",
+      "usage": "scene-still",
+      "uri": "/assets/characters/haeun/scene.png"
+    },
+    {
+      "key": "character.seoul.food_street.minseo.sprite.default",
+      "source": "repo",
+      "status": "draft",
+      "type": "image",
+      "usage": "runtime-sprite",
+      "uri": "/assets/characters/haeun/eye_front_casual.png"
+    },
+    {
+      "key": "character.seoul.food_street.minseo.voice.reference",
+      "source": "repo",
+      "status": "draft",
+      "type": "text",
+      "usage": "voice-reference",
+      "uri": "assets/content-packs/starter-cast-roster.spec.md"
+    },
+    {
+      "key": "character.seoul.practice_studio.seungwoo.portrait.default",
+      "source": "repo",
+      "status": "draft",
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "uri": "/assets/characters/haeun/haeun.png"
+    },
+    {
+      "key": "character.seoul.practice_studio.seungwoo.scene.default",
+      "source": "repo",
+      "status": "draft",
+      "type": "image",
+      "usage": "scene-still",
+      "uri": "/assets/characters/haeun/scene.png"
+    },
+    {
+      "key": "character.seoul.practice_studio.seungwoo.sprite.default",
+      "source": "repo",
+      "status": "draft",
+      "type": "image",
+      "usage": "runtime-sprite",
+      "uri": "/assets/characters/haeun/eye_front_casual.png"
+    },
+    {
+      "key": "character.seoul.practice_studio.seungwoo.voice.reference",
+      "source": "repo",
+      "status": "draft",
+      "type": "text",
+      "usage": "voice-reference",
+      "uri": "assets/content-packs/starter-cast-roster.spec.md"
+    },
+    {
+      "key": "character.seoul.practice_studio.yujin.portrait.default",
+      "source": "repo",
+      "status": "draft",
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "uri": "/assets/characters/haeun/haeun.png"
+    },
+    {
+      "key": "character.seoul.practice_studio.yujin.scene.default",
+      "source": "repo",
+      "status": "draft",
+      "type": "image",
+      "usage": "scene-still",
+      "uri": "/assets/characters/haeun/scene.png"
+    },
+    {
+      "key": "character.seoul.practice_studio.yujin.sprite.default",
+      "source": "repo",
+      "status": "draft",
+      "type": "image",
+      "usage": "runtime-sprite",
+      "uri": "/assets/characters/haeun/eye_front_casual.png"
+    },
+    {
+      "key": "character.seoul.practice_studio.yujin.voice.reference",
+      "source": "repo",
+      "status": "draft",
+      "type": "text",
+      "usage": "voice-reference",
+      "uri": "assets/content-packs/starter-cast-roster.spec.md"
+    },
+    {
+      "key": "character.seoul.subway_hub.nari.portrait.default",
+      "source": "repo",
+      "status": "draft",
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "uri": "/assets/characters/haeun/haeun.png"
+    },
+    {
+      "key": "character.seoul.subway_hub.nari.scene.default",
+      "source": "repo",
+      "status": "draft",
+      "type": "image",
+      "usage": "scene-still",
+      "uri": "/assets/characters/haeun/scene.png"
+    },
+    {
+      "key": "character.seoul.subway_hub.nari.sprite.default",
+      "source": "repo",
+      "status": "draft",
+      "type": "image",
+      "usage": "runtime-sprite",
+      "uri": "/assets/characters/haeun/eye_front_casual.png"
+    },
+    {
+      "key": "character.seoul.subway_hub.nari.voice.reference",
+      "source": "repo",
+      "status": "draft",
+      "type": "text",
+      "usage": "voice-reference",
+      "uri": "assets/content-packs/starter-cast-roster.spec.md"
+    },
+    {
+      "key": "character.seoul.subway_hub.taemin.portrait.default",
+      "source": "repo",
+      "status": "draft",
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "uri": "/assets/characters/haeun/haeun.png"
+    },
+    {
+      "key": "character.seoul.subway_hub.taemin.scene.default",
+      "source": "repo",
+      "status": "draft",
+      "type": "image",
+      "usage": "scene-still",
+      "uri": "/assets/characters/haeun/scene.png"
+    },
+    {
+      "key": "character.seoul.subway_hub.taemin.sprite.default",
+      "source": "repo",
+      "status": "draft",
+      "type": "image",
+      "usage": "runtime-sprite",
+      "uri": "/assets/characters/haeun/eye_front_casual.png"
+    },
+    {
+      "key": "character.seoul.subway_hub.taemin.voice.reference",
+      "source": "repo",
+      "status": "draft",
+      "type": "text",
+      "usage": "voice-reference",
+      "uri": "assets/content-packs/starter-cast-roster.spec.md"
+    },
+    {
+      "key": "city.seoul.location.cafe.ambience.default",
+      "source": "repo",
+      "status": "draft",
+      "type": "audio",
+      "usage": "scene-ambience",
+      "uri": "/assets/locations/seoul.mp4"
+    },
+    {
+      "key": "city.seoul.location.cafe.backdrop.default",
+      "source": "repo",
+      "status": "draft",
+      "type": "image",
+      "usage": "scene-backdrop",
+      "uri": "/assets/backdrops/seoul/pojangmacha.png"
+    },
+    {
+      "key": "city.seoul.location.convenience-store.ambience.default",
+      "source": "repo",
+      "status": "draft",
+      "type": "audio",
+      "usage": "scene-ambience",
+      "uri": "/assets/locations/seoul.mp4"
+    },
+    {
+      "key": "city.seoul.location.convenience-store.backdrop.default",
+      "source": "repo",
+      "status": "draft",
+      "type": "image",
+      "usage": "scene-backdrop",
+      "uri": "/assets/backdrops/seoul/pojangmacha.png"
+    },
+    {
+      "key": "city.seoul.location.food-street.ambience.default",
+      "source": "repo",
+      "status": "draft",
+      "type": "audio",
+      "usage": "scene-ambience",
+      "uri": "/assets/locations/seoul.mp4"
+    },
+    {
+      "key": "city.seoul.location.practice-studio.ambience.default",
+      "source": "repo",
+      "status": "draft",
+      "type": "audio",
+      "usage": "scene-ambience",
+      "uri": "/assets/locations/seoul.mp4"
+    },
+    {
+      "key": "city.seoul.location.practice-studio.backdrop.default",
+      "source": "repo",
+      "status": "draft",
+      "type": "image",
+      "usage": "scene-backdrop",
+      "uri": "/assets/backdrops/seoul/pojangmacha.png"
+    },
+    {
+      "key": "city.seoul.location.subway-hub.ambience.default",
+      "source": "repo",
+      "status": "draft",
+      "type": "audio",
+      "usage": "scene-ambience",
+      "uri": "/assets/locations/seoul.mp4"
+    },
+    {
+      "key": "city.seoul.location.subway-hub.backdrop.default",
+      "source": "repo",
+      "status": "draft",
+      "type": "image",
+      "usage": "scene-backdrop",
+      "uri": "/assets/backdrops/seoul/pojangmacha.png"
+    },
+    {
       "key": "character.ding-man.portrait.default",
       "type": "image",
       "usage": "dialogue-avatar",

--- a/assets/manifest/starter-cast-registry.json
+++ b/assets/manifest/starter-cast-registry.json
@@ -1,7 +1,9 @@
 {
   "registryVersion": "2026-03-21",
   "issue": 69,
-  "dependsOn": [114],
+  "dependsOn": [
+    114
+  ],
   "sourceMapRegistry": "packages/contracts/world-map-registry.sample.json",
   "keyConventions": {
     "characterId": "char.<city>.<dagLocationSlot>.<name>",
@@ -59,7 +61,7 @@
     "runtimeAssumptions": [
       "Every playable city/map pin resolves through packages/contracts/world-map-registry.sample.json before selecting a roster.",
       "Each live mapLocationId references one starter slot roster via its dagLocationSlot and may reuse the same two-character roster across multiple pins in the same city.",
-      "Cities may also define reserved shared-slot rosters with no current live map pin yet so downstream city-pack planning stays aligned with the five-slot world model.",
+      "Cities may define reserved shared-slot rosters with no current live map pin only when downstream issue scope explicitly requires them; non-live reserved rosters should otherwise stay out of checked-in sources.",
       "Tong remains a global assistant and is not counted toward the two local starter characters per slot.",
       "If optional outputs are missing, runtime-assets falls back to portrait.default + scene.default without blocking pack approval."
     ]
@@ -204,15 +206,6 @@
           "coveredMapLocationIds": [
             "tea_house"
           ]
-        },
-        {
-          "slotRosterId": "slot.tokyo.practice_studio.starter",
-          "dagLocationSlot": "practice_studio",
-          "characterIds": [
-            "char.tokyo.practice_studio.noa",
-            "char.tokyo.practice_studio.shin"
-          ],
-          "coveredMapLocationIds": []
         }
       ],
       "mapPins": [
@@ -349,35 +342,484 @@
     }
   ],
   "characters": [
-    {"characterId":"char.seoul.food_street.minseo","displayName":"Minseo","cityId":"seoul","dagLocationSlot":"food_street","archetype":"night-market host","packRole":"lead","requiredAssetKeys":["character.seoul.food_street.minseo.portrait.default","character.seoul.food_street.minseo.sprite.default","character.seoul.food_street.minseo.scene.default","character.seoul.food_street.minseo.voice.reference"],"optionalAssetKeys":["character.seoul.food_street.minseo.sprite.expression-set","character.seoul.food_street.minseo.reward.polaroid"]},
-    {"characterId":"char.seoul.food_street.jiho","displayName":"Jiho","cityId":"seoul","dagLocationSlot":"food_street","archetype":"late-shift foodie","packRole":"support","requiredAssetKeys":["character.seoul.food_street.jiho.portrait.default","character.seoul.food_street.jiho.sprite.default","character.seoul.food_street.jiho.scene.default","character.seoul.food_street.jiho.voice.reference"],"optionalAssetKeys":["character.seoul.food_street.jiho.sprite.expression-set"]},
-    {"characterId":"char.seoul.cafe.sora","displayName":"Sora","cityId":"seoul","dagLocationSlot":"cafe","archetype":"study-barista","packRole":"lead","requiredAssetKeys":["character.seoul.cafe.sora.portrait.default","character.seoul.cafe.sora.sprite.default","character.seoul.cafe.sora.scene.default","character.seoul.cafe.sora.voice.reference"],"optionalAssetKeys":["character.seoul.cafe.sora.sprite.expression-set"]},
-    {"characterId":"char.seoul.cafe.donghyun","displayName":"Donghyun","cityId":"seoul","dagLocationSlot":"cafe","archetype":"indie songwriter","packRole":"support","requiredAssetKeys":["character.seoul.cafe.donghyun.portrait.default","character.seoul.cafe.donghyun.sprite.default","character.seoul.cafe.donghyun.scene.default","character.seoul.cafe.donghyun.voice.reference"],"optionalAssetKeys":["character.seoul.cafe.donghyun.intro.video"]},
-    {"characterId":"char.seoul.convenience_store.eunji","displayName":"Eunji","cityId":"seoul","dagLocationSlot":"convenience_store","archetype":"overnight clerk","packRole":"lead","requiredAssetKeys":["character.seoul.convenience_store.eunji.portrait.default","character.seoul.convenience_store.eunji.sprite.default","character.seoul.convenience_store.eunji.scene.default","character.seoul.convenience_store.eunji.voice.reference"],"optionalAssetKeys":["character.seoul.convenience_store.eunji.sprite.expression-set"]},
-    {"characterId":"char.seoul.convenience_store.hyunwoo","displayName":"Hyunwoo","cityId":"seoul","dagLocationSlot":"convenience_store","archetype":"snack reviewer","packRole":"support","requiredAssetKeys":["character.seoul.convenience_store.hyunwoo.portrait.default","character.seoul.convenience_store.hyunwoo.sprite.default","character.seoul.convenience_store.hyunwoo.scene.default","character.seoul.convenience_store.hyunwoo.voice.reference"],"optionalAssetKeys":["character.seoul.convenience_store.hyunwoo.reward.polaroid"]},
-    {"characterId":"char.seoul.subway_hub.nari","displayName":"Nari","cityId":"seoul","dagLocationSlot":"subway_hub","archetype":"commuter mentor","packRole":"lead","requiredAssetKeys":["character.seoul.subway_hub.nari.portrait.default","character.seoul.subway_hub.nari.sprite.default","character.seoul.subway_hub.nari.scene.default","character.seoul.subway_hub.nari.voice.reference"],"optionalAssetKeys":["character.seoul.subway_hub.nari.sprite.expression-set"]},
-    {"characterId":"char.seoul.subway_hub.taemin","displayName":"Taemin","cityId":"seoul","dagLocationSlot":"subway_hub","archetype":"busker commuter","packRole":"support","requiredAssetKeys":["character.seoul.subway_hub.taemin.portrait.default","character.seoul.subway_hub.taemin.sprite.default","character.seoul.subway_hub.taemin.scene.default","character.seoul.subway_hub.taemin.voice.reference"],"optionalAssetKeys":["character.seoul.subway_hub.taemin.intro.video"]},
-    {"characterId":"char.seoul.practice_studio.yujin","displayName":"Yujin","cityId":"seoul","dagLocationSlot":"practice_studio","archetype":"dance captain","packRole":"lead","requiredAssetKeys":["character.seoul.practice_studio.yujin.portrait.default","character.seoul.practice_studio.yujin.sprite.default","character.seoul.practice_studio.yujin.scene.default","character.seoul.practice_studio.yujin.voice.reference"],"optionalAssetKeys":["character.seoul.practice_studio.yujin.sprite.expression-set"]},
-    {"characterId":"char.seoul.practice_studio.seungwoo","displayName":"Seungwoo","cityId":"seoul","dagLocationSlot":"practice_studio","archetype":"producer trainee","packRole":"support","requiredAssetKeys":["character.seoul.practice_studio.seungwoo.portrait.default","character.seoul.practice_studio.seungwoo.sprite.default","character.seoul.practice_studio.seungwoo.scene.default","character.seoul.practice_studio.seungwoo.voice.reference"],"optionalAssetKeys":["character.seoul.practice_studio.seungwoo.reward.polaroid"]},
-    {"characterId":"char.tokyo.subway_hub.akira","displayName":"Akira","cityId":"tokyo","dagLocationSlot":"subway_hub","archetype":"rail guide","packRole":"lead","requiredAssetKeys":["character.tokyo.subway_hub.akira.portrait.default","character.tokyo.subway_hub.akira.sprite.default","character.tokyo.subway_hub.akira.scene.default","character.tokyo.subway_hub.akira.voice.reference"],"optionalAssetKeys":["character.tokyo.subway_hub.akira.sprite.expression-set"]},
-    {"characterId":"char.tokyo.subway_hub.mei","displayName":"Mei","cityId":"tokyo","dagLocationSlot":"subway_hub","archetype":"rush-hour illustrator","packRole":"support","requiredAssetKeys":["character.tokyo.subway_hub.mei.portrait.default","character.tokyo.subway_hub.mei.sprite.default","character.tokyo.subway_hub.mei.scene.default","character.tokyo.subway_hub.mei.voice.reference"],"optionalAssetKeys":["character.tokyo.subway_hub.mei.reward.polaroid"]},
-    {"characterId":"char.tokyo.food_street.rin","displayName":"Rin","cityId":"tokyo","dagLocationSlot":"food_street","archetype":"izakaya server","packRole":"lead","requiredAssetKeys":["character.tokyo.food_street.rin.portrait.default","character.tokyo.food_street.rin.sprite.default","character.tokyo.food_street.rin.scene.default","character.tokyo.food_street.rin.voice.reference"],"optionalAssetKeys":["character.tokyo.food_street.rin.sprite.expression-set"]},
-    {"characterId":"char.tokyo.food_street.daichi","displayName":"Daichi","cityId":"tokyo","dagLocationSlot":"food_street","archetype":"ramen regular","packRole":"support","requiredAssetKeys":["character.tokyo.food_street.daichi.portrait.default","character.tokyo.food_street.daichi.sprite.default","character.tokyo.food_street.daichi.scene.default","character.tokyo.food_street.daichi.voice.reference"],"optionalAssetKeys":["character.tokyo.food_street.daichi.intro.video"]},
-    {"characterId":"char.tokyo.convenience_store.yui","displayName":"Yui","cityId":"tokyo","dagLocationSlot":"convenience_store","archetype":"konbini shift lead","packRole":"lead","requiredAssetKeys":["character.tokyo.convenience_store.yui.portrait.default","character.tokyo.convenience_store.yui.sprite.default","character.tokyo.convenience_store.yui.scene.default","character.tokyo.convenience_store.yui.voice.reference"],"optionalAssetKeys":["character.tokyo.convenience_store.yui.sprite.expression-set"]},
-    {"characterId":"char.tokyo.convenience_store.kaito","displayName":"Kaito","cityId":"tokyo","dagLocationSlot":"convenience_store","archetype":"after-school gamer","packRole":"support","requiredAssetKeys":["character.tokyo.convenience_store.kaito.portrait.default","character.tokyo.convenience_store.kaito.sprite.default","character.tokyo.convenience_store.kaito.scene.default","character.tokyo.convenience_store.kaito.voice.reference"],"optionalAssetKeys":["character.tokyo.convenience_store.kaito.reward.polaroid"]},
-    {"characterId":"char.tokyo.cafe.hina","displayName":"Hina","cityId":"tokyo","dagLocationSlot":"cafe","archetype":"tea house host","packRole":"lead","requiredAssetKeys":["character.tokyo.cafe.hina.portrait.default","character.tokyo.cafe.hina.sprite.default","character.tokyo.cafe.hina.scene.default","character.tokyo.cafe.hina.voice.reference"],"optionalAssetKeys":["character.tokyo.cafe.hina.sprite.expression-set"]},
-    {"characterId":"char.tokyo.cafe.ren","displayName":"Ren","cityId":"tokyo","dagLocationSlot":"cafe","archetype":"calligrapher regular","packRole":"support","requiredAssetKeys":["character.tokyo.cafe.ren.portrait.default","character.tokyo.cafe.ren.sprite.default","character.tokyo.cafe.ren.scene.default","character.tokyo.cafe.ren.voice.reference"],"optionalAssetKeys":["character.tokyo.cafe.ren.intro.video"]},
-    {"characterId":"char.tokyo.practice_studio.noa","displayName":"Noa","cityId":"tokyo","dagLocationSlot":"practice_studio","archetype":"underground dance coach","packRole":"lead","requiredAssetKeys":["character.tokyo.practice_studio.noa.portrait.default","character.tokyo.practice_studio.noa.sprite.default","character.tokyo.practice_studio.noa.scene.default","character.tokyo.practice_studio.noa.voice.reference"],"optionalAssetKeys":["character.tokyo.practice_studio.noa.sprite.expression-set"]},
-    {"characterId":"char.tokyo.practice_studio.shin","displayName":"Shin","cityId":"tokyo","dagLocationSlot":"practice_studio","archetype":"rehearsal pianist","packRole":"support","requiredAssetKeys":["character.tokyo.practice_studio.shin.portrait.default","character.tokyo.practice_studio.shin.sprite.default","character.tokyo.practice_studio.shin.scene.default","character.tokyo.practice_studio.shin.voice.reference"],"optionalAssetKeys":["character.tokyo.practice_studio.shin.intro.video"]},
-    {"characterId":"char.shanghai.subway_hub.lin","displayName":"Lin","cityId":"shanghai","dagLocationSlot":"subway_hub","archetype":"metro navigator","packRole":"lead","requiredAssetKeys":["character.shanghai.subway_hub.lin.portrait.default","character.shanghai.subway_hub.lin.sprite.default","character.shanghai.subway_hub.lin.scene.default","character.shanghai.subway_hub.lin.voice.reference"],"optionalAssetKeys":["character.shanghai.subway_hub.lin.sprite.expression-set"]},
-    {"characterId":"char.shanghai.subway_hub.wei","displayName":"Wei","cityId":"shanghai","dagLocationSlot":"subway_hub","archetype":"delivery rider","packRole":"support","requiredAssetKeys":["character.shanghai.subway_hub.wei.portrait.default","character.shanghai.subway_hub.wei.sprite.default","character.shanghai.subway_hub.wei.scene.default","character.shanghai.subway_hub.wei.voice.reference"],"optionalAssetKeys":["character.shanghai.subway_hub.wei.reward.polaroid"]},
-    {"characterId":"char.shanghai.food_street.qiao","displayName":"Qiao","cityId":"shanghai","dagLocationSlot":"food_street","archetype":"bbq vendor","packRole":"lead","requiredAssetKeys":["character.shanghai.food_street.qiao.portrait.default","character.shanghai.food_street.qiao.sprite.default","character.shanghai.food_street.qiao.scene.default","character.shanghai.food_street.qiao.voice.reference"],"optionalAssetKeys":["character.shanghai.food_street.qiao.sprite.expression-set"]},
-    {"characterId":"char.shanghai.food_street.ming","displayName":"Ming","cityId":"shanghai","dagLocationSlot":"food_street","archetype":"dumpling scout","packRole":"support","requiredAssetKeys":["character.shanghai.food_street.ming.portrait.default","character.shanghai.food_street.ming.sprite.default","character.shanghai.food_street.ming.scene.default","character.shanghai.food_street.ming.voice.reference"],"optionalAssetKeys":["character.shanghai.food_street.ming.intro.video"]},
-    {"characterId":"char.shanghai.convenience_store.an","displayName":"An","cityId":"shanghai","dagLocationSlot":"convenience_store","archetype":"night cashier","packRole":"lead","requiredAssetKeys":["character.shanghai.convenience_store.an.portrait.default","character.shanghai.convenience_store.an.sprite.default","character.shanghai.convenience_store.an.scene.default","character.shanghai.convenience_store.an.voice.reference"],"optionalAssetKeys":["character.shanghai.convenience_store.an.sprite.expression-set"]},
-    {"characterId":"char.shanghai.convenience_store.yue","displayName":"Yue","cityId":"shanghai","dagLocationSlot":"convenience_store","archetype":"study-group organizer","packRole":"support","requiredAssetKeys":["character.shanghai.convenience_store.yue.portrait.default","character.shanghai.convenience_store.yue.sprite.default","character.shanghai.convenience_store.yue.scene.default","character.shanghai.convenience_store.yue.voice.reference"],"optionalAssetKeys":["character.shanghai.convenience_store.yue.reward.polaroid"]},
-    {"characterId":"char.shanghai.cafe.jing","displayName":"Jing","cityId":"shanghai","dagLocationSlot":"cafe","archetype":"milk-foam barista","packRole":"lead","requiredAssetKeys":["character.shanghai.cafe.jing.portrait.default","character.shanghai.cafe.jing.sprite.default","character.shanghai.cafe.jing.scene.default","character.shanghai.cafe.jing.voice.reference"],"optionalAssetKeys":["character.shanghai.cafe.jing.sprite.expression-set"]},
-    {"characterId":"char.shanghai.cafe.hao","displayName":"Hao","cityId":"shanghai","dagLocationSlot":"cafe","archetype":"tabletop sketch artist","packRole":"support","requiredAssetKeys":["character.shanghai.cafe.hao.portrait.default","character.shanghai.cafe.hao.sprite.default","character.shanghai.cafe.hao.scene.default","character.shanghai.cafe.hao.voice.reference"],"optionalAssetKeys":["character.shanghai.cafe.hao.intro.video"]},
-    {"characterId":"char.shanghai.practice_studio.xinyi","displayName":"Xinyi","cityId":"shanghai","dagLocationSlot":"practice_studio","archetype":"dance challenge streamer","packRole":"lead","requiredAssetKeys":["character.shanghai.practice_studio.xinyi.portrait.default","character.shanghai.practice_studio.xinyi.sprite.default","character.shanghai.practice_studio.xinyi.scene.default","character.shanghai.practice_studio.xinyi.voice.reference"],"optionalAssetKeys":["character.shanghai.practice_studio.xinyi.reward.video-call","character.shanghai.practice_studio.xinyi.reward.polaroid"]},
-    {"characterId":"char.shanghai.practice_studio.zhen","displayName":"Zhen","cityId":"shanghai","dagLocationSlot":"practice_studio","archetype":"sound engineer","packRole":"support","requiredAssetKeys":["character.shanghai.practice_studio.zhen.portrait.default","character.shanghai.practice_studio.zhen.sprite.default","character.shanghai.practice_studio.zhen.scene.default","character.shanghai.practice_studio.zhen.voice.reference"],"optionalAssetKeys":["character.shanghai.practice_studio.zhen.sprite.expression-set","character.shanghai.practice_studio.zhen.reward.video-call"]}
+    {
+      "characterId": "char.seoul.food_street.minseo",
+      "displayName": "Minseo",
+      "cityId": "seoul",
+      "dagLocationSlot": "food_street",
+      "archetype": "night-market host",
+      "packRole": "lead",
+      "requiredAssetKeys": [
+        "character.seoul.food_street.minseo.portrait.default",
+        "character.seoul.food_street.minseo.sprite.default",
+        "character.seoul.food_street.minseo.scene.default",
+        "character.seoul.food_street.minseo.voice.reference"
+      ],
+      "optionalAssetKeys": [
+        "character.seoul.food_street.minseo.sprite.expression-set",
+        "character.seoul.food_street.minseo.reward.polaroid"
+      ]
+    },
+    {
+      "characterId": "char.seoul.food_street.jiho",
+      "displayName": "Jiho",
+      "cityId": "seoul",
+      "dagLocationSlot": "food_street",
+      "archetype": "late-shift foodie",
+      "packRole": "support",
+      "requiredAssetKeys": [
+        "character.seoul.food_street.jiho.portrait.default",
+        "character.seoul.food_street.jiho.sprite.default",
+        "character.seoul.food_street.jiho.scene.default",
+        "character.seoul.food_street.jiho.voice.reference"
+      ],
+      "optionalAssetKeys": [
+        "character.seoul.food_street.jiho.sprite.expression-set"
+      ]
+    },
+    {
+      "characterId": "char.seoul.cafe.sora",
+      "displayName": "Sora",
+      "cityId": "seoul",
+      "dagLocationSlot": "cafe",
+      "archetype": "study-barista",
+      "packRole": "lead",
+      "requiredAssetKeys": [
+        "character.seoul.cafe.sora.portrait.default",
+        "character.seoul.cafe.sora.sprite.default",
+        "character.seoul.cafe.sora.scene.default",
+        "character.seoul.cafe.sora.voice.reference"
+      ],
+      "optionalAssetKeys": [
+        "character.seoul.cafe.sora.sprite.expression-set"
+      ]
+    },
+    {
+      "characterId": "char.seoul.cafe.donghyun",
+      "displayName": "Donghyun",
+      "cityId": "seoul",
+      "dagLocationSlot": "cafe",
+      "archetype": "indie songwriter",
+      "packRole": "support",
+      "requiredAssetKeys": [
+        "character.seoul.cafe.donghyun.portrait.default",
+        "character.seoul.cafe.donghyun.sprite.default",
+        "character.seoul.cafe.donghyun.scene.default",
+        "character.seoul.cafe.donghyun.voice.reference"
+      ],
+      "optionalAssetKeys": [
+        "character.seoul.cafe.donghyun.intro.video"
+      ]
+    },
+    {
+      "characterId": "char.seoul.convenience_store.eunji",
+      "displayName": "Eunji",
+      "cityId": "seoul",
+      "dagLocationSlot": "convenience_store",
+      "archetype": "overnight clerk",
+      "packRole": "lead",
+      "requiredAssetKeys": [
+        "character.seoul.convenience_store.eunji.portrait.default",
+        "character.seoul.convenience_store.eunji.sprite.default",
+        "character.seoul.convenience_store.eunji.scene.default",
+        "character.seoul.convenience_store.eunji.voice.reference"
+      ],
+      "optionalAssetKeys": [
+        "character.seoul.convenience_store.eunji.sprite.expression-set"
+      ]
+    },
+    {
+      "characterId": "char.seoul.convenience_store.hyunwoo",
+      "displayName": "Hyunwoo",
+      "cityId": "seoul",
+      "dagLocationSlot": "convenience_store",
+      "archetype": "snack reviewer",
+      "packRole": "support",
+      "requiredAssetKeys": [
+        "character.seoul.convenience_store.hyunwoo.portrait.default",
+        "character.seoul.convenience_store.hyunwoo.sprite.default",
+        "character.seoul.convenience_store.hyunwoo.scene.default",
+        "character.seoul.convenience_store.hyunwoo.voice.reference"
+      ],
+      "optionalAssetKeys": [
+        "character.seoul.convenience_store.hyunwoo.reward.polaroid"
+      ]
+    },
+    {
+      "characterId": "char.seoul.subway_hub.nari",
+      "displayName": "Nari",
+      "cityId": "seoul",
+      "dagLocationSlot": "subway_hub",
+      "archetype": "commuter mentor",
+      "packRole": "lead",
+      "requiredAssetKeys": [
+        "character.seoul.subway_hub.nari.portrait.default",
+        "character.seoul.subway_hub.nari.sprite.default",
+        "character.seoul.subway_hub.nari.scene.default",
+        "character.seoul.subway_hub.nari.voice.reference"
+      ],
+      "optionalAssetKeys": [
+        "character.seoul.subway_hub.nari.sprite.expression-set"
+      ]
+    },
+    {
+      "characterId": "char.seoul.subway_hub.taemin",
+      "displayName": "Taemin",
+      "cityId": "seoul",
+      "dagLocationSlot": "subway_hub",
+      "archetype": "busker commuter",
+      "packRole": "support",
+      "requiredAssetKeys": [
+        "character.seoul.subway_hub.taemin.portrait.default",
+        "character.seoul.subway_hub.taemin.sprite.default",
+        "character.seoul.subway_hub.taemin.scene.default",
+        "character.seoul.subway_hub.taemin.voice.reference"
+      ],
+      "optionalAssetKeys": [
+        "character.seoul.subway_hub.taemin.intro.video"
+      ]
+    },
+    {
+      "characterId": "char.seoul.practice_studio.yujin",
+      "displayName": "Yujin",
+      "cityId": "seoul",
+      "dagLocationSlot": "practice_studio",
+      "archetype": "dance captain",
+      "packRole": "lead",
+      "requiredAssetKeys": [
+        "character.seoul.practice_studio.yujin.portrait.default",
+        "character.seoul.practice_studio.yujin.sprite.default",
+        "character.seoul.practice_studio.yujin.scene.default",
+        "character.seoul.practice_studio.yujin.voice.reference"
+      ],
+      "optionalAssetKeys": [
+        "character.seoul.practice_studio.yujin.sprite.expression-set"
+      ]
+    },
+    {
+      "characterId": "char.seoul.practice_studio.seungwoo",
+      "displayName": "Seungwoo",
+      "cityId": "seoul",
+      "dagLocationSlot": "practice_studio",
+      "archetype": "producer trainee",
+      "packRole": "support",
+      "requiredAssetKeys": [
+        "character.seoul.practice_studio.seungwoo.portrait.default",
+        "character.seoul.practice_studio.seungwoo.sprite.default",
+        "character.seoul.practice_studio.seungwoo.scene.default",
+        "character.seoul.practice_studio.seungwoo.voice.reference"
+      ],
+      "optionalAssetKeys": [
+        "character.seoul.practice_studio.seungwoo.reward.polaroid"
+      ]
+    },
+    {
+      "characterId": "char.tokyo.subway_hub.akira",
+      "displayName": "Akira",
+      "cityId": "tokyo",
+      "dagLocationSlot": "subway_hub",
+      "archetype": "rail guide",
+      "packRole": "lead",
+      "requiredAssetKeys": [
+        "character.tokyo.subway_hub.akira.portrait.default",
+        "character.tokyo.subway_hub.akira.sprite.default",
+        "character.tokyo.subway_hub.akira.scene.default",
+        "character.tokyo.subway_hub.akira.voice.reference"
+      ],
+      "optionalAssetKeys": [
+        "character.tokyo.subway_hub.akira.sprite.expression-set"
+      ]
+    },
+    {
+      "characterId": "char.tokyo.subway_hub.mei",
+      "displayName": "Mei",
+      "cityId": "tokyo",
+      "dagLocationSlot": "subway_hub",
+      "archetype": "rush-hour illustrator",
+      "packRole": "support",
+      "requiredAssetKeys": [
+        "character.tokyo.subway_hub.mei.portrait.default",
+        "character.tokyo.subway_hub.mei.sprite.default",
+        "character.tokyo.subway_hub.mei.scene.default",
+        "character.tokyo.subway_hub.mei.voice.reference"
+      ],
+      "optionalAssetKeys": [
+        "character.tokyo.subway_hub.mei.reward.polaroid"
+      ]
+    },
+    {
+      "characterId": "char.tokyo.food_street.rin",
+      "displayName": "Rin",
+      "cityId": "tokyo",
+      "dagLocationSlot": "food_street",
+      "archetype": "izakaya server",
+      "packRole": "lead",
+      "requiredAssetKeys": [
+        "character.tokyo.food_street.rin.portrait.default",
+        "character.tokyo.food_street.rin.sprite.default",
+        "character.tokyo.food_street.rin.scene.default",
+        "character.tokyo.food_street.rin.voice.reference"
+      ],
+      "optionalAssetKeys": [
+        "character.tokyo.food_street.rin.sprite.expression-set"
+      ]
+    },
+    {
+      "characterId": "char.tokyo.food_street.daichi",
+      "displayName": "Daichi",
+      "cityId": "tokyo",
+      "dagLocationSlot": "food_street",
+      "archetype": "ramen regular",
+      "packRole": "support",
+      "requiredAssetKeys": [
+        "character.tokyo.food_street.daichi.portrait.default",
+        "character.tokyo.food_street.daichi.sprite.default",
+        "character.tokyo.food_street.daichi.scene.default",
+        "character.tokyo.food_street.daichi.voice.reference"
+      ],
+      "optionalAssetKeys": [
+        "character.tokyo.food_street.daichi.intro.video"
+      ]
+    },
+    {
+      "characterId": "char.tokyo.convenience_store.yui",
+      "displayName": "Yui",
+      "cityId": "tokyo",
+      "dagLocationSlot": "convenience_store",
+      "archetype": "konbini shift lead",
+      "packRole": "lead",
+      "requiredAssetKeys": [
+        "character.tokyo.convenience_store.yui.portrait.default",
+        "character.tokyo.convenience_store.yui.sprite.default",
+        "character.tokyo.convenience_store.yui.scene.default",
+        "character.tokyo.convenience_store.yui.voice.reference"
+      ],
+      "optionalAssetKeys": [
+        "character.tokyo.convenience_store.yui.sprite.expression-set"
+      ]
+    },
+    {
+      "characterId": "char.tokyo.convenience_store.kaito",
+      "displayName": "Kaito",
+      "cityId": "tokyo",
+      "dagLocationSlot": "convenience_store",
+      "archetype": "after-school gamer",
+      "packRole": "support",
+      "requiredAssetKeys": [
+        "character.tokyo.convenience_store.kaito.portrait.default",
+        "character.tokyo.convenience_store.kaito.sprite.default",
+        "character.tokyo.convenience_store.kaito.scene.default",
+        "character.tokyo.convenience_store.kaito.voice.reference"
+      ],
+      "optionalAssetKeys": [
+        "character.tokyo.convenience_store.kaito.reward.polaroid"
+      ]
+    },
+    {
+      "characterId": "char.tokyo.cafe.hina",
+      "displayName": "Hina",
+      "cityId": "tokyo",
+      "dagLocationSlot": "cafe",
+      "archetype": "tea house host",
+      "packRole": "lead",
+      "requiredAssetKeys": [
+        "character.tokyo.cafe.hina.portrait.default",
+        "character.tokyo.cafe.hina.sprite.default",
+        "character.tokyo.cafe.hina.scene.default",
+        "character.tokyo.cafe.hina.voice.reference"
+      ],
+      "optionalAssetKeys": [
+        "character.tokyo.cafe.hina.sprite.expression-set"
+      ]
+    },
+    {
+      "characterId": "char.tokyo.cafe.ren",
+      "displayName": "Ren",
+      "cityId": "tokyo",
+      "dagLocationSlot": "cafe",
+      "archetype": "calligrapher regular",
+      "packRole": "support",
+      "requiredAssetKeys": [
+        "character.tokyo.cafe.ren.portrait.default",
+        "character.tokyo.cafe.ren.sprite.default",
+        "character.tokyo.cafe.ren.scene.default",
+        "character.tokyo.cafe.ren.voice.reference"
+      ],
+      "optionalAssetKeys": [
+        "character.tokyo.cafe.ren.intro.video"
+      ]
+    },
+    {
+      "characterId": "char.shanghai.subway_hub.lin",
+      "displayName": "Lin",
+      "cityId": "shanghai",
+      "dagLocationSlot": "subway_hub",
+      "archetype": "metro navigator",
+      "packRole": "lead",
+      "requiredAssetKeys": [
+        "character.shanghai.subway_hub.lin.portrait.default",
+        "character.shanghai.subway_hub.lin.sprite.default",
+        "character.shanghai.subway_hub.lin.scene.default",
+        "character.shanghai.subway_hub.lin.voice.reference"
+      ],
+      "optionalAssetKeys": [
+        "character.shanghai.subway_hub.lin.sprite.expression-set"
+      ]
+    },
+    {
+      "characterId": "char.shanghai.subway_hub.wei",
+      "displayName": "Wei",
+      "cityId": "shanghai",
+      "dagLocationSlot": "subway_hub",
+      "archetype": "delivery rider",
+      "packRole": "support",
+      "requiredAssetKeys": [
+        "character.shanghai.subway_hub.wei.portrait.default",
+        "character.shanghai.subway_hub.wei.sprite.default",
+        "character.shanghai.subway_hub.wei.scene.default",
+        "character.shanghai.subway_hub.wei.voice.reference"
+      ],
+      "optionalAssetKeys": [
+        "character.shanghai.subway_hub.wei.reward.polaroid"
+      ]
+    },
+    {
+      "characterId": "char.shanghai.food_street.qiao",
+      "displayName": "Qiao",
+      "cityId": "shanghai",
+      "dagLocationSlot": "food_street",
+      "archetype": "bbq vendor",
+      "packRole": "lead",
+      "requiredAssetKeys": [
+        "character.shanghai.food_street.qiao.portrait.default",
+        "character.shanghai.food_street.qiao.sprite.default",
+        "character.shanghai.food_street.qiao.scene.default",
+        "character.shanghai.food_street.qiao.voice.reference"
+      ],
+      "optionalAssetKeys": [
+        "character.shanghai.food_street.qiao.sprite.expression-set"
+      ]
+    },
+    {
+      "characterId": "char.shanghai.food_street.ming",
+      "displayName": "Ming",
+      "cityId": "shanghai",
+      "dagLocationSlot": "food_street",
+      "archetype": "dumpling scout",
+      "packRole": "support",
+      "requiredAssetKeys": [
+        "character.shanghai.food_street.ming.portrait.default",
+        "character.shanghai.food_street.ming.sprite.default",
+        "character.shanghai.food_street.ming.scene.default",
+        "character.shanghai.food_street.ming.voice.reference"
+      ],
+      "optionalAssetKeys": [
+        "character.shanghai.food_street.ming.intro.video"
+      ]
+    },
+    {
+      "characterId": "char.shanghai.convenience_store.an",
+      "displayName": "An",
+      "cityId": "shanghai",
+      "dagLocationSlot": "convenience_store",
+      "archetype": "night cashier",
+      "packRole": "lead",
+      "requiredAssetKeys": [
+        "character.shanghai.convenience_store.an.portrait.default",
+        "character.shanghai.convenience_store.an.sprite.default",
+        "character.shanghai.convenience_store.an.scene.default",
+        "character.shanghai.convenience_store.an.voice.reference"
+      ],
+      "optionalAssetKeys": [
+        "character.shanghai.convenience_store.an.sprite.expression-set"
+      ]
+    },
+    {
+      "characterId": "char.shanghai.convenience_store.yue",
+      "displayName": "Yue",
+      "cityId": "shanghai",
+      "dagLocationSlot": "convenience_store",
+      "archetype": "study-group organizer",
+      "packRole": "support",
+      "requiredAssetKeys": [
+        "character.shanghai.convenience_store.yue.portrait.default",
+        "character.shanghai.convenience_store.yue.sprite.default",
+        "character.shanghai.convenience_store.yue.scene.default",
+        "character.shanghai.convenience_store.yue.voice.reference"
+      ],
+      "optionalAssetKeys": [
+        "character.shanghai.convenience_store.yue.reward.polaroid"
+      ]
+    },
+    {
+      "characterId": "char.shanghai.cafe.jing",
+      "displayName": "Jing",
+      "cityId": "shanghai",
+      "dagLocationSlot": "cafe",
+      "archetype": "milk-foam barista",
+      "packRole": "lead",
+      "requiredAssetKeys": [
+        "character.shanghai.cafe.jing.portrait.default",
+        "character.shanghai.cafe.jing.sprite.default",
+        "character.shanghai.cafe.jing.scene.default",
+        "character.shanghai.cafe.jing.voice.reference"
+      ],
+      "optionalAssetKeys": [
+        "character.shanghai.cafe.jing.sprite.expression-set"
+      ]
+    },
+    {
+      "characterId": "char.shanghai.cafe.hao",
+      "displayName": "Hao",
+      "cityId": "shanghai",
+      "dagLocationSlot": "cafe",
+      "archetype": "tabletop sketch artist",
+      "packRole": "support",
+      "requiredAssetKeys": [
+        "character.shanghai.cafe.hao.portrait.default",
+        "character.shanghai.cafe.hao.sprite.default",
+        "character.shanghai.cafe.hao.scene.default",
+        "character.shanghai.cafe.hao.voice.reference"
+      ],
+      "optionalAssetKeys": [
+        "character.shanghai.cafe.hao.intro.video"
+      ]
+    },
+    {
+      "characterId": "char.shanghai.practice_studio.xinyi",
+      "displayName": "Xinyi",
+      "cityId": "shanghai",
+      "dagLocationSlot": "practice_studio",
+      "archetype": "dance challenge streamer",
+      "packRole": "lead",
+      "requiredAssetKeys": [
+        "character.shanghai.practice_studio.xinyi.portrait.default",
+        "character.shanghai.practice_studio.xinyi.sprite.default",
+        "character.shanghai.practice_studio.xinyi.scene.default",
+        "character.shanghai.practice_studio.xinyi.voice.reference"
+      ],
+      "optionalAssetKeys": [
+        "character.shanghai.practice_studio.xinyi.reward.video-call",
+        "character.shanghai.practice_studio.xinyi.reward.polaroid"
+      ]
+    },
+    {
+      "characterId": "char.shanghai.practice_studio.zhen",
+      "displayName": "Zhen",
+      "cityId": "shanghai",
+      "dagLocationSlot": "practice_studio",
+      "archetype": "sound engineer",
+      "packRole": "support",
+      "requiredAssetKeys": [
+        "character.shanghai.practice_studio.zhen.portrait.default",
+        "character.shanghai.practice_studio.zhen.sprite.default",
+        "character.shanghai.practice_studio.zhen.scene.default",
+        "character.shanghai.practice_studio.zhen.voice.reference"
+      ],
+      "optionalAssetKeys": [
+        "character.shanghai.practice_studio.zhen.sprite.expression-set",
+        "character.shanghai.practice_studio.zhen.reward.video-call"
+      ]
+    }
   ]
 }

--- a/docs/qa/world-content-issue-closure-plan.md
+++ b/docs/qa/world-content-issue-closure-plan.md
@@ -104,8 +104,11 @@ Block on:
 - prerequisite contracts issue for `mapLocationId -> dagLocationSlot`
 
 Current live Seoul map pins to call out:
-- `chimaek_place`
-- any other live Seoul pins currently shipped in the active map experience
+- `food_street`
+- `cafe`
+- `convenience_store`
+- `subway_hub`
+- `practice_studio` (player-facing label: **Chimaek Place**)
 
 Required proof:
 - pack/objective diff summary
@@ -125,6 +128,9 @@ Current live Tokyo map pins to call out:
 - `tea_house`
 - `ramen_shop`
 
+Tokyo note:
+- Do **not** carry a checked-in reserved Tokyo `practice_studio` starter roster unless the canonical world-map registry later gains a live Tokyo-backed `practice_studio` pin.
+
 Required proof:
 - pack/objective diff summary
 - dashboard or API trace showing Tokyo pack resolution through the registry
@@ -142,6 +148,9 @@ Current live Shanghai map pins to call out:
 - `convenience_store`
 - `milk_tea_shop`
 - `dumpling_shop`
+
+Canonical registry note:
+- The current registry-backed mappings are Tokyo `train_station -> subway_hub`, `izakaya -> food_street`, `konbini -> convenience_store`, `tea_house -> cafe`, `ramen_shop -> food_street`; and Shanghai `metro_station -> subway_hub`, `bbq_stall -> food_street`, `convenience_store -> convenience_store`, `milk_tea_shop -> practice_studio`, `dumpling_shop -> food_street`.
 
 Required proof:
 - pack/reward-bundle diff summary

--- a/packages/contracts/objective-identity-map.sample.json
+++ b/packages/contracts/objective-identity-map.sample.json
@@ -73,6 +73,66 @@
       "objectiveCategory": "conversation",
       "mapLocationId": "subway_hub",
       "dagLocationSlot": "subway_hub"
+    },
+    {
+      "canonicalObjectiveId": "ko-seoul-food-street-basics",
+      "legacyObjectiveIds": [
+        "ko_food_l2_001"
+      ],
+      "lang": "ko",
+      "cityId": "seoul",
+      "locationId": "food_street",
+      "objectiveCategory": "vocabulary",
+      "mapLocationId": "food_street",
+      "dagLocationSlot": "food_street"
+    },
+    {
+      "canonicalObjectiveId": "ko-seoul-cafe-study-session",
+      "legacyObjectiveIds": [
+        "ko_cafe_l2_001"
+      ],
+      "lang": "ko",
+      "cityId": "seoul",
+      "locationId": "cafe",
+      "objectiveCategory": "conversation",
+      "mapLocationId": "cafe",
+      "dagLocationSlot": "cafe"
+    },
+    {
+      "canonicalObjectiveId": "ko-seoul-convenience-store-run",
+      "legacyObjectiveIds": [
+        "ko_store_l2_001"
+      ],
+      "lang": "ko",
+      "cityId": "seoul",
+      "locationId": "convenience_store",
+      "objectiveCategory": "vocabulary",
+      "mapLocationId": "convenience_store",
+      "dagLocationSlot": "convenience_store"
+    },
+    {
+      "canonicalObjectiveId": "ko-seoul-subway-meetup",
+      "legacyObjectiveIds": [
+        "ko_subway_l2_001"
+      ],
+      "lang": "ko",
+      "cityId": "seoul",
+      "locationId": "subway_hub",
+      "objectiveCategory": "conversation",
+      "mapLocationId": "subway_hub",
+      "dagLocationSlot": "subway_hub"
+    },
+    {
+      "canonicalObjectiveId": "ko-seoul-chimaek-hangout",
+      "legacyObjectiveIds": [
+        "ko_chimaek_l2_001"
+      ],
+      "lang": "ko",
+      "cityId": "seoul",
+      "locationId": "practice_studio",
+      "objectiveCategory": "conversation",
+      "mapLocationId": "practice_studio",
+      "dagLocationSlot": "practice_studio"
     }
   ]
 }

--- a/scripts/demo_smoke_check.mjs
+++ b/scripts/demo_smoke_check.mjs
@@ -93,6 +93,10 @@ const requiredFiles = [
   "assets/manifest/runtime-asset-manifest.json",
   "assets/manifest/canonical-asset-manifest.json",
   "assets/content-packs/seoul-food-street.starter.json",
+  "assets/content-packs/seoul-cafe.starter.json",
+  "assets/content-packs/seoul-convenience-store.starter.json",
+  "assets/content-packs/seoul-subway-hub.starter.json",
+  "assets/content-packs/seoul-practice-studio.starter.json",
   "assets/rewards/shanghai-reward-bundle.placeholder.json"
 ];
 
@@ -191,12 +195,50 @@ const canonicalAssetManifest = JSON.parse(
     "utf8"
   )
 );
-const seoulStarterPack = JSON.parse(
-  fs.readFileSync(
-    path.join(root, "assets/content-packs/seoul-food-street.starter.json"),
-    "utf8"
-  )
-);
+const seoulStarterPacks = [
+  "seoul-food-street.starter.json",
+  "seoul-cafe.starter.json",
+  "seoul-convenience-store.starter.json",
+  "seoul-subway-hub.starter.json",
+  "seoul-practice-studio.starter.json",
+].map((file) => JSON.parse(
+  fs.readFileSync(path.join(root, "assets/content-packs", file), "utf8")
+));
+for (const pack of seoulStarterPacks) {
+  if (pack.templateVersion !== "1.1.0") {
+    console.error(`Seoul starter pack ${pack.packId} must use templateVersion 1.1.0`);
+    process.exit(1);
+  }
+  if (!pack.packId.startsWith("pack.seoul.")) {
+    console.error(`Seoul starter pack ${pack.packId} must use pack.seoul.<mapLocationId>.starter`);
+    process.exit(1);
+  }
+  if (pack.city !== "seoul") {
+    console.error(`Seoul starter pack ${pack.packId} must set city=seoul`);
+    process.exit(1);
+  }
+  if (typeof pack.mapLocationId !== "string" || pack.mapLocationId.length === 0) {
+    console.error(`Seoul starter pack ${pack.packId} missing mapLocationId`);
+    process.exit(1);
+  }
+  if (!Array.isArray(pack.characterRoster) || pack.characterRoster.length < 3) {
+    console.error(`Seoul starter pack ${pack.packId} must include local pair + Tong`);
+    process.exit(1);
+  }
+  if (!pack.characterRoster.some((entry) => entry.id === "tong")) {
+    console.error(`Seoul starter pack ${pack.packId} missing Tong assistant`);
+    process.exit(1);
+  }
+  if (!pack.objectiveSeed || typeof pack.objectiveSeed.objectiveId !== "string") {
+    console.error(`Seoul starter pack ${pack.packId} missing objectiveSeed.objectiveId`);
+    process.exit(1);
+  }
+  if (pack.mapLocationId === "practice_studio" && pack.location.id !== "practice_studio") {
+    console.error("Chimaek Place pack must preserve internal practice_studio slot mapping");
+    process.exit(1);
+  }
+}
+
 const shanghaiRewardBundle = JSON.parse(
   fs.readFileSync(
     path.join(root, "assets/rewards/shanghai-reward-bundle.placeholder.json"),
@@ -646,7 +688,7 @@ for (const key of canonicalKeys) {
   }
 }
 
-const keyRegex = /^[a-z0-9]+(\.[a-z0-9-]+){3,}$/;
+const keyRegex = /^[a-z0-9_]+(\.[a-z0-9_-]+){3,}$/;
 const seenKeys = new Set();
 for (const asset of runtimeAssetManifest.assets) {
   if (typeof asset.key !== "string" || !keyRegex.test(asset.key)) {
@@ -709,10 +751,12 @@ for (const key of clientRuntimeAssetUsage.manifestKeys) {
   }
 }
 
-for (const ref of seoulStarterPack.manifestKeys ?? []) {
-  if (!seenKeys.has(ref)) {
-    console.error(`Starter pack manifest key not found: ${ref}`);
-    process.exit(1);
+for (const pack of seoulStarterPacks) {
+  for (const ref of pack.manifestKeys ?? []) {
+    if (!seenKeys.has(ref)) {
+      console.error(`Starter pack manifest key not found for ${pack.packId}: ${ref}`);
+      process.exit(1);
+    }
   }
 }
 


### PR DESCRIPTION
### Motivation

- Centralize world-map and starter-pack resolution logic into a dedicated registry to drive consistent pack lookups and player-facing labels.
- Add Seoul starter content and roster entries so runtime can resolve live map pins to starter packs and characters.
- Surface starter-pack resolution in curriculum graph outputs so callers can observe registry-backed pack/slot resolution and player-facing labels.

### Description

- Introduce `apps/server/src/starter-pack-registry.mjs` which encapsulates world-map registry reads, location listing (`listWorldMapLocationIds`), `resolveWorldMapLocation`, `inferCityFromLocation`, and `resolveStarterPack` logic.
- Replace inlined world-map/location helpers with imports from the new registry in `curriculum-graph.mjs` and `index.mjs`, and use `listWorldMapLocationIds()` to populate `VALID_LOCATIONS`.
- Add Seoul starter content packs under `assets/content-packs/*` and expand `assets/manifest/*` and `assets/manifest/starter-cast-registry.json` to register new starter packs, characters, and asset keys; update objective identity map entries and add runtime objective configs for new Seoul objectives.
- Wire starter-pack metadata into API responses and runtime objects by adding `starterPackResolution` to `locationSkillTree` and `selectedPack`, and embed `starterPack` in personalized objective payloads.
- Update the demo smoke check script `scripts/demo_smoke_check.mjs` to validate multiple Seoul starter packs, relax the asset key regex to allow underscores/dashes, and ensure starter-pack template and identity conventions are enforced; add an artifact trace `artifacts/issue62-seoul-pack-resolution-trace.json` capturing a sample dashboard resolution.

### Testing

- Ran the demo smoke check via the repository script (`scripts/demo_smoke_check.mjs`), which parsed manifests and packs and completed successfully with the new starter packs (reported: "Demo smoke check passed.").
- Generated a dashboard API trace for `?city=seoul&location=practice_studio` and recorded resolution results in `artifacts/issue62-seoul-pack-resolution-trace.json`, confirming registry-backed `packId`, `mapLocationId`, `dagLocationSlot`, `playerFacingLabel`, and `registryResolved` fields.
- JSON and manifest validations included in the demo smoke check were executed and passed for the added/modified JSON assets.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69beb5af41f8832a9f5d1924703be505)