### PR TITLE
Add Tokyo and Shanghai starter packs and wire registry/runtime resolution

### DIFF
--- a/apps/server/src/curriculum-graph.mjs
+++ b/apps/server/src/curriculum-graph.mjs
@@ -43,7 +43,6 @@ const LEGACY_SHARED_LOCATIONS = [
 ];
 
 const VALID_CITIES = new Set(Object.keys(CITY_LABELS));
-const VALID_LOCATIONS = new Set(Object.keys(LOCATION_LABELS));
 const LESSON_STATUSES = new Set(['available', 'due', 'learning']);
 const COMPLETED_STATUSES = new Set(['validated', 'mastered']);
 const BLOCKER_CLEAR_STATUSES = new Set(['due', 'validated', 'mastered']);
@@ -61,6 +60,19 @@ function loadJson(relativePath) {
 }
 
 const WORLD_MAP_REGISTRY = loadJson('packages/contracts/world-map-registry.sample.json');
+
+const VALID_LOCATION_IDS = new Set(
+  [
+    ...Object.keys(LOCATION_LABELS),
+    ...((WORLD_MAP_REGISTRY.cities || []).flatMap((city) =>
+      (city.locations || []).flatMap((entry) => [
+        entry.mapLocationId,
+        entry.dagLocationSlot,
+        ...((entry.legacyLocationIds || [])),
+      ]),
+    )),
+  ].filter(Boolean),
+);
 
 function cloneJson(value) {
   return JSON.parse(JSON.stringify(value));
@@ -154,10 +166,15 @@ function loadStarterPacks() {
         cityId: raw.city,
         mapLocationId: resolvedLocation.mapLocationId,
         dagLocationSlot: raw.location?.id || resolvedLocation.dagLocationSlot,
+        locationId: raw.location?.id || resolvedLocation.dagLocationSlot,
+        lang: CITY_LANG[raw.city],
+        title: `${CITY_LABELS[raw.city]} ${raw.playerFacingLocationLabel || resolvedLocation.label}`,
         playerFacingLocationLabel: raw.playerFacingLocationLabel || resolvedLocation.label,
         status: raw.status || 'draft',
+        characterRoster: cloneJson(raw.characterRoster || []),
         objectiveSeed: cloneJson(raw.objectiveSeed || {}),
         manifestKeys: cloneJson(raw.manifestKeys || []),
+        rewardHooks: cloneJson(raw.rewardHooks || {}),
       };
     })
     .filter(Boolean);
@@ -256,8 +273,10 @@ function buildStarterPackStub(starterPack) {
       mapLocationId: starterPack.mapLocationId,
       playerFacingLocationLabel: starterPack.playerFacingLocationLabel,
       status: starterPack.status,
+      characterRoster: cloneJson(starterPack.characterRoster || []),
       manifestKeys: cloneJson(starterPack.manifestKeys || []),
       objectiveSeed: cloneJson(starterPack.objectiveSeed || {}),
+      rewardHooks: cloneJson(starterPack.rewardHooks || {}),
     },
   };
 }
@@ -306,11 +325,13 @@ function buildPackRegistry() {
   for (const starterPack of STARTER_PACKS) {
     const key = keyFor(starterPack.cityId, starterPack.dagLocationSlot);
     if (key === keyFor('seoul', 'food_street')) continue;
-    registry.set(key, buildStarterPackStub(starterPack));
+    if (!registry.has(key)) {
+      registry.set(key, buildStarterPackStub(starterPack));
+    }
   }
 
   for (const cityId of VALID_CITIES) {
-    for (const locationId of VALID_LOCATIONS) {
+    for (const locationId of Object.keys(LOCATION_LABELS)) {
       const key = keyFor(cityId, locationId);
       if (registry.has(key)) continue;
       registry.set(key, buildStubPack(cityId, locationId));
@@ -694,7 +715,7 @@ function normalizeCity(value) {
 
 function normalizeLocation(value) {
   if (value === undefined || value === null || value === '') return null;
-  if (!VALID_LOCATIONS.has(value)) {
+  if (!VALID_LOCATION_IDS.has(value)) {
     throw createGraphError('invalid_graph_location', `Unknown graph location "${value}".`, 400, {
       location: value,
     });
@@ -704,31 +725,42 @@ function normalizeLocation(value) {
 
 function inferCityFromLocation(locationId) {
   if (!locationId) return null;
-  if (locationId === 'practice_studio') return 'shanghai';
-  return 'seoul';
+  for (const city of WORLD_MAP_REGISTRY.cities || []) {
+    const matches = (city.locations || []).some(
+      (entry) =>
+        entry.mapLocationId === locationId ||
+        entry.dagLocationSlot === locationId ||
+        (entry.legacyLocationIds || []).includes(locationId),
+    );
+    if (matches) return city.cityId;
+  }
+  return null;
 }
 
 function resolveSelection(args = {}) {
   const requestedLocation = normalizeLocation(args.location);
   const requestedCity = normalizeCity(args.city) || inferCityFromLocation(requestedLocation) || 'seoul';
-  const locationId = requestedLocation || DEFAULT_LOCATION_BY_CITY[requestedCity];
-  const pack = PACK_REGISTRY.get(keyFor(requestedCity, locationId));
+  const requestedLocationId = requestedLocation || DEFAULT_LOCATION_BY_CITY[requestedCity];
+  const resolvedLocation = resolveWorldMapLocation(requestedCity, requestedLocationId);
+  const pack = getStarterPackMetadata(requestedCity, requestedLocationId)
+    || PACK_REGISTRY.get(keyFor(requestedCity, resolvedLocation.dagLocationSlot));
 
   if (!pack) {
     throw createGraphError(
       'graph_pack_not_found',
-      `No curriculum pack is registered for ${requestedCity}/${locationId}.`,
+      `No curriculum pack is registered for ${requestedCity}/${requestedLocationId}.`,
       404,
       {
         city: requestedCity,
-        location: locationId,
+        location: requestedLocationId,
       },
     );
   }
 
   return {
     cityId: requestedCity,
-    locationId,
+    locationId: resolvedLocation.dagLocationSlot,
+    mapLocationId: resolvedLocation.mapLocationId,
     pack,
   };
 }
@@ -1646,15 +1678,16 @@ function buildLegacyWorldRoadmap(persona, foundationEvaluation, overlayCandidate
       label: 'Tokyo',
       focus: cityFocus.get('ja') || 'foundation',
       proficiency: persona.proficiency.ja || 'beginner',
-      locations: LEGACY_SHARED_LOCATIONS.map((location, index) => {
+      locations: LEGACY_SHARED_LOCATIONS.map((location) => {
         const resolvedLocation = resolveWorldMapLocation('tokyo', location.locationId);
+        const starterPack = getStarterPackMetadata('tokyo', location.locationId);
         return {
           locationId: location.locationId,
           mapLocationId: resolvedLocation.mapLocationId,
           dagLocationSlot: resolvedLocation.dagLocationSlot,
-          label: resolvedLocation.label,
-          status: index === 0 ? 'preview' : 'locked',
-          progress: index === 0 ? 'Starter path scaffolded for future pack generation' : 'Locked',
+          label: starterPack?.playerFacingLocationLabel || resolvedLocation.label,
+          status: starterPack ? 'preview' : 'locked',
+          progress: starterPack ? `Starter pack checked in: ${starterPack.packId}` : 'Awaiting authored starter pack',
         };
       }),
       levels: [
@@ -1667,25 +1700,30 @@ function buildLegacyWorldRoadmap(persona, foundationEvaluation, overlayCandidate
       label: 'Shanghai',
       focus: cityFocus.get('zh') || 'personalization',
       proficiency: persona.proficiency.zh || 'beginner',
-      locations: LEGACY_SHARED_LOCATIONS.map((location, index) => {
+      locations: LEGACY_SHARED_LOCATIONS.map((location) => {
         const resolvedLocation = resolveWorldMapLocation('shanghai', location.locationId);
+        const starterPack = getStarterPackMetadata('shanghai', location.locationId);
         return {
           locationId: location.locationId,
           mapLocationId: resolvedLocation.mapLocationId,
           dagLocationSlot: resolvedLocation.dagLocationSlot,
-          label: resolvedLocation.label,
+          label: starterPack?.playerFacingLocationLabel || resolvedLocation.label,
           status:
             location.locationId === 'practice_studio'
-              ? overlayCandidates.some((candidate) => candidate.overlay.lang === 'zh')
+              ? starterPack || overlayCandidates.some((candidate) => candidate.overlay.lang === 'zh')
                 ? 'preview'
                 : 'locked'
-              : index === 0
+              : starterPack
                 ? 'preview'
                 : 'locked',
           progress:
             location.locationId === 'practice_studio'
-              ? 'Personalized overlay ready for creator vocabulary'
-              : 'Awaiting generated pack',
+              ? starterPack
+                ? `Starter pack checked in: ${starterPack.packId}`
+                : 'Personalized overlay ready for creator vocabulary'
+              : starterPack
+                ? `Starter pack checked in: ${starterPack.packId}`
+                : 'Awaiting generated pack',
         };
       }),
       levels: [

--- a/apps/server/src/index.mjs
+++ b/apps/server/src/index.mjs
@@ -2438,7 +2438,7 @@ async function invokeAgentTool(toolName, rawArgs = {}) {
     }
     case 'graph.dashboard.get': {
       const city = args.city === 'tokyo' || args.city === 'shanghai' || args.city === 'seoul' ? args.city : undefined;
-      const location = city ? resolveWorldMapLocation(city, args.location).dagLocationSlot : args.location;
+      const location = city ? (args.location || undefined) : args.location;
       return {
         statusCode: 200,
         payload: {
@@ -2985,7 +2985,7 @@ const server = http.createServer(async (req, res) => {
     if (pathname === '/api/v1/graph/dashboard' && req.method === 'GET') {
       const personaId = url.searchParams.get('personaId') || url.searchParams.get('learnerId') || undefined;
       const city = url.searchParams.get('city') || undefined;
-      const location = city ? resolveWorldMapLocation(city, url.searchParams.get('location') || undefined).dagLocationSlot : (url.searchParams.get('location') || undefined);
+      const location = url.searchParams.get('location') || undefined;
       const userId = getUserIdFromQuery(url.searchParams);
       jsonResponse(res, 200, {
         worldMapRegistry: cloneJson(WORLD_MAP_REGISTRY),

--- a/assets/content-packs/shanghai-bbq-stall.starter.json
+++ b/assets/content-packs/shanghai-bbq-stall.starter.json
@@ -1,0 +1,82 @@
+{
+  "templateVersion": "1.1.0",
+  "packType": "city-location-character-starter",
+  "packId": "pack.shanghai.bbq_stall.starter",
+  "city": "shanghai",
+  "mapLocationId": "bbq_stall",
+  "playerFacingLocationLabel": "BBQ Stall",
+  "location": {
+    "id": "food_street",
+    "assetSlug": "bbq-stall",
+    "modes": [
+      "learn",
+      "hangout"
+    ]
+  },
+  "characterRoster": [
+    {
+      "id": "char.shanghai.food_street.qiao",
+      "role": "lead",
+      "relationshipTrack": "rp",
+      "requiredManifestKeys": [
+        "character.shanghai.food_street.qiao.portrait.default",
+        "character.shanghai.food_street.qiao.sprite.default",
+        "character.shanghai.food_street.qiao.scene.default",
+        "character.shanghai.food_street.qiao.voice.reference"
+      ],
+      "optionalManifestKeys": [
+        "character.shanghai.food_street.qiao.sprite.expression-set"
+      ]
+    },
+    {
+      "id": "char.shanghai.food_street.ming",
+      "role": "support",
+      "relationshipTrack": "rp",
+      "requiredManifestKeys": [
+        "character.shanghai.food_street.ming.portrait.default",
+        "character.shanghai.food_street.ming.sprite.default",
+        "character.shanghai.food_street.ming.scene.default",
+        "character.shanghai.food_street.ming.voice.reference"
+      ],
+      "optionalManifestKeys": [
+        "character.shanghai.food_street.ming.intro.video"
+      ]
+    },
+    {
+      "id": "tong",
+      "role": "assistant",
+      "relationshipTrack": "rp",
+      "requiredManifestKeys": [
+        "character.tong.expression.neutral"
+      ],
+      "optionalManifestKeys": [
+        "character.tong.expression.cheerful",
+        "character.tong.expression.thinking"
+      ]
+    }
+  ],
+  "objectiveSeed": {
+    "objectiveId": "shanghai-bbq-stall-street-ordering-v1",
+    "targetTypes": [
+      "vocabulary",
+      "grammar",
+      "sentenceStructures"
+    ],
+    "missionGate": {
+      "validatedHangoutsRequired": 2,
+      "masteryTierUnlock": "A1.3"
+    }
+  },
+  "manifestKeys": [
+    "city.shanghai.location.bbq-stall.backdrop.default",
+    "character.shanghai.food_street.qiao.portrait.default",
+    "character.shanghai.food_street.ming.portrait.default",
+    "character.tong.expression.neutral"
+  ],
+  "rewardHooks": {
+    "videoCallRewardKey": null,
+    "polaroidRewardKey": null
+  },
+  "status": "draft",
+  "rosterRegistrySource": "assets/manifest/starter-cast-registry.json"
+}

--- a/assets/content-packs/shanghai-convenience-store.starter.json
+++ b/assets/content-packs/shanghai-convenience-store.starter.json
@@ -1,0 +1,82 @@
+{
+  "templateVersion": "1.1.0",
+  "packType": "city-location-character-starter",
+  "packId": "pack.shanghai.convenience_store.starter",
+  "city": "shanghai",
+  "mapLocationId": "convenience_store",
+  "playerFacingLocationLabel": "Convenience Store",
+  "location": {
+    "id": "convenience_store",
+    "assetSlug": "convenience-store",
+    "modes": [
+      "learn",
+      "hangout"
+    ]
+  },
+  "characterRoster": [
+    {
+      "id": "char.shanghai.convenience_store.an",
+      "role": "lead",
+      "relationshipTrack": "rp",
+      "requiredManifestKeys": [
+        "character.shanghai.convenience_store.an.portrait.default",
+        "character.shanghai.convenience_store.an.sprite.default",
+        "character.shanghai.convenience_store.an.scene.default",
+        "character.shanghai.convenience_store.an.voice.reference"
+      ],
+      "optionalManifestKeys": [
+        "character.shanghai.convenience_store.an.sprite.expression-set"
+      ]
+    },
+    {
+      "id": "char.shanghai.convenience_store.yue",
+      "role": "support",
+      "relationshipTrack": "rp",
+      "requiredManifestKeys": [
+        "character.shanghai.convenience_store.yue.portrait.default",
+        "character.shanghai.convenience_store.yue.sprite.default",
+        "character.shanghai.convenience_store.yue.scene.default",
+        "character.shanghai.convenience_store.yue.voice.reference"
+      ],
+      "optionalManifestKeys": [
+        "character.shanghai.convenience_store.yue.reward.polaroid"
+      ]
+    },
+    {
+      "id": "tong",
+      "role": "assistant",
+      "relationshipTrack": "rp",
+      "requiredManifestKeys": [
+        "character.tong.expression.neutral"
+      ],
+      "optionalManifestKeys": [
+        "character.tong.expression.cheerful",
+        "character.tong.expression.thinking"
+      ]
+    }
+  ],
+  "objectiveSeed": {
+    "objectiveId": "shanghai-convenience-store-errand-chat-v1",
+    "targetTypes": [
+      "vocabulary",
+      "grammar",
+      "sentenceStructures"
+    ],
+    "missionGate": {
+      "validatedHangoutsRequired": 2,
+      "masteryTierUnlock": "A1.3"
+    }
+  },
+  "manifestKeys": [
+    "city.shanghai.location.convenience-store.backdrop.default",
+    "character.shanghai.convenience_store.an.portrait.default",
+    "character.shanghai.convenience_store.yue.portrait.default",
+    "character.tong.expression.neutral"
+  ],
+  "rewardHooks": {
+    "videoCallRewardKey": null,
+    "polaroidRewardKey": null
+  },
+  "status": "draft",
+  "rosterRegistrySource": "assets/manifest/starter-cast-registry.json"
+}

--- a/assets/content-packs/shanghai-dumpling-shop.starter.json
+++ b/assets/content-packs/shanghai-dumpling-shop.starter.json
@@ -1,0 +1,82 @@
+{
+  "templateVersion": "1.1.0",
+  "packType": "city-location-character-starter",
+  "packId": "pack.shanghai.dumpling_shop.starter",
+  "city": "shanghai",
+  "mapLocationId": "dumpling_shop",
+  "playerFacingLocationLabel": "Dumpling Shop",
+  "location": {
+    "id": "food_street",
+    "assetSlug": "dumpling-shop",
+    "modes": [
+      "learn",
+      "hangout"
+    ]
+  },
+  "characterRoster": [
+    {
+      "id": "char.shanghai.food_street.qiao",
+      "role": "lead",
+      "relationshipTrack": "rp",
+      "requiredManifestKeys": [
+        "character.shanghai.food_street.qiao.portrait.default",
+        "character.shanghai.food_street.qiao.sprite.default",
+        "character.shanghai.food_street.qiao.scene.default",
+        "character.shanghai.food_street.qiao.voice.reference"
+      ],
+      "optionalManifestKeys": [
+        "character.shanghai.food_street.qiao.sprite.expression-set"
+      ]
+    },
+    {
+      "id": "char.shanghai.food_street.ming",
+      "role": "support",
+      "relationshipTrack": "rp",
+      "requiredManifestKeys": [
+        "character.shanghai.food_street.ming.portrait.default",
+        "character.shanghai.food_street.ming.sprite.default",
+        "character.shanghai.food_street.ming.scene.default",
+        "character.shanghai.food_street.ming.voice.reference"
+      ],
+      "optionalManifestKeys": [
+        "character.shanghai.food_street.ming.intro.video"
+      ]
+    },
+    {
+      "id": "tong",
+      "role": "assistant",
+      "relationshipTrack": "rp",
+      "requiredManifestKeys": [
+        "character.tong.expression.neutral"
+      ],
+      "optionalManifestKeys": [
+        "character.tong.expression.cheerful",
+        "character.tong.expression.thinking"
+      ]
+    }
+  ],
+  "objectiveSeed": {
+    "objectiveId": "shanghai-dumpling-shop-shared-plates-v1",
+    "targetTypes": [
+      "vocabulary",
+      "grammar",
+      "sentenceStructures"
+    ],
+    "missionGate": {
+      "validatedHangoutsRequired": 2,
+      "masteryTierUnlock": "A1.3"
+    }
+  },
+  "manifestKeys": [
+    "city.shanghai.location.dumpling-shop.backdrop.default",
+    "character.shanghai.food_street.qiao.portrait.default",
+    "character.shanghai.food_street.ming.portrait.default",
+    "character.tong.expression.neutral"
+  ],
+  "rewardHooks": {
+    "videoCallRewardKey": null,
+    "polaroidRewardKey": null
+  },
+  "status": "draft",
+  "rosterRegistrySource": "assets/manifest/starter-cast-registry.json"
+}

--- a/assets/content-packs/shanghai-metro-station.starter.json
+++ b/assets/content-packs/shanghai-metro-station.starter.json
@@ -1,0 +1,82 @@
+{
+  "templateVersion": "1.1.0",
+  "packType": "city-location-character-starter",
+  "packId": "pack.shanghai.metro_station.starter",
+  "city": "shanghai",
+  "mapLocationId": "metro_station",
+  "playerFacingLocationLabel": "Metro Station",
+  "location": {
+    "id": "subway_hub",
+    "assetSlug": "metro-station",
+    "modes": [
+      "learn",
+      "hangout"
+    ]
+  },
+  "characterRoster": [
+    {
+      "id": "char.shanghai.subway_hub.lin",
+      "role": "lead",
+      "relationshipTrack": "rp",
+      "requiredManifestKeys": [
+        "character.shanghai.subway_hub.lin.portrait.default",
+        "character.shanghai.subway_hub.lin.sprite.default",
+        "character.shanghai.subway_hub.lin.scene.default",
+        "character.shanghai.subway_hub.lin.voice.reference"
+      ],
+      "optionalManifestKeys": [
+        "character.shanghai.subway_hub.lin.sprite.expression-set"
+      ]
+    },
+    {
+      "id": "char.shanghai.subway_hub.wei",
+      "role": "support",
+      "relationshipTrack": "rp",
+      "requiredManifestKeys": [
+        "character.shanghai.subway_hub.wei.portrait.default",
+        "character.shanghai.subway_hub.wei.sprite.default",
+        "character.shanghai.subway_hub.wei.scene.default",
+        "character.shanghai.subway_hub.wei.voice.reference"
+      ],
+      "optionalManifestKeys": [
+        "character.shanghai.subway_hub.wei.reward.polaroid"
+      ]
+    },
+    {
+      "id": "tong",
+      "role": "assistant",
+      "relationshipTrack": "rp",
+      "requiredManifestKeys": [
+        "character.tong.expression.neutral"
+      ],
+      "optionalManifestKeys": [
+        "character.tong.expression.cheerful",
+        "character.tong.expression.thinking"
+      ]
+    }
+  ],
+  "objectiveSeed": {
+    "objectiveId": "shanghai-metro-station-navigation-v1",
+    "targetTypes": [
+      "vocabulary",
+      "grammar",
+      "sentenceStructures"
+    ],
+    "missionGate": {
+      "validatedHangoutsRequired": 2,
+      "masteryTierUnlock": "A1.3"
+    }
+  },
+  "manifestKeys": [
+    "city.shanghai.location.metro-station.backdrop.default",
+    "character.shanghai.subway_hub.lin.portrait.default",
+    "character.shanghai.subway_hub.wei.portrait.default",
+    "character.tong.expression.neutral"
+  ],
+  "rewardHooks": {
+    "videoCallRewardKey": null,
+    "polaroidRewardKey": null
+  },
+  "status": "draft",
+  "rosterRegistrySource": "assets/manifest/starter-cast-registry.json"
+}

--- a/assets/content-packs/shanghai-milk-tea-shop.starter.json
+++ b/assets/content-packs/shanghai-milk-tea-shop.starter.json
@@ -1,0 +1,86 @@
+{
+  "templateVersion": "1.1.0",
+  "packType": "city-location-character-starter",
+  "packId": "pack.shanghai.milk_tea_shop.starter",
+  "city": "shanghai",
+  "mapLocationId": "milk_tea_shop",
+  "playerFacingLocationLabel": "Milk Tea Shop",
+  "location": {
+    "id": "practice_studio",
+    "assetSlug": "milk-tea-shop",
+    "modes": [
+      "learn",
+      "hangout"
+    ]
+  },
+  "characterRoster": [
+    {
+      "id": "char.shanghai.practice_studio.xinyi",
+      "role": "lead",
+      "relationshipTrack": "rp",
+      "requiredManifestKeys": [
+        "character.shanghai.practice_studio.xinyi.portrait.default",
+        "character.shanghai.practice_studio.xinyi.sprite.default",
+        "character.shanghai.practice_studio.xinyi.scene.default",
+        "character.shanghai.practice_studio.xinyi.voice.reference"
+      ],
+      "optionalManifestKeys": [
+        "character.shanghai.practice_studio.xinyi.reward.video-call",
+        "character.shanghai.practice_studio.xinyi.reward.polaroid"
+      ]
+    },
+    {
+      "id": "char.shanghai.practice_studio.zhen",
+      "role": "support",
+      "relationshipTrack": "rp",
+      "requiredManifestKeys": [
+        "character.shanghai.practice_studio.zhen.portrait.default",
+        "character.shanghai.practice_studio.zhen.sprite.default",
+        "character.shanghai.practice_studio.zhen.scene.default",
+        "character.shanghai.practice_studio.zhen.voice.reference"
+      ],
+      "optionalManifestKeys": [
+        "character.shanghai.practice_studio.zhen.sprite.expression-set",
+        "character.shanghai.practice_studio.zhen.reward.video-call"
+      ]
+    },
+    {
+      "id": "tong",
+      "role": "assistant",
+      "relationshipTrack": "rp",
+      "requiredManifestKeys": [
+        "character.tong.expression.neutral"
+      ],
+      "optionalManifestKeys": [
+        "character.tong.expression.cheerful",
+        "character.tong.expression.thinking"
+      ]
+    }
+  ],
+  "objectiveSeed": {
+    "objectiveId": "shanghai-milk-tea-shop-texting-mission-v1",
+    "targetTypes": [
+      "vocabulary",
+      "grammar",
+      "sentenceStructures"
+    ],
+    "missionGate": {
+      "validatedHangoutsRequired": 3,
+      "masteryTierUnlock": "A2.1"
+    }
+  },
+  "manifestKeys": [
+    "city.shanghai.location.milk-tea-shop.backdrop.default",
+    "character.shanghai.practice_studio.xinyi.portrait.default",
+    "character.shanghai.practice_studio.zhen.portrait.default",
+    "character.tong.expression.neutral",
+    "reward.shanghai.milk_tea_shop.video_call",
+    "reward.shanghai.milk_tea_shop.polaroid"
+  ],
+  "rewardHooks": {
+    "videoCallRewardKey": "reward.shanghai.milk_tea_shop.video_call",
+    "polaroidRewardKey": "reward.shanghai.milk_tea_shop.polaroid"
+  },
+  "status": "draft",
+  "rosterRegistrySource": "assets/manifest/starter-cast-registry.json"
+}

--- a/assets/content-packs/tokyo-izakaya.starter.json
+++ b/assets/content-packs/tokyo-izakaya.starter.json
@@ -1,0 +1,82 @@
+{
+  "templateVersion": "1.1.0",
+  "packType": "city-location-character-starter",
+  "packId": "pack.tokyo.izakaya.starter",
+  "city": "tokyo",
+  "mapLocationId": "izakaya",
+  "playerFacingLocationLabel": "Izakaya",
+  "location": {
+    "id": "food_street",
+    "assetSlug": "izakaya",
+    "modes": [
+      "learn",
+      "hangout"
+    ]
+  },
+  "characterRoster": [
+    {
+      "id": "char.tokyo.food_street.rin",
+      "role": "lead",
+      "relationshipTrack": "rp",
+      "requiredManifestKeys": [
+        "character.tokyo.food_street.rin.portrait.default",
+        "character.tokyo.food_street.rin.sprite.default",
+        "character.tokyo.food_street.rin.scene.default",
+        "character.tokyo.food_street.rin.voice.reference"
+      ],
+      "optionalManifestKeys": [
+        "character.tokyo.food_street.rin.sprite.expression-set"
+      ]
+    },
+    {
+      "id": "char.tokyo.food_street.daichi",
+      "role": "support",
+      "relationshipTrack": "rp",
+      "requiredManifestKeys": [
+        "character.tokyo.food_street.daichi.portrait.default",
+        "character.tokyo.food_street.daichi.sprite.default",
+        "character.tokyo.food_street.daichi.scene.default",
+        "character.tokyo.food_street.daichi.voice.reference"
+      ],
+      "optionalManifestKeys": [
+        "character.tokyo.food_street.daichi.intro.video"
+      ]
+    },
+    {
+      "id": "tong",
+      "role": "assistant",
+      "relationshipTrack": "rp",
+      "requiredManifestKeys": [
+        "character.tong.expression.neutral"
+      ],
+      "optionalManifestKeys": [
+        "character.tong.expression.cheerful",
+        "character.tong.expression.thinking"
+      ]
+    }
+  ],
+  "objectiveSeed": {
+    "objectiveId": "tokyo-izakaya-ordering-v1",
+    "targetTypes": [
+      "vocabulary",
+      "grammar",
+      "sentenceStructures"
+    ],
+    "missionGate": {
+      "validatedHangoutsRequired": 2,
+      "masteryTierUnlock": "A1.2"
+    }
+  },
+  "manifestKeys": [
+    "city.tokyo.location.izakaya.backdrop.default",
+    "character.tokyo.food_street.rin.portrait.default",
+    "character.tokyo.food_street.daichi.portrait.default",
+    "character.tong.expression.neutral"
+  ],
+  "rewardHooks": {
+    "videoCallRewardKey": null,
+    "polaroidRewardKey": null
+  },
+  "status": "draft",
+  "rosterRegistrySource": "assets/manifest/starter-cast-registry.json"
+}

--- a/assets/content-packs/tokyo-konbini.starter.json
+++ b/assets/content-packs/tokyo-konbini.starter.json
@@ -1,0 +1,82 @@
+{
+  "templateVersion": "1.1.0",
+  "packType": "city-location-character-starter",
+  "packId": "pack.tokyo.konbini.starter",
+  "city": "tokyo",
+  "mapLocationId": "konbini",
+  "playerFacingLocationLabel": "Convenience Store",
+  "location": {
+    "id": "convenience_store",
+    "assetSlug": "konbini",
+    "modes": [
+      "learn",
+      "hangout"
+    ]
+  },
+  "characterRoster": [
+    {
+      "id": "char.tokyo.convenience_store.yui",
+      "role": "lead",
+      "relationshipTrack": "rp",
+      "requiredManifestKeys": [
+        "character.tokyo.convenience_store.yui.portrait.default",
+        "character.tokyo.convenience_store.yui.sprite.default",
+        "character.tokyo.convenience_store.yui.scene.default",
+        "character.tokyo.convenience_store.yui.voice.reference"
+      ],
+      "optionalManifestKeys": [
+        "character.tokyo.convenience_store.yui.sprite.expression-set"
+      ]
+    },
+    {
+      "id": "char.tokyo.convenience_store.kaito",
+      "role": "support",
+      "relationshipTrack": "rp",
+      "requiredManifestKeys": [
+        "character.tokyo.convenience_store.kaito.portrait.default",
+        "character.tokyo.convenience_store.kaito.sprite.default",
+        "character.tokyo.convenience_store.kaito.scene.default",
+        "character.tokyo.convenience_store.kaito.voice.reference"
+      ],
+      "optionalManifestKeys": [
+        "character.tokyo.convenience_store.kaito.reward.polaroid"
+      ]
+    },
+    {
+      "id": "tong",
+      "role": "assistant",
+      "relationshipTrack": "rp",
+      "requiredManifestKeys": [
+        "character.tong.expression.neutral"
+      ],
+      "optionalManifestKeys": [
+        "character.tong.expression.cheerful",
+        "character.tong.expression.thinking"
+      ]
+    }
+  ],
+  "objectiveSeed": {
+    "objectiveId": "tokyo-konbini-quick-chat-v1",
+    "targetTypes": [
+      "vocabulary",
+      "grammar",
+      "sentenceStructures"
+    ],
+    "missionGate": {
+      "validatedHangoutsRequired": 2,
+      "masteryTierUnlock": "A1.2"
+    }
+  },
+  "manifestKeys": [
+    "city.tokyo.location.konbini.backdrop.default",
+    "character.tokyo.convenience_store.yui.portrait.default",
+    "character.tokyo.convenience_store.kaito.portrait.default",
+    "character.tong.expression.neutral"
+  ],
+  "rewardHooks": {
+    "videoCallRewardKey": null,
+    "polaroidRewardKey": null
+  },
+  "status": "draft",
+  "rosterRegistrySource": "assets/manifest/starter-cast-registry.json"
+}

--- a/assets/content-packs/tokyo-ramen-shop.starter.json
+++ b/assets/content-packs/tokyo-ramen-shop.starter.json
@@ -1,0 +1,82 @@
+{
+  "templateVersion": "1.1.0",
+  "packType": "city-location-character-starter",
+  "packId": "pack.tokyo.ramen_shop.starter",
+  "city": "tokyo",
+  "mapLocationId": "ramen_shop",
+  "playerFacingLocationLabel": "Ramen Shop",
+  "location": {
+    "id": "food_street",
+    "assetSlug": "ramen-shop",
+    "modes": [
+      "learn",
+      "hangout"
+    ]
+  },
+  "characterRoster": [
+    {
+      "id": "char.tokyo.food_street.rin",
+      "role": "lead",
+      "relationshipTrack": "rp",
+      "requiredManifestKeys": [
+        "character.tokyo.food_street.rin.portrait.default",
+        "character.tokyo.food_street.rin.sprite.default",
+        "character.tokyo.food_street.rin.scene.default",
+        "character.tokyo.food_street.rin.voice.reference"
+      ],
+      "optionalManifestKeys": [
+        "character.tokyo.food_street.rin.sprite.expression-set"
+      ]
+    },
+    {
+      "id": "char.tokyo.food_street.daichi",
+      "role": "support",
+      "relationshipTrack": "rp",
+      "requiredManifestKeys": [
+        "character.tokyo.food_street.daichi.portrait.default",
+        "character.tokyo.food_street.daichi.sprite.default",
+        "character.tokyo.food_street.daichi.scene.default",
+        "character.tokyo.food_street.daichi.voice.reference"
+      ],
+      "optionalManifestKeys": [
+        "character.tokyo.food_street.daichi.intro.video"
+      ]
+    },
+    {
+      "id": "tong",
+      "role": "assistant",
+      "relationshipTrack": "rp",
+      "requiredManifestKeys": [
+        "character.tong.expression.neutral"
+      ],
+      "optionalManifestKeys": [
+        "character.tong.expression.cheerful",
+        "character.tong.expression.thinking"
+      ]
+    }
+  ],
+  "objectiveSeed": {
+    "objectiveId": "tokyo-ramen-shop-counter-chat-v1",
+    "targetTypes": [
+      "vocabulary",
+      "grammar",
+      "sentenceStructures"
+    ],
+    "missionGate": {
+      "validatedHangoutsRequired": 2,
+      "masteryTierUnlock": "A1.2"
+    }
+  },
+  "manifestKeys": [
+    "city.tokyo.location.ramen-shop.backdrop.default",
+    "character.tokyo.food_street.rin.portrait.default",
+    "character.tokyo.food_street.daichi.portrait.default",
+    "character.tong.expression.neutral"
+  ],
+  "rewardHooks": {
+    "videoCallRewardKey": null,
+    "polaroidRewardKey": null
+  },
+  "status": "draft",
+  "rosterRegistrySource": "assets/manifest/starter-cast-registry.json"
+}

--- a/assets/content-packs/tokyo-tea-house.starter.json
+++ b/assets/content-packs/tokyo-tea-house.starter.json
@@ -1,0 +1,82 @@
+{
+  "templateVersion": "1.1.0",
+  "packType": "city-location-character-starter",
+  "packId": "pack.tokyo.tea_house.starter",
+  "city": "tokyo",
+  "mapLocationId": "tea_house",
+  "playerFacingLocationLabel": "Tea House",
+  "location": {
+    "id": "cafe",
+    "assetSlug": "tea-house",
+    "modes": [
+      "learn",
+      "hangout"
+    ]
+  },
+  "characterRoster": [
+    {
+      "id": "char.tokyo.cafe.hina",
+      "role": "lead",
+      "relationshipTrack": "rp",
+      "requiredManifestKeys": [
+        "character.tokyo.cafe.hina.portrait.default",
+        "character.tokyo.cafe.hina.sprite.default",
+        "character.tokyo.cafe.hina.scene.default",
+        "character.tokyo.cafe.hina.voice.reference"
+      ],
+      "optionalManifestKeys": [
+        "character.tokyo.cafe.hina.sprite.expression-set"
+      ]
+    },
+    {
+      "id": "char.tokyo.cafe.ren",
+      "role": "support",
+      "relationshipTrack": "rp",
+      "requiredManifestKeys": [
+        "character.tokyo.cafe.ren.portrait.default",
+        "character.tokyo.cafe.ren.sprite.default",
+        "character.tokyo.cafe.ren.scene.default",
+        "character.tokyo.cafe.ren.voice.reference"
+      ],
+      "optionalManifestKeys": [
+        "character.tokyo.cafe.ren.intro.video"
+      ]
+    },
+    {
+      "id": "tong",
+      "role": "assistant",
+      "relationshipTrack": "rp",
+      "requiredManifestKeys": [
+        "character.tong.expression.neutral"
+      ],
+      "optionalManifestKeys": [
+        "character.tong.expression.cheerful",
+        "character.tong.expression.thinking"
+      ]
+    }
+  ],
+  "objectiveSeed": {
+    "objectiveId": "tokyo-tea-house-polite-orders-v1",
+    "targetTypes": [
+      "vocabulary",
+      "grammar",
+      "sentenceStructures"
+    ],
+    "missionGate": {
+      "validatedHangoutsRequired": 2,
+      "masteryTierUnlock": "A1.2"
+    }
+  },
+  "manifestKeys": [
+    "city.tokyo.location.tea-house.backdrop.default",
+    "character.tokyo.cafe.hina.portrait.default",
+    "character.tokyo.cafe.ren.portrait.default",
+    "character.tong.expression.neutral"
+  ],
+  "rewardHooks": {
+    "videoCallRewardKey": null,
+    "polaroidRewardKey": null
+  },
+  "status": "draft",
+  "rosterRegistrySource": "assets/manifest/starter-cast-registry.json"
+}

--- a/assets/content-packs/tokyo-train-station.starter.json
+++ b/assets/content-packs/tokyo-train-station.starter.json
@@ -1,0 +1,82 @@
+{
+  "templateVersion": "1.1.0",
+  "packType": "city-location-character-starter",
+  "packId": "pack.tokyo.train_station.starter",
+  "city": "tokyo",
+  "mapLocationId": "train_station",
+  "playerFacingLocationLabel": "Train Station",
+  "location": {
+    "id": "subway_hub",
+    "assetSlug": "train-station",
+    "modes": [
+      "learn",
+      "hangout"
+    ]
+  },
+  "characterRoster": [
+    {
+      "id": "char.tokyo.subway_hub.akira",
+      "role": "lead",
+      "relationshipTrack": "rp",
+      "requiredManifestKeys": [
+        "character.tokyo.subway_hub.akira.portrait.default",
+        "character.tokyo.subway_hub.akira.sprite.default",
+        "character.tokyo.subway_hub.akira.scene.default",
+        "character.tokyo.subway_hub.akira.voice.reference"
+      ],
+      "optionalManifestKeys": [
+        "character.tokyo.subway_hub.akira.sprite.expression-set"
+      ]
+    },
+    {
+      "id": "char.tokyo.subway_hub.mei",
+      "role": "support",
+      "relationshipTrack": "rp",
+      "requiredManifestKeys": [
+        "character.tokyo.subway_hub.mei.portrait.default",
+        "character.tokyo.subway_hub.mei.sprite.default",
+        "character.tokyo.subway_hub.mei.scene.default",
+        "character.tokyo.subway_hub.mei.voice.reference"
+      ],
+      "optionalManifestKeys": [
+        "character.tokyo.subway_hub.mei.reward.polaroid"
+      ]
+    },
+    {
+      "id": "tong",
+      "role": "assistant",
+      "relationshipTrack": "rp",
+      "requiredManifestKeys": [
+        "character.tong.expression.neutral"
+      ],
+      "optionalManifestKeys": [
+        "character.tong.expression.cheerful",
+        "character.tong.expression.thinking"
+      ]
+    }
+  ],
+  "objectiveSeed": {
+    "objectiveId": "tokyo-train-station-commute-v1",
+    "targetTypes": [
+      "vocabulary",
+      "grammar",
+      "sentenceStructures"
+    ],
+    "missionGate": {
+      "validatedHangoutsRequired": 2,
+      "masteryTierUnlock": "A1.2"
+    }
+  },
+  "manifestKeys": [
+    "city.tokyo.location.train-station.backdrop.default",
+    "character.tokyo.subway_hub.akira.portrait.default",
+    "character.tokyo.subway_hub.mei.portrait.default",
+    "character.tong.expression.neutral"
+  ],
+  "rewardHooks": {
+    "videoCallRewardKey": null,
+    "polaroidRewardKey": null
+  },
+  "status": "draft",
+  "rosterRegistrySource": "assets/manifest/starter-cast-registry.json"
+}

--- a/assets/manifest/canonical-asset-manifest.json
+++ b/assets/manifest/canonical-asset-manifest.json
@@ -563,6 +563,396 @@
       "promptTemplate": null,
       "status": "draft",
       "uri": "assets/rewards/shanghai-reward-bundle.placeholder.json"
+    },
+    {
+      "key": "city.tokyo.location.train-station.backdrop.default",
+      "type": "image",
+      "usage": "hangout-backdrop",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/locations/tokyo-static.png",
+      "rights": "internal-demo",
+      "promptTemplate": null
+    },
+    {
+      "key": "city.tokyo.location.train-station.pack.starter",
+      "type": "content-pack",
+      "usage": "scene-authoring",
+      "source": "repo",
+      "status": "draft",
+      "uri": "assets/content-packs/tokyo-train-station.starter.json",
+      "rights": "internal-demo",
+      "promptTemplate": null
+    },
+    {
+      "key": "city.tokyo.location.izakaya.backdrop.default",
+      "type": "image",
+      "usage": "hangout-backdrop",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/locations/tokyo-static.png",
+      "rights": "internal-demo",
+      "promptTemplate": null
+    },
+    {
+      "key": "city.tokyo.location.izakaya.pack.starter",
+      "type": "content-pack",
+      "usage": "scene-authoring",
+      "source": "repo",
+      "status": "draft",
+      "uri": "assets/content-packs/tokyo-izakaya.starter.json",
+      "rights": "internal-demo",
+      "promptTemplate": null
+    },
+    {
+      "key": "city.tokyo.location.konbini.backdrop.default",
+      "type": "image",
+      "usage": "hangout-backdrop",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/locations/tokyo-static.png",
+      "rights": "internal-demo",
+      "promptTemplate": null
+    },
+    {
+      "key": "city.tokyo.location.konbini.pack.starter",
+      "type": "content-pack",
+      "usage": "scene-authoring",
+      "source": "repo",
+      "status": "draft",
+      "uri": "assets/content-packs/tokyo-konbini.starter.json",
+      "rights": "internal-demo",
+      "promptTemplate": null
+    },
+    {
+      "key": "city.tokyo.location.tea-house.backdrop.default",
+      "type": "image",
+      "usage": "hangout-backdrop",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/locations/tokyo-static.png",
+      "rights": "internal-demo",
+      "promptTemplate": null
+    },
+    {
+      "key": "city.tokyo.location.tea-house.pack.starter",
+      "type": "content-pack",
+      "usage": "scene-authoring",
+      "source": "repo",
+      "status": "draft",
+      "uri": "assets/content-packs/tokyo-tea-house.starter.json",
+      "rights": "internal-demo",
+      "promptTemplate": null
+    },
+    {
+      "key": "city.tokyo.location.ramen-shop.backdrop.default",
+      "type": "image",
+      "usage": "hangout-backdrop",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/locations/tokyo-static.png",
+      "rights": "internal-demo",
+      "promptTemplate": null
+    },
+    {
+      "key": "city.tokyo.location.ramen-shop.pack.starter",
+      "type": "content-pack",
+      "usage": "scene-authoring",
+      "source": "repo",
+      "status": "draft",
+      "uri": "assets/content-packs/tokyo-ramen-shop.starter.json",
+      "rights": "internal-demo",
+      "promptTemplate": null
+    },
+    {
+      "key": "city.shanghai.location.metro-station.backdrop.default",
+      "type": "image",
+      "usage": "hangout-backdrop",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/locations/shanghai-static.png",
+      "rights": "internal-demo",
+      "promptTemplate": null
+    },
+    {
+      "key": "city.shanghai.location.metro-station.pack.starter",
+      "type": "content-pack",
+      "usage": "scene-authoring",
+      "source": "repo",
+      "status": "draft",
+      "uri": "assets/content-packs/shanghai-metro-station.starter.json",
+      "rights": "internal-demo",
+      "promptTemplate": null
+    },
+    {
+      "key": "city.shanghai.location.bbq-stall.backdrop.default",
+      "type": "image",
+      "usage": "hangout-backdrop",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/locations/shanghai-static.png",
+      "rights": "internal-demo",
+      "promptTemplate": null
+    },
+    {
+      "key": "city.shanghai.location.bbq-stall.pack.starter",
+      "type": "content-pack",
+      "usage": "scene-authoring",
+      "source": "repo",
+      "status": "draft",
+      "uri": "assets/content-packs/shanghai-bbq-stall.starter.json",
+      "rights": "internal-demo",
+      "promptTemplate": null
+    },
+    {
+      "key": "city.shanghai.location.convenience-store.backdrop.default",
+      "type": "image",
+      "usage": "hangout-backdrop",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/locations/shanghai-static.png",
+      "rights": "internal-demo",
+      "promptTemplate": null
+    },
+    {
+      "key": "city.shanghai.location.convenience-store.pack.starter",
+      "type": "content-pack",
+      "usage": "scene-authoring",
+      "source": "repo",
+      "status": "draft",
+      "uri": "assets/content-packs/shanghai-convenience-store.starter.json",
+      "rights": "internal-demo",
+      "promptTemplate": null
+    },
+    {
+      "key": "city.shanghai.location.milk-tea-shop.backdrop.default",
+      "type": "image",
+      "usage": "hangout-backdrop",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/locations/shanghai-static.png",
+      "rights": "internal-demo",
+      "promptTemplate": null
+    },
+    {
+      "key": "city.shanghai.location.milk-tea-shop.pack.starter",
+      "type": "content-pack",
+      "usage": "scene-authoring",
+      "source": "repo",
+      "status": "draft",
+      "uri": "assets/content-packs/shanghai-milk-tea-shop.starter.json",
+      "rights": "internal-demo",
+      "promptTemplate": null
+    },
+    {
+      "key": "city.shanghai.location.dumpling-shop.backdrop.default",
+      "type": "image",
+      "usage": "hangout-backdrop",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/locations/shanghai-static.png",
+      "rights": "internal-demo",
+      "promptTemplate": null
+    },
+    {
+      "key": "city.shanghai.location.dumpling-shop.pack.starter",
+      "type": "content-pack",
+      "usage": "scene-authoring",
+      "source": "repo",
+      "status": "draft",
+      "uri": "assets/content-packs/shanghai-dumpling-shop.starter.json",
+      "rights": "internal-demo",
+      "promptTemplate": null
+    },
+    {
+      "key": "character.tokyo.cafe.hina.portrait.default",
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/characters/haeun/haeun.png",
+      "rights": "internal-demo",
+      "promptTemplate": null
+    },
+    {
+      "key": "character.tokyo.cafe.ren.portrait.default",
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/characters/jin/jin.png",
+      "rights": "internal-demo",
+      "promptTemplate": null
+    },
+    {
+      "key": "character.tokyo.convenience_store.kaito.portrait.default",
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/characters/haeun/haeun.png",
+      "rights": "internal-demo",
+      "promptTemplate": null
+    },
+    {
+      "key": "character.tokyo.convenience_store.yui.portrait.default",
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/characters/jin/jin.png",
+      "rights": "internal-demo",
+      "promptTemplate": null
+    },
+    {
+      "key": "character.tokyo.food_street.daichi.portrait.default",
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/characters/haeun/haeun.png",
+      "rights": "internal-demo",
+      "promptTemplate": null
+    },
+    {
+      "key": "character.tokyo.food_street.rin.portrait.default",
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/characters/jin/jin.png",
+      "rights": "internal-demo",
+      "promptTemplate": null
+    },
+    {
+      "key": "character.tokyo.subway_hub.akira.portrait.default",
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/characters/haeun/haeun.png",
+      "rights": "internal-demo",
+      "promptTemplate": null
+    },
+    {
+      "key": "character.tokyo.subway_hub.mei.portrait.default",
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/characters/jin/jin.png",
+      "rights": "internal-demo",
+      "promptTemplate": null
+    },
+    {
+      "key": "character.shanghai.convenience_store.an.portrait.default",
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/characters/haeun/haeun.png",
+      "rights": "internal-demo",
+      "promptTemplate": null
+    },
+    {
+      "key": "character.shanghai.convenience_store.yue.portrait.default",
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/characters/jin/jin.png",
+      "rights": "internal-demo",
+      "promptTemplate": null
+    },
+    {
+      "key": "character.shanghai.food_street.ming.portrait.default",
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/characters/haeun/haeun.png",
+      "rights": "internal-demo",
+      "promptTemplate": null
+    },
+    {
+      "key": "character.shanghai.food_street.qiao.portrait.default",
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/characters/jin/jin.png",
+      "rights": "internal-demo",
+      "promptTemplate": null
+    },
+    {
+      "key": "character.shanghai.practice_studio.xinyi.portrait.default",
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/characters/haeun/haeun.png",
+      "rights": "internal-demo",
+      "promptTemplate": null
+    },
+    {
+      "key": "character.shanghai.practice_studio.zhen.portrait.default",
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/characters/jin/jin.png",
+      "rights": "internal-demo",
+      "promptTemplate": null
+    },
+    {
+      "key": "character.shanghai.subway_hub.lin.portrait.default",
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/characters/haeun/haeun.png",
+      "rights": "internal-demo",
+      "promptTemplate": null
+    },
+    {
+      "key": "character.shanghai.subway_hub.wei.portrait.default",
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/characters/jin/jin.png",
+      "rights": "internal-demo",
+      "promptTemplate": null
+    },
+    {
+      "key": "reward.shanghai.milk_tea_shop.video_call",
+      "type": "video",
+      "usage": "mission-reward",
+      "source": "generated-placeholder",
+      "status": "placeholder",
+      "uri": "assets/rewards/shanghai-video-call.placeholder.mp4",
+      "rights": "internal-demo",
+      "promptTemplate": null
+    },
+    {
+      "key": "reward.shanghai.milk_tea_shop.polaroid",
+      "type": "image",
+      "usage": "collectible-memory",
+      "source": "generated-placeholder",
+      "status": "placeholder",
+      "uri": "assets/rewards/shanghai-polaroid.placeholder.png",
+      "rights": "internal-demo",
+      "promptTemplate": "reward-polaroid-placeholder-v1"
+    },
+    {
+      "key": "reward.shanghai.milk_tea_shop.bundle",
+      "type": "reward-bundle",
+      "usage": "reward-resolution",
+      "source": "repo",
+      "status": "planned",
+      "uri": "assets/rewards/shanghai-reward-bundle.placeholder.json",
+      "rights": "internal-demo",
+      "promptTemplate": null
     }
   ]
 }

--- a/assets/manifest/runtime-asset-manifest.json
+++ b/assets/manifest/runtime-asset-manifest.json
@@ -444,6 +444,318 @@
       "source": "repo",
       "status": "draft",
       "uri": "assets/rewards/shanghai-reward-bundle.placeholder.json"
+    },
+    {
+      "key": "city.tokyo.location.train-station.backdrop.default",
+      "type": "image",
+      "usage": "hangout-backdrop",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/locations/tokyo-static.png"
+    },
+    {
+      "key": "city.tokyo.location.train-station.pack.starter",
+      "type": "content-pack",
+      "usage": "scene-authoring",
+      "source": "repo",
+      "status": "draft",
+      "uri": "assets/content-packs/tokyo-train-station.starter.json"
+    },
+    {
+      "key": "city.tokyo.location.izakaya.backdrop.default",
+      "type": "image",
+      "usage": "hangout-backdrop",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/locations/tokyo-static.png"
+    },
+    {
+      "key": "city.tokyo.location.izakaya.pack.starter",
+      "type": "content-pack",
+      "usage": "scene-authoring",
+      "source": "repo",
+      "status": "draft",
+      "uri": "assets/content-packs/tokyo-izakaya.starter.json"
+    },
+    {
+      "key": "city.tokyo.location.konbini.backdrop.default",
+      "type": "image",
+      "usage": "hangout-backdrop",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/locations/tokyo-static.png"
+    },
+    {
+      "key": "city.tokyo.location.konbini.pack.starter",
+      "type": "content-pack",
+      "usage": "scene-authoring",
+      "source": "repo",
+      "status": "draft",
+      "uri": "assets/content-packs/tokyo-konbini.starter.json"
+    },
+    {
+      "key": "city.tokyo.location.tea-house.backdrop.default",
+      "type": "image",
+      "usage": "hangout-backdrop",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/locations/tokyo-static.png"
+    },
+    {
+      "key": "city.tokyo.location.tea-house.pack.starter",
+      "type": "content-pack",
+      "usage": "scene-authoring",
+      "source": "repo",
+      "status": "draft",
+      "uri": "assets/content-packs/tokyo-tea-house.starter.json"
+    },
+    {
+      "key": "city.tokyo.location.ramen-shop.backdrop.default",
+      "type": "image",
+      "usage": "hangout-backdrop",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/locations/tokyo-static.png"
+    },
+    {
+      "key": "city.tokyo.location.ramen-shop.pack.starter",
+      "type": "content-pack",
+      "usage": "scene-authoring",
+      "source": "repo",
+      "status": "draft",
+      "uri": "assets/content-packs/tokyo-ramen-shop.starter.json"
+    },
+    {
+      "key": "city.shanghai.location.metro-station.backdrop.default",
+      "type": "image",
+      "usage": "hangout-backdrop",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/locations/shanghai-static.png"
+    },
+    {
+      "key": "city.shanghai.location.metro-station.pack.starter",
+      "type": "content-pack",
+      "usage": "scene-authoring",
+      "source": "repo",
+      "status": "draft",
+      "uri": "assets/content-packs/shanghai-metro-station.starter.json"
+    },
+    {
+      "key": "city.shanghai.location.bbq-stall.backdrop.default",
+      "type": "image",
+      "usage": "hangout-backdrop",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/locations/shanghai-static.png"
+    },
+    {
+      "key": "city.shanghai.location.bbq-stall.pack.starter",
+      "type": "content-pack",
+      "usage": "scene-authoring",
+      "source": "repo",
+      "status": "draft",
+      "uri": "assets/content-packs/shanghai-bbq-stall.starter.json"
+    },
+    {
+      "key": "city.shanghai.location.convenience-store.backdrop.default",
+      "type": "image",
+      "usage": "hangout-backdrop",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/locations/shanghai-static.png"
+    },
+    {
+      "key": "city.shanghai.location.convenience-store.pack.starter",
+      "type": "content-pack",
+      "usage": "scene-authoring",
+      "source": "repo",
+      "status": "draft",
+      "uri": "assets/content-packs/shanghai-convenience-store.starter.json"
+    },
+    {
+      "key": "city.shanghai.location.milk-tea-shop.backdrop.default",
+      "type": "image",
+      "usage": "hangout-backdrop",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/locations/shanghai-static.png"
+    },
+    {
+      "key": "city.shanghai.location.milk-tea-shop.pack.starter",
+      "type": "content-pack",
+      "usage": "scene-authoring",
+      "source": "repo",
+      "status": "draft",
+      "uri": "assets/content-packs/shanghai-milk-tea-shop.starter.json"
+    },
+    {
+      "key": "city.shanghai.location.dumpling-shop.backdrop.default",
+      "type": "image",
+      "usage": "hangout-backdrop",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/locations/shanghai-static.png"
+    },
+    {
+      "key": "city.shanghai.location.dumpling-shop.pack.starter",
+      "type": "content-pack",
+      "usage": "scene-authoring",
+      "source": "repo",
+      "status": "draft",
+      "uri": "assets/content-packs/shanghai-dumpling-shop.starter.json"
+    },
+    {
+      "key": "character.tokyo.cafe.hina.portrait.default",
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/characters/haeun/haeun.png"
+    },
+    {
+      "key": "character.tokyo.cafe.ren.portrait.default",
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/characters/jin/jin.png"
+    },
+    {
+      "key": "character.tokyo.convenience_store.kaito.portrait.default",
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/characters/haeun/haeun.png"
+    },
+    {
+      "key": "character.tokyo.convenience_store.yui.portrait.default",
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/characters/jin/jin.png"
+    },
+    {
+      "key": "character.tokyo.food_street.daichi.portrait.default",
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/characters/haeun/haeun.png"
+    },
+    {
+      "key": "character.tokyo.food_street.rin.portrait.default",
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/characters/jin/jin.png"
+    },
+    {
+      "key": "character.tokyo.subway_hub.akira.portrait.default",
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/characters/haeun/haeun.png"
+    },
+    {
+      "key": "character.tokyo.subway_hub.mei.portrait.default",
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/characters/jin/jin.png"
+    },
+    {
+      "key": "character.shanghai.convenience_store.an.portrait.default",
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/characters/haeun/haeun.png"
+    },
+    {
+      "key": "character.shanghai.convenience_store.yue.portrait.default",
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/characters/jin/jin.png"
+    },
+    {
+      "key": "character.shanghai.food_street.ming.portrait.default",
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/characters/haeun/haeun.png"
+    },
+    {
+      "key": "character.shanghai.food_street.qiao.portrait.default",
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/characters/jin/jin.png"
+    },
+    {
+      "key": "character.shanghai.practice_studio.xinyi.portrait.default",
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/characters/haeun/haeun.png"
+    },
+    {
+      "key": "character.shanghai.practice_studio.zhen.portrait.default",
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/characters/jin/jin.png"
+    },
+    {
+      "key": "character.shanghai.subway_hub.lin.portrait.default",
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/characters/haeun/haeun.png"
+    },
+    {
+      "key": "character.shanghai.subway_hub.wei.portrait.default",
+      "type": "image",
+      "usage": "dialogue-avatar",
+      "source": "repo",
+      "status": "placeholder",
+      "uri": "/assets/characters/jin/jin.png"
+    },
+    {
+      "key": "reward.shanghai.milk_tea_shop.video_call",
+      "type": "video",
+      "usage": "mission-reward",
+      "source": "generated-placeholder",
+      "status": "placeholder",
+      "uri": "assets/rewards/shanghai-video-call.placeholder.mp4"
+    },
+    {
+      "key": "reward.shanghai.milk_tea_shop.polaroid",
+      "type": "image",
+      "usage": "collectible-memory",
+      "source": "generated-placeholder",
+      "status": "placeholder",
+      "uri": "assets/rewards/shanghai-polaroid.placeholder.png"
+    },
+    {
+      "key": "reward.shanghai.milk_tea_shop.bundle",
+      "type": "reward-bundle",
+      "usage": "reward-resolution",
+      "source": "repo",
+      "status": "planned",
+      "uri": "assets/rewards/shanghai-reward-bundle.placeholder.json"
     }
   ]
 }

--- a/assets/rewards/shanghai-reward-bundle.placeholder.json
+++ b/assets/rewards/shanghai-reward-bundle.placeholder.json
@@ -1,8 +1,8 @@
 {
   "bundleId": "shanghai-advanced-reward-placeholder",
   "manifestKeys": [
-    "reward.shanghai.video-call.placeholder.v1",
-    "reward.shanghai.polaroid.placeholder.v1"
+    "reward.shanghai.milk_tea_shop.video_call",
+    "reward.shanghai.milk_tea_shop.polaroid"
   ],
   "status": "planned"
 }

--- a/docs/handoff-notes.md
+++ b/docs/handoff-notes.md
@@ -1,3 +1,12 @@
+
+## 2026-03-21 (Issues 63/64 combined Tokyo+Shanghai starter-pack intent)
+- Date: 2026-03-21
+- Branch/worktree: `work` (combined city-pack run crossing creative-assets/runtime-assets/server-api shared files)
+- Intent:
+  - Add repo-visible Tokyo and Shanghai starter-pack files for every live post-#118 map pin under `assets/content-packs/**` using the canonical world-map registry and starter-cast registry.
+  - Update shared manifests, creative-assets docs, and runtime/API validation so dashboard and graph flows resolve authored Tokyo/Shanghai packs by `mapLocationId` through the registry instead of stale slot-only assumptions.
+  - Keep Tokyo free of any non-live `practice_studio` pack and preserve Shanghai `milk_tea_shop -> practice_studio` reward hooks.
+
 ## 2026-03-21 (Issue 62 Seoul starter-pack cross-lane intent)
 - Date: 2026-03-21
 - Branch/worktree: `codex/issue-62-seoul-starter-pack` + `.worktrees/creative-assets`

--- a/docs/mock-ui-and-assets-track.md
+++ b/docs/mock-ui-and-assets-track.md
@@ -37,10 +37,21 @@ Unblock demo validation early while API/plumbing is still in progress.
    - `assets/content-packs/seoul-convenience-store.starter.json`
    - `assets/content-packs/seoul-subway-hub.starter.json`
    - `assets/content-packs/seoul-practice-studio.starter.json`
+   - `assets/content-packs/tokyo-train-station.starter.json`
+   - `assets/content-packs/tokyo-izakaya.starter.json`
+   - `assets/content-packs/tokyo-konbini.starter.json`
+   - `assets/content-packs/tokyo-tea-house.starter.json`
+   - `assets/content-packs/tokyo-ramen-shop.starter.json`
+   - `assets/content-packs/shanghai-metro-station.starter.json`
+   - `assets/content-packs/shanghai-bbq-stall.starter.json`
+   - `assets/content-packs/shanghai-convenience-store.starter.json`
+   - `assets/content-packs/shanghai-milk-tea-shop.starter.json`
+   - `assets/content-packs/shanghai-dumpling-shop.starter.json`
    - `assets/rewards/shanghai-reward-bundle.placeholder.json`
    Pack data should use contract IDs such as `food_street`; reserve hyphenated slugs such as `food-street` for asset keys and file naming.
    - `assets/content-packs/starter-cast-roster.spec.md`
    - `assets/manifest/starter-cast-registry.json`
    Issue `#69` makes these the approved starter-cast and per-character asset-bundle source of truth for downstream city-pack work.
+   Tokyo intentionally has no live `practice_studio` pin, while Shanghai's live `milk_tea_shop` pin resolves to `dagLocationSlot: practice_studio` and keeps the advanced reward hooks on that starter pack.
 5. `npm run demo:smoke` now cross-checks concrete client `/assets/...` refs against the runtime manifest and on-disk files.
 6. Final plumbing should swap data sources without redesigning screens.

--- a/scripts/demo_smoke_check.mjs
+++ b/scripts/demo_smoke_check.mjs
@@ -753,24 +753,38 @@ if (!seoulRegistry) {
   process.exit(1);
 }
 
-const authoredSeoulPacks = starterPacks
-  .filter((pack) => pack.city === "seoul")
-  .map((pack) => pack.mapLocationId)
-  .sort();
-const expectedSeoulPacks = seoulRegistry.locations.map((entry) => entry.mapLocationId).sort();
-if (JSON.stringify(authoredSeoulPacks) !== JSON.stringify(expectedSeoulPacks)) {
-  console.error("Seoul starter-pack coverage does not match world-map-registry");
-  console.error(JSON.stringify({ expectedSeoulPacks, authoredSeoulPacks }, null, 2));
-  process.exit(1);
-}
-
-for (const starterPack of starterPacks.filter((pack) => pack.city === "seoul")) {
-  const expectedPackId = `pack.seoul.${starterPack.mapLocationId}.starter`;
-  if (starterPack.packId !== expectedPackId) {
-    console.error(`Unexpected Seoul starter packId for ${starterPack.mapLocationId}: ${starterPack.packId}`);
+function assertStarterPackCoverage(cityId) {
+  const cityRegistry = worldMapRegistry.cities.find((city) => city.cityId === cityId);
+  if (!cityRegistry) {
+    console.error(`world-map-registry missing ${cityId} city entry`);
     process.exit(1);
   }
+
+  const authoredPacks = starterPacks
+    .filter((pack) => pack.city === cityId)
+    .map((pack) => pack.mapLocationId)
+    .sort();
+  const expectedPacks = cityRegistry.locations.map((entry) => entry.mapLocationId).sort();
+  if (JSON.stringify(authoredPacks) !== JSON.stringify(expectedPacks)) {
+    console.error(`${cityId} starter-pack coverage does not match world-map-registry`);
+    console.error(JSON.stringify({ expectedPacks, authoredPacks }, null, 2));
+    process.exit(1);
+  }
+
+  for (const starterPack of starterPacks.filter((pack) => pack.city === cityId)) {
+    const expectedPackId = `pack.${cityId}.${starterPack.mapLocationId}.starter`;
+    if (starterPack.packId !== expectedPackId) {
+      console.error(`Unexpected ${cityId} starter packId for ${starterPack.mapLocationId}: ${starterPack.packId}`);
+      process.exit(1);
+    }
+  }
+
+  return authoredPacks;
 }
+
+const authoredSeoulPacks = assertStarterPackCoverage("seoul");
+const authoredTokyoPacks = assertStarterPackCoverage("tokyo");
+const authoredShanghaiPacks = assertStarterPackCoverage("shanghai");
 
 const practiceStudioPack = starterPacks.find(
   (pack) => pack.city === "seoul" && pack.mapLocationId === "practice_studio"
@@ -783,6 +797,32 @@ if (practiceStudioPack?.playerFacingLocationLabel !== "Chimaek Place") {
 const tokyoSlotRosters = starterCastRegistry.cities.find((city) => city.cityId === "tokyo")?.slotRosters ?? [];
 if (tokyoSlotRosters.some((roster) => roster.dagLocationSlot === "practice_studio")) {
   console.error("Tokyo starter-cast registry still contains a non-live practice_studio reserved roster");
+  process.exit(1);
+}
+
+if (starterPacks.some((pack) => pack.city === "tokyo" && pack.mapLocationId === "practice_studio")) {
+  console.error("Tokyo should not ship a non-live practice_studio starter pack");
+  process.exit(1);
+}
+
+if (starterPacks.some((pack) => pack.city === "shanghai" && pack.mapLocationId === "cafe")) {
+  console.error("Shanghai should not ship a non-live cafe starter pack");
+  process.exit(1);
+}
+
+const milkTeaPack = starterPacks.find(
+  (pack) => pack.city === "shanghai" && pack.mapLocationId === "milk_tea_shop"
+);
+if (milkTeaPack?.location?.id !== "practice_studio") {
+  console.error("Shanghai milk_tea_shop starter pack must resolve to the practice_studio DAG slot");
+  process.exit(1);
+}
+if (milkTeaPack?.rewardHooks?.videoCallRewardKey !== "reward.shanghai.milk_tea_shop.video_call") {
+  console.error("Shanghai milk_tea_shop starter pack must preserve the video_call reward hook");
+  process.exit(1);
+}
+if (milkTeaPack?.rewardHooks?.polaroidRewardKey !== "reward.shanghai.milk_tea_shop.polaroid") {
+  console.error("Shanghai milk_tea_shop starter pack must preserve the polaroid reward hook");
   process.exit(1);
 }
 
@@ -812,3 +852,5 @@ console.log("- Runtime asset manifest keys validated");
 console.log("- Canonical/runtime manifest parity validated");
 console.log(`- Client runtime manifest keys resolved (${clientRuntimeAssetUsage.manifestKeys.length})`);
 console.log(`- Seoul starter-pack coverage validated (${authoredSeoulPacks.length} packs)`);
+console.log(`- Tokyo starter-pack coverage validated (${authoredTokyoPacks.length} packs)`);
+console.log(`- Shanghai starter-pack coverage validated (${authoredShanghaiPacks.length} packs)`);

--- a/scripts/mock_api_flow_check.mjs
+++ b/scripts/mock_api_flow_check.mjs
@@ -381,6 +381,23 @@ async function run() {
       ?.locations?.find((location) => location.locationId === 'subway_hub');
     assert(tokyoLegacySubwayEntry?.mapLocationId === 'train_station', 'graphDashboard worldRoadmap subway_hub.mapLocationId mismatch');
     assert(tokyoLegacySubwayEntry?.dagLocationSlot === 'subway_hub', 'graphDashboard worldRoadmap subway_hub.dagLocationSlot mismatch');
+    const teaHouseDashboard = await requestJson(
+      `/api/v1/graph/dashboard?userId=${encodeURIComponent(userId)}&city=tokyo&location=tea_house`,
+    );
+    assert(teaHouseDashboard.ok, `/graph/dashboard tokyo tea_house failed (${teaHouseDashboard.status})`);
+    assert(teaHouseDashboard.data?.selectedPack?.pack?.packId === 'pack.tokyo.tea_house.starter', 'graphDashboard tokyo tea_house selectedPack.packId mismatch');
+    assert(teaHouseDashboard.data?.selectedPack?.pack?.mapLocationId === 'tea_house', 'graphDashboard tokyo tea_house pack.mapLocationId mismatch');
+    assert(teaHouseDashboard.data?.lessonBundle?.mapLocationId === 'tea_house', 'graphDashboard tokyo tea_house lessonBundle.mapLocationId mismatch');
+    assert(teaHouseDashboard.data?.lessonBundle?.dagLocationSlot === 'cafe', 'graphDashboard tokyo tea_house lessonBundle.dagLocationSlot mismatch');
+    const izakayaDashboard = await requestJson(
+      `/api/v1/graph/dashboard?userId=${encodeURIComponent(userId)}&city=tokyo&location=izakaya`,
+    );
+    assert(izakayaDashboard.ok, `/graph/dashboard tokyo izakaya failed (${izakayaDashboard.status})`);
+    assert(izakayaDashboard.data?.selectedPack?.pack?.packId === 'pack.tokyo.izakaya.starter', 'graphDashboard tokyo izakaya selectedPack.packId mismatch');
+    const izakayaRoster = izakayaDashboard.data?.selectedPack?.pack?.characterRoster || [];
+    assertArray(izakayaRoster, 'graphDashboard tokyo izakaya starter roster');
+    assert(izakayaRoster.some((entry) => entry.id === 'char.tokyo.food_street.rin'), 'graphDashboard tokyo izakaya roster should reuse Rin');
+    assert(izakayaRoster.some((entry) => entry.id === 'char.tokyo.food_street.daichi'), 'graphDashboard tokyo izakaya roster should reuse Daichi');
     logPass('/api/v1/graph/dashboard');
   }
 
@@ -405,6 +422,40 @@ async function run() {
     const chimaekEntry = seoulWorldRoadmap.find((location) => location.mapLocationId === 'practice_studio');
     assert(chimaekEntry?.label === 'Chimaek Place', 'graphDashboard seoul practice_studio label should preserve Chimaek Place');
     logPass('/api/v1/graph/dashboard?city=seoul&location=cafe');
+  }
+
+  const shanghaiGraphDashboard = await requestJson(
+    `/api/v1/graph/dashboard?userId=${encodeURIComponent(userId)}&city=shanghai&location=milk_tea_shop`,
+  );
+  if (shanghaiGraphDashboard.status === 404) {
+    logWarn('/api/v1/graph/dashboard shanghai starter-pack coverage unavailable on this runtime; skipped shanghai coverage checks');
+  } else {
+    assert(shanghaiGraphDashboard.ok, `/graph/dashboard shanghai failed (${shanghaiGraphDashboard.status})`);
+    assert(shanghaiGraphDashboard.data?.selectedPack?.pack?.packId === 'pack.shanghai.milk_tea_shop.starter', 'graphDashboard shanghai selectedPack.packId mismatch');
+    assert(shanghaiGraphDashboard.data?.selectedPack?.pack?.locationId === 'practice_studio', 'graphDashboard shanghai selectedPack.locationId mismatch');
+    assert(shanghaiGraphDashboard.data?.selectedPack?.pack?.mapLocationId === 'milk_tea_shop', 'graphDashboard shanghai pack.mapLocationId mismatch');
+    assert(shanghaiGraphDashboard.data?.lessonBundle?.mapLocationId === 'milk_tea_shop', 'graphDashboard shanghai lessonBundle.mapLocationId mismatch');
+    assert(shanghaiGraphDashboard.data?.lessonBundle?.dagLocationSlot === 'practice_studio', 'graphDashboard shanghai lessonBundle.dagLocationSlot mismatch');
+    assert(shanghaiGraphDashboard.data?.hangoutBundle?.mapLocationId === 'milk_tea_shop', 'graphDashboard shanghai hangoutBundle.mapLocationId mismatch');
+    assert(shanghaiGraphDashboard.data?.hangoutBundle?.dagLocationSlot === 'practice_studio', 'graphDashboard shanghai hangoutBundle.dagLocationSlot mismatch');
+    assert(
+      shanghaiGraphDashboard.data?.selectedPack?.pack?.rewardHooks?.videoCallRewardKey === 'reward.shanghai.milk_tea_shop.video_call',
+      'graphDashboard shanghai video_call reward hook mismatch',
+    );
+    assert(
+      shanghaiGraphDashboard.data?.selectedPack?.pack?.rewardHooks?.polaroidRewardKey === 'reward.shanghai.milk_tea_shop.polaroid',
+      'graphDashboard shanghai polaroid reward hook mismatch',
+    );
+    const dumplingDashboard = await requestJson(
+      `/api/v1/graph/dashboard?userId=${encodeURIComponent(userId)}&city=shanghai&location=dumpling_shop`,
+    );
+    assert(dumplingDashboard.ok, `/graph/dashboard shanghai dumpling_shop failed (${dumplingDashboard.status})`);
+    assert(dumplingDashboard.data?.selectedPack?.pack?.packId === 'pack.shanghai.dumpling_shop.starter', 'graphDashboard shanghai dumpling_shop selectedPack.packId mismatch');
+    const dumplingRoster = dumplingDashboard.data?.selectedPack?.pack?.characterRoster || [];
+    assertArray(dumplingRoster, 'graphDashboard shanghai dumpling_shop starter roster');
+    assert(dumplingRoster.some((entry) => entry.id === 'char.shanghai.food_street.qiao'), 'graphDashboard shanghai dumpling_shop roster should reuse Qiao');
+    assert(dumplingRoster.some((entry) => entry.id === 'char.shanghai.food_street.ming'), 'graphDashboard shanghai dumpling_shop roster should reuse Ming');
+    logPass('/api/v1/graph/dashboard?city=shanghai&location=milk_tea_shop');
   }
 
   const gameStart = await requestJson('/api/v1/game/start-or-resume', {


### PR DESCRIPTION
### Motivation
- Land repo-visible starter-pack files for all live Tokyo and Shanghai map pins so the runtime and dashboard resolve authored packs through the canonical world-map registry.
- Preserve constraints from the world-map and starter-cast registry contracts (no Tokyo `practice_studio`; Shanghai `milk_tea_shop -> practice_studio` with advanced reward hooks).
- Combine work for issues #63 and #64 into one serialized change set to avoid shared-file collisions and update supporting runtime/manifest/QA checks.\n\n### Description
- Added Tokyo starter packs: `assets/content-packs/tokyo-train-station.starter.json`, `assets/content-packs/tokyo-izakaya.starter.json`, `assets/content-packs/tokyo-konbini.starter.json`, `assets/content-packs/tokyo-tea-house.starter.json`, `assets/content-packs/tokyo-ramen-shop.starter.json`.\n- Added Shanghai starter packs: `assets/content-packs/shanghai-metro-station.starter.json`, `assets/content-packs/shanghai-bbq-stall.starter.json`, `assets/content-packs/shanghai-convenience-store.starter.json`, `assets/content-packs/shanghai-milk-tea-shop.starter.json`, `assets/content-packs/shanghai-dumpling-shop.starter.json`.\n- Updated runtime manifests and reward placeholder: `assets/manifest/canonical-asset-manifest.json`, `assets/manifest/runtime-asset-manifest.json`, and `assets/rewards/shanghai-reward-bundle.placeholder.json` so the new packs, portrait placeholders, and Shanghai reward hooks are consumable.\n- Updated server resolution and dashboard plumbing so `mapLocationId` queries resolve authored packs via `packages/contracts/world-map-registry.sample.json` and `getStarterPackMetadata` instead of falling back to stale slot-only assumptions (`apps/server/src/curriculum-graph.mjs`, `apps/server/src/index.mjs`).\n- Extended validation and docs: `scripts/demo_smoke_check.mjs`, `scripts/mock_api_flow_check.mjs`, `docs/mock-ui-and-assets-track.md`, and `docs/handoff-notes.md` to reflect the combined city-pack closeout and proof expectations.\n\nNotable explicit decisions: Tokyo has no live `practice_studio` pin (no Tokyo `practice_studio` pack added); Shanghai keeps `milk_tea_shop -> practice_studio` and preserves `reward.shanghai.milk_tea_shop.video_call` and `reward.shanghai.milk_tea_shop.polaroid`; Tokyo `izakaya` and `ramen_shop` are separate pack files that intentionally reuse the same Tokyo `food_street` starter roster; Shanghai `bbq_stall` and `dumpling_shop` are separate pack files that intentionally reuse the same Shanghai `food_street` starter roster.\n\nFixes #63\nFixes #64\nRefs #60\n\n### Testing
- Verified JSON validity for every added/updated pack and manifest with `python3 -m json.tool` on each file (succeeded).\n- Ran `npm run demo:smoke` and observed smoke checks pass, including authored Tokyo/Shanghai starter-pack coverage (passed).\n- Ran contract checks `npm run test:kg-contract-schema` and `npm run test:graph-contracts` (both passed).\n- Started the mock server (`npm --prefix apps/server run start`) and ran the API flow assertions with `node scripts/mock_api_flow_check.mjs http://127.0.0.1:8787 --strict-state --trace-file=artifacts/qa-runs/functional-qa/world-content/issue-63-64-combined/.../verification/mock-api-trace.json`, which validated: Tokyo `tea_house` resolution and shared-food roster reuse, Shanghai `milk_tea_shop -> practice_studio` resolution with preserved video-call+polaroid reward hooks, and `dumpling_shop` shared-food roster reuse (passed).\n\nHow to test locally: run `python3 -m json.tool` against the new/updated JSON files; run `npm run demo:smoke`; run `npm run test:kg-contract-schema` and `npm run test:graph-contracts`; start server with `npm --prefix apps/server run start` and run `node scripts/mock_api_flow_check.mjs http://127.0.0.1:8787 --strict-state` to inspect dashboard/resolution traces.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bec6bcd2e4832ab5a2dc62ad3ee33b)