### PR TITLE
feat: auto-merge autofix PRs + R2 artifact storage + agent trace pipeline

### DIFF
--- a/.github/workflows/qa-publish.yml
+++ b/.github/workflows/qa-publish.yml
@@ -302,6 +302,26 @@ jobs:
             echo "- Dry run: \`${{ needs.resolve.outputs.dry_run }}\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Auto-merge autofix PRs
+        if: success() && startsWith(needs.resolve.outputs.head_ref, 'autofix/')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "Autofix branch detected: ${{ needs.resolve.outputs.head_ref }}"
+          echo "Enabling auto-merge for PR #${{ needs.resolve.outputs.pr_number }}..."
+          gh pr merge "${{ needs.resolve.outputs.pr_number }}" \
+            --repo "${{ github.repository }}" \
+            --auto --squash \
+            --subject "fix(autofix): $(gh pr view ${{ needs.resolve.outputs.pr_number }} --repo ${{ github.repository }} --json title -q .title)" || {
+            echo "Auto-merge failed (branch protection may not be configured). Commenting instead."
+            gh pr comment "${{ needs.resolve.outputs.pr_number }}" --repo "${{ github.repository }}" --body "$(cat <<'AUTOMERGE'
+          QA publish succeeded. This is an autofix PR — auto-merge was requested but could not be enabled (branch protection rules may need 'Allow auto-merge').
+
+          To merge manually: \`gh pr merge ${{ needs.resolve.outputs.pr_number }} --squash\`
+          AUTOMERGE
+            )"
+          }
+
       - name: Stop local QA services
         if: always() && needs.resolve.outputs.qa_recipe != ''
         run: |

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -2376,6 +2376,48 @@ async function handleRequest(request: Request): Promise<Response> {
       });
     }
 
+    // Store/retrieve artifacts (analysis results, agent traces) in R2
+    if (pathname.match(/^\/api\/v1\/playtest\/sessions\/[^/]+\/artifacts$/) && request.method === 'PUT') {
+      const sessionId = pathname.split('/')[5];
+      const env = (globalThis as any).__env;
+      if (!env?.TONG_RUNS_BUCKET) return jsonResponse(500, { error: 'r2_not_configured' });
+      const body = await readJsonBody(request);
+      const validTypes = ['analysis', 'agent-trace'];
+      if (!body.type || !validTypes.includes(body.type)) {
+        return jsonResponse(400, { error: 'invalid_type', valid: validTypes });
+      }
+      const r2Key = `playtest/${sessionId}/${body.type}.json`;
+      await env.TONG_RUNS_BUCKET.put(r2Key, JSON.stringify(body.data, null, 2), {
+        httpMetadata: { contentType: 'application/json' },
+      });
+      // Update D1 with artifact key
+      if (env?.DB) {
+        if (body.type === 'analysis') {
+          await env.DB.prepare(
+            `UPDATE playtest_sessions SET analysis_id = ?, updated_at = datetime('now') WHERE session_id = ?`
+          ).bind(body.data?.analysisId || r2Key, sessionId).run();
+        }
+      }
+      const publicBase = env?.TONG_RUNS_PUBLIC_BASE_URL || 'https://runs.tong.berlayar.ai';
+      return jsonResponse(200, { ok: true, key: r2Key, url: `${publicBase}/${r2Key}` });
+    }
+
+    if (pathname.match(/^\/api\/v1\/playtest\/sessions\/[^/]+\/artifacts\/[^/]+$/) && request.method === 'GET') {
+      const parts = pathname.split('/');
+      const sessionId = parts[5];
+      const artifactType = parts[7];
+      const env = (globalThis as any).__env;
+      if (!env?.TONG_RUNS_BUCKET) return jsonResponse(500, { error: 'r2_not_configured' });
+      const r2Key = `playtest/${sessionId}/${artifactType}.json`;
+      const obj = await env.TONG_RUNS_BUCKET.get(r2Key);
+      if (!obj) return jsonResponse(404, { error: 'artifact_not_found', type: artifactType });
+      const data = await obj.text();
+      return new Response(data, {
+        status: 200,
+        headers: { 'Content-Type': 'application/json; charset=utf-8', ...CORS_HEADERS },
+      });
+    }
+
     return jsonResponse(404, { error: 'not_found', pathname });
   } catch (error) {
     return jsonResponse(500, {

--- a/scripts/analyze-playtest-session.mjs
+++ b/scripts/analyze-playtest-session.mjs
@@ -253,9 +253,24 @@ try {
     console.log(json);
   }
 
-  // Update session in D1 if requested
+  // Update session + store analysis artifact in R2
   if (args['update-session']) {
     try {
+      // Store analysis.json in R2 via artifact endpoint
+      const artifactRes = await fetch(`${apiBase}/api/v1/playtest/sessions/${sessionId}/artifacts`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          'User-Agent': 'Mozilla/5.0 (tong-pipeline)',
+        },
+        body: JSON.stringify({ type: 'analysis', data: output }),
+      });
+      if (artifactRes.ok) {
+        const artifactData = await artifactRes.json();
+        console.error(`[analyze] Analysis stored in R2: ${artifactData.url}`);
+      }
+
+      // Update session status
       await fetch(`${apiBase}/api/v1/playtest/sessions/${sessionId}`, {
         method: 'PATCH',
         headers: {


### PR DESCRIPTION
## Summary

Closes #138 — completes the pipeline loop (Phase 4 of #134).

### Auto-merge for autofix PRs
`qa-publish.yml` now enables auto-merge (`gh pr merge --auto --squash`) after successful QA publish when the branch starts with `autofix/`. Falls back gracefully if branch protection isn't configured.

### R2 artifact storage
New Worker endpoints:
- `PUT /api/v1/playtest/sessions/:id/artifacts` — stores analysis results or agent traces in R2
- `GET /api/v1/playtest/sessions/:id/artifacts/:type` — retrieves stored artifacts

Artifacts stored at `playtest/{id}/analysis.json` and `playtest/{id}/agent-trace.json`, accessible from the Replay UI.

### Analysis CLI stores results in R2
`--update-session` flag now also stores `analysis.json` in R2 via the artifact endpoint, so the Replay UI's Analysis tab shows real data.

### Remote agent trace storage
Daily agent prompt updated to store its reasoning trace in R2 after each run — visible in the Replay UI's Agent Trace tab.

## Test plan
- [x] `PUT /artifacts` stores JSON in R2 — verified via curl
- [x] `GET /artifacts/agent-trace` returns stored data
- [x] R2 direct access works (`runs.tong.berlayar.ai/playtest/{id}/agent-trace.json`)
- [x] Worker deployed with new endpoints
- [ ] Auto-merge fires on next autofix PR after QA publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)