### PR TITLE
feat: playtest session replay UI

### DIFF
--- a/apps/client/app/backstage/layout.tsx
+++ b/apps/client/app/backstage/layout.tsx
@@ -9,6 +9,7 @@ const TABS = [
   { href: '/backstage/signals', label: 'Signals' },
   { href: '/backstage/campaigns', label: 'Campaigns' },
   { href: '/backstage/triage', label: 'Triage' },
+  { href: '/backstage/replay', label: 'Replay' },
 ];
 
 export default function BackstageLayout({ children }: { children: React.ReactNode }) {

--- a/apps/client/app/backstage/replay/page.tsx
+++ b/apps/client/app/backstage/replay/page.tsx
@@ -1,0 +1,444 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+/* ── Types ────────────────────────────────────────────────────────── */
+
+interface PlaytestSession {
+  session_id: string;
+  city: string;
+  scene_type: string;
+  language: string;
+  status: string;
+  created_at: string;
+}
+
+interface Annotation {
+  id: string;
+  timestamp: number;
+  type: 'draw' | 'comment';
+  pathData?: string;
+  color?: string;
+  text?: string;
+  x?: number;
+  y?: number;
+  screenshot?: string;
+  screenshotUrl?: string;
+}
+
+interface AnalysisResult {
+  sessionId: string;
+  mode: string;
+  preset: string;
+  model: string;
+  analysisId: string;
+  screenshotCount: number;
+  tokensUsed: { inputTokens: number; outputTokens: number; totalTokens: number };
+  result: {
+    sessionSummary: string;
+    issues: Array<{
+      timestamp: string;
+      category: string;
+      severity: number;
+      description: string;
+      suggestedFix: string;
+      autoFixable: boolean;
+      affectedComponent?: string;
+    }>;
+    overallScore: number;
+    topPriority: string;
+  };
+  summary: {
+    issueCount: number;
+    autoFixableCount: number;
+  };
+}
+
+type Tab = 'timeline' | 'gallery' | 'analysis' | 'trace';
+
+/* ── API helpers ──────────────────────────────────────────────────── */
+
+const API_BASE = process.env.NEXT_PUBLIC_TONG_API_BASE || 'http://localhost:8787';
+const R2_BASE = 'https://runs.tong.berlayar.ai';
+
+async function fetchSessions(): Promise<PlaytestSession[]> {
+  const res = await fetch(`${API_BASE}/api/v1/playtest/sessions`);
+  if (!res.ok) return [];
+  const data = await res.json();
+  return data.sessions || [];
+}
+
+async function fetchAnnotations(sessionId: string): Promise<Annotation[]> {
+  try {
+    const res = await fetch(`${R2_BASE}/playtest/${sessionId}/annotations.json`);
+    if (!res.ok) return [];
+    const data = await res.json();
+    return data.annotations || (Array.isArray(data) ? data : []);
+  } catch {
+    return [];
+  }
+}
+
+async function fetchAnalysis(sessionId: string): Promise<AnalysisResult | null> {
+  try {
+    const res = await fetch(`${R2_BASE}/playtest/${sessionId}/analysis.json`);
+    if (!res.ok) return null;
+    return res.json();
+  } catch {
+    return null;
+  }
+}
+
+async function fetchAgentTrace(sessionId: string): Promise<any | null> {
+  try {
+    const res = await fetch(`${R2_BASE}/playtest/${sessionId}/agent-trace.json`);
+    if (!res.ok) return null;
+    return res.json();
+  } catch {
+    return null;
+  }
+}
+
+/* ── Helpers ──────────────────────────────────────────────────────── */
+
+const SEVERITY_COLORS: Record<number, string> = {
+  1: '#94a3b8', 2: '#60a5fa', 3: '#fbbf24', 4: '#f97316', 5: '#ef4444',
+};
+
+function fmtTime(s: number): string {
+  return `${String(Math.floor(s / 60)).padStart(2, '0')}:${String(s % 60).padStart(2, '0')}`;
+}
+
+/* ── Component ────────────────────────────────────────────────────── */
+
+export default function ReplayPage() {
+  const [sessions, setSessions] = useState<PlaytestSession[]>([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [annotations, setAnnotations] = useState<Annotation[]>([]);
+  const [analysis, setAnalysis] = useState<AnalysisResult | null>(null);
+  const [agentTrace, setAgentTrace] = useState<any | null>(null);
+  const [activeTab, setActiveTab] = useState<Tab>('timeline');
+  const [activeAnnotation, setActiveAnnotation] = useState<number>(0);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetchSessions().then((s) => {
+      setSessions(s.filter((x) => x.status === 'submitted' || x.status === 'analyzing'));
+      setLoading(false);
+    });
+  }, []);
+
+  const loadSession = useCallback(async (id: string) => {
+    setSelectedId(id);
+    setActiveAnnotation(0);
+    setActiveTab('timeline');
+    const [anns, anal, trace] = await Promise.all([
+      fetchAnnotations(id),
+      fetchAnalysis(id),
+      fetchAgentTrace(id),
+    ]);
+    setAnnotations(anns.sort((a, b) => a.timestamp - b.timestamp));
+    setAnalysis(anal);
+    setAgentTrace(trace);
+  }, []);
+
+  const selected = sessions.find((s) => s.session_id === selectedId);
+  const currentAnn = annotations[activeAnnotation];
+  const screenshotAnnotations = annotations.filter((a) => a.screenshotUrl || a.screenshot);
+
+  return (
+    <div>
+      <div className="triage-header">
+        <h1 className="triage-title">Session Replay</h1>
+        <p className="triage-subtitle">
+          {sessions.length} session{sessions.length !== 1 ? 's' : ''} with recordings
+        </p>
+      </div>
+
+      <div className="triage-layout">
+        {/* ── Session sidebar ──────────────────────────────────── */}
+        <div className="triage-sidebar">
+          <h2 className="triage-section-title">Sessions</h2>
+          {loading && <p className="triage-muted">Loading...</p>}
+          {!loading && sessions.length === 0 && (
+            <p className="triage-muted">No submitted sessions yet.</p>
+          )}
+          {sessions.map((s) => (
+            <button
+              key={s.session_id}
+              className={`triage-session-card ${selectedId === s.session_id ? 'triage-session-selected' : ''}`}
+              onClick={() => loadSession(s.session_id)}
+            >
+              <div className="triage-session-top">
+                <span className="triage-session-id">{s.session_id.slice(0, 8)}</span>
+                <span className={`triage-status triage-status-${s.status}`}>{s.status}</span>
+              </div>
+              <div className="triage-session-meta">
+                {s.city} / {s.scene_type} / {s.language}
+              </div>
+              <div className="triage-session-time">
+                {new Date(s.created_at).toLocaleString()}
+              </div>
+            </button>
+          ))}
+        </div>
+
+        {/* ── Main panel ───────────────────────────────────────── */}
+        <div className="triage-main">
+          {!selectedId && (
+            <div className="triage-empty">Select a session to replay</div>
+          )}
+
+          {selectedId && (
+            <>
+              {/* Tab bar */}
+              <div className="signals-controls" style={{ marginBottom: 16 }}>
+                {(['timeline', 'gallery', 'analysis', 'trace'] as Tab[]).map((tab) => (
+                  <button
+                    key={tab}
+                    className={`signals-platform-btn ${activeTab === tab ? 'signals-platform-active' : ''}`}
+                    onClick={() => setActiveTab(tab)}
+                  >
+                    {tab === 'timeline' ? `Timeline (${annotations.length})` :
+                     tab === 'gallery' ? `Screenshots (${screenshotAnnotations.length})` :
+                     tab === 'analysis' ? `Analysis${analysis ? ` (${analysis.summary.issueCount})` : ''}` :
+                     `Agent Trace${agentTrace ? '' : ' (none)'}`}
+                  </button>
+                ))}
+              </div>
+
+              {/* ── Timeline tab ──────────────────────────────── */}
+              {activeTab === 'timeline' && (
+                <div>
+                  {annotations.length === 0 ? (
+                    <div className="triage-empty">No annotations in this session</div>
+                  ) : (
+                    <>
+                      {/* Timeline bar */}
+                      <div className="replay-timeline-bar">
+                        {annotations.map((ann, idx) => (
+                          <button
+                            key={ann.id}
+                            className={`replay-timeline-marker ${idx === activeAnnotation ? 'replay-timeline-active' : ''} replay-marker-${ann.type}`}
+                            onClick={() => setActiveAnnotation(idx)}
+                            title={`${fmtTime(ann.timestamp)} — ${ann.type}${ann.text ? ': ' + ann.text.slice(0, 50) : ''}`}
+                            style={{ left: `${annotations.length === 1 ? 50 : (idx / (annotations.length - 1)) * 100}%` }}
+                          />
+                        ))}
+                      </div>
+
+                      {/* Navigation */}
+                      <div className="replay-nav">
+                        <button
+                          className="triage-action"
+                          disabled={activeAnnotation === 0}
+                          onClick={() => setActiveAnnotation((p) => Math.max(0, p - 1))}
+                        >
+                          Prev
+                        </button>
+                        <span className="triage-muted">
+                          {activeAnnotation + 1} / {annotations.length} — {fmtTime(currentAnn?.timestamp || 0)}
+                        </span>
+                        <button
+                          className="triage-action"
+                          disabled={activeAnnotation === annotations.length - 1}
+                          onClick={() => setActiveAnnotation((p) => Math.min(annotations.length - 1, p + 1))}
+                        >
+                          Next
+                        </button>
+                      </div>
+
+                      {/* Annotation viewer */}
+                      {currentAnn && (
+                        <div className="replay-viewer">
+                          {/* Screenshot or placeholder */}
+                          <div className="replay-screenshot-container">
+                            {currentAnn.screenshotUrl ? (
+                              <img
+                                src={currentAnn.screenshotUrl}
+                                alt={`Screenshot at ${fmtTime(currentAnn.timestamp)}`}
+                                className="replay-screenshot"
+                              />
+                            ) : (
+                              <div className="replay-no-screenshot">
+                                No screenshot captured
+                              </div>
+                            )}
+
+                            {/* Overlay: SVG drawing */}
+                            {currentAnn.type === 'draw' && currentAnn.pathData && (
+                              <svg className="replay-svg-overlay" viewBox="0 0 1280 800">
+                                <path
+                                  d={currentAnn.pathData}
+                                  stroke={currentAnn.color || '#ff6b2c'}
+                                  strokeWidth="3"
+                                  fill="none"
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                />
+                              </svg>
+                            )}
+
+                            {/* Overlay: comment pin */}
+                            {currentAnn.type === 'comment' && currentAnn.x != null && (
+                              <div
+                                className="replay-pin"
+                                style={{ left: `${(currentAnn.x ?? 0) * 100}%`, top: `${(currentAnn.y ?? 0) * 100}%` }}
+                              />
+                            )}
+                          </div>
+
+                          {/* Annotation details */}
+                          <div className="replay-details">
+                            <div className="replay-detail-header">
+                              <span className={`triage-auto-badge`}>{currentAnn.type}</span>
+                              <span className="triage-issue-time">{fmtTime(currentAnn.timestamp)}</span>
+                              {currentAnn.color && (
+                                <span className="replay-color-dot" style={{ background: currentAnn.color }} />
+                              )}
+                            </div>
+                            {currentAnn.text && (
+                              <p className="replay-comment-text">{currentAnn.text}</p>
+                            )}
+                            {currentAnn.pathData && (
+                              <p className="triage-muted" style={{ fontSize: '0.7rem' }}>
+                                SVG path: {currentAnn.pathData.slice(0, 60)}...
+                              </p>
+                            )}
+                          </div>
+                        </div>
+                      )}
+                    </>
+                  )}
+                </div>
+              )}
+
+              {/* ── Gallery tab ───────────────────────────────── */}
+              {activeTab === 'gallery' && (
+                <div>
+                  <p className="triage-muted" style={{ marginBottom: 12 }}>
+                    {screenshotAnnotations.length} screenshots captured — these are what Gemini analyzes in screenshot mode.
+                  </p>
+                  {screenshotAnnotations.length === 0 ? (
+                    <div className="triage-empty">No screenshots. Session may predate screenshot capture.</div>
+                  ) : (
+                    <div className="replay-gallery">
+                      {screenshotAnnotations.map((ann) => (
+                        <div key={ann.id} className="replay-gallery-card" onClick={() => {
+                          setActiveTab('timeline');
+                          setActiveAnnotation(annotations.indexOf(ann));
+                        }}>
+                          {ann.screenshotUrl ? (
+                            <img src={ann.screenshotUrl} alt={ann.id} className="replay-gallery-img" />
+                          ) : (
+                            <div className="replay-no-screenshot" style={{ height: 120 }}>No URL</div>
+                          )}
+                          <div className="replay-gallery-label">
+                            <span className="triage-issue-time">{fmtTime(ann.timestamp)}</span>
+                            <span className="triage-auto-badge">{ann.type}</span>
+                          </div>
+                          {ann.text && (
+                            <p className="replay-gallery-text">{ann.text.slice(0, 80)}</p>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {/* ── Analysis tab ──────────────────────────────── */}
+              {activeTab === 'analysis' && (
+                <div>
+                  {!analysis ? (
+                    <div className="triage-empty">
+                      No analysis results yet. Run: <code>/analyze-playtest {selectedId}</code>
+                    </div>
+                  ) : (
+                    <>
+                      <div className="triage-summary-bar">
+                        <div className="triage-score">
+                          <span className="triage-score-number">{analysis.result.overallScore}</span>
+                          <span className="triage-score-label">/10</span>
+                        </div>
+                        <div className="triage-summary-text">
+                          <p className="triage-summary-desc">{analysis.result.sessionSummary}</p>
+                          <p className="triage-top-priority">Top priority: {analysis.result.topPriority}</p>
+                        </div>
+                        <div className="triage-token-cost">
+                          {analysis.tokensUsed.totalTokens.toLocaleString()} tokens
+                          {analysis.mode === 'screenshots' ? ' (screenshots)' : ' (video)'}
+                        </div>
+                      </div>
+
+                      <div className="triage-issues">
+                        {analysis.result.issues.map((issue, idx) => (
+                          <div key={idx} className="triage-issue">
+                            <div className="triage-issue-header">
+                              <span className="triage-issue-time">{issue.timestamp}</span>
+                              <span
+                                className="triage-issue-severity"
+                                style={{ background: SEVERITY_COLORS[issue.severity] || '#94a3b8' }}
+                              >
+                                {issue.severity}/5
+                              </span>
+                              <span className="triage-issue-category">
+                                {issue.category.replace(/_/g, ' ')}
+                              </span>
+                              {issue.autoFixable && <span className="triage-auto-badge">auto-fixable</span>}
+                            </div>
+                            <p className="triage-issue-desc">{issue.description}</p>
+                            {issue.suggestedFix && (
+                              <p className="triage-issue-fix">Fix: {issue.suggestedFix}</p>
+                            )}
+                            {issue.affectedComponent && (
+                              <p className="triage-issue-component">
+                                Component: <code>{issue.affectedComponent}</code>
+                              </p>
+                            )}
+                          </div>
+                        ))}
+                      </div>
+                    </>
+                  )}
+                </div>
+              )}
+
+              {/* ── Agent Trace tab ───────────────────────────── */}
+              {activeTab === 'trace' && (
+                <div>
+                  {!agentTrace ? (
+                    <div className="triage-empty">
+                      No agent trace for this session. The daily pipeline posts traces after running.
+                    </div>
+                  ) : (
+                    <div className="triage-issues">
+                      {(agentTrace.steps || [agentTrace]).map((step: any, idx: number) => (
+                        <div key={idx} className="triage-issue">
+                          <div className="triage-issue-header">
+                            <span className="triage-auto-badge">{step.action || step.type || 'step'}</span>
+                            {step.prUrl && (
+                              <a href={step.prUrl} target="_blank" rel="noopener noreferrer"
+                                className="triage-issue-time" style={{ color: 'var(--mint)' }}>
+                                {step.prUrl}
+                              </a>
+                            )}
+                          </div>
+                          {step.reasoning && <p className="triage-issue-desc">{step.reasoning}</p>}
+                          {step.result && <p className="triage-issue-fix">{step.result}</p>}
+                          {step.error && (
+                            <p style={{ color: '#ef4444', fontSize: '0.8rem' }}>{step.error}</p>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/client/app/globals.css
+++ b/apps/client/app/globals.css
@@ -8499,3 +8499,159 @@ main.app-shell.app-shell--wide {
     align-items: flex-start;
   }
 }
+
+/* ── Replay page ───────────────────────────────────────────────────── */
+
+.replay-timeline-bar {
+  position: relative;
+  height: 32px;
+  background: rgba(255,255,255,0.04);
+  border-radius: 8px;
+  margin: 0 0 12px;
+}
+
+.replay-timeline-marker {
+  position: absolute;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 2px solid var(--ink, #f5f0e8);
+  cursor: pointer;
+  transition: transform 0.15s, box-shadow 0.15s;
+  padding: 0;
+}
+
+.replay-marker-draw { background: var(--orange, #ff6b2c); }
+.replay-marker-comment { background: var(--mint, #5ce0c2); }
+
+.replay-timeline-active {
+  transform: translate(-50%, -50%) scale(1.5);
+  box-shadow: 0 0 0 3px rgba(255,255,255,0.2);
+}
+
+.replay-nav {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  margin: 0 0 16px;
+}
+
+.replay-viewer {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.replay-screenshot-container {
+  position: relative;
+  background: #0d0d1a;
+  border-radius: 12px;
+  overflow: hidden;
+  aspect-ratio: 16 / 10;
+}
+
+.replay-screenshot {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  display: block;
+}
+
+.replay-no-screenshot {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  min-height: 200px;
+  color: var(--muted, #888);
+  font-size: 0.85rem;
+}
+
+.replay-svg-overlay {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+.replay-pin {
+  position: absolute;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--mint, #5ce0c2);
+  border: 2px solid white;
+  transform: translate(-50%, -50%);
+  box-shadow: 0 2px 8px rgba(0,0,0,0.4);
+}
+
+.replay-details {
+  background: rgba(255,255,255,0.04);
+  border-radius: 10px;
+  padding: 12px 16px;
+}
+
+.replay-detail-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.replay-color-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+.replay-comment-text {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: var(--ink, #f5f0e8);
+}
+
+.replay-gallery {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 12px;
+}
+
+.replay-gallery-card {
+  background: rgba(255,255,255,0.04);
+  border-radius: 10px;
+  overflow: hidden;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.replay-gallery-card:hover {
+  background: rgba(255,255,255,0.08);
+}
+
+.replay-gallery-img {
+  width: 100%;
+  aspect-ratio: 16 / 10;
+  object-fit: cover;
+  display: block;
+}
+
+.replay-gallery-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px 4px;
+}
+
+.replay-gallery-text {
+  padding: 0 10px 8px;
+  margin: 0;
+  font-size: 0.75rem;
+  color: var(--muted, #888);
+  line-height: 1.4;
+}


### PR DESCRIPTION
## Summary

New `/backstage/replay` page for reviewing playtest sessions end-to-end.

### 4 tabs

**Timeline** — step through annotations chronologically
- Colored markers on a timeline bar (orange = draw, mint = comment)
- Screenshot viewer with SVG drawing overlay + comment pin positions
- Prev/Next navigation with timestamp display

**Screenshots Gallery** — grid of all captured screenshots
- Shows exactly what Gemini analyzes in screenshot mode
- Click any card to jump to that point in the timeline

**Analysis** — Gemini structured output
- Overall score, session summary, top priority
- Issue list with severity, category, suggested fix, auto-fixable badge
- Token cost and analysis mode (screenshots vs video)

**Agent Trace** — daily pipeline reasoning
- What the agent decided to fix, PR links, errors
- Loaded from R2 `agent-trace.json` when available

### Data sources
All data fetched from R2 (`runs.tong.berlayar.ai`):
- `playtest/{id}/annotations.json` — annotation timeline
- `playtest/{id}/screenshots/{annId}.png` — per-annotation screenshots
- `playtest/{id}/analysis.json` — Gemini analysis results
- `playtest/{id}/agent-trace.json` — agent reasoning trace

## Test plan
- [ ] Open `/backstage/replay` — sessions listed in sidebar
- [ ] Select a submitted session — timeline loads with annotation markers
- [ ] Click prev/next — navigates between annotations
- [ ] Screenshots tab — shows grid of captured images
- [ ] Analysis tab — shows "run /analyze-playtest" prompt (no analysis yet)
- [ ] Agent trace tab — shows "no trace" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)