### PR TITLE
feat: seamless canvas recording + floating pill toolbar + video replay

### DIFF
--- a/apps/client/app/backstage/replay/page.tsx
+++ b/apps/client/app/backstage/replay/page.tsx
@@ -54,7 +54,7 @@ interface AnalysisResult {
   };
 }
 
-type Tab = 'timeline' | 'gallery' | 'analysis' | 'trace';
+type Tab = 'session' | 'gallery' | 'analysis' | 'trace';
 
 /* ── API helpers ──────────────────────────────────────────────────── */
 
@@ -117,7 +117,7 @@ export default function ReplayPage() {
   const [annotations, setAnnotations] = useState<Annotation[]>([]);
   const [analysis, setAnalysis] = useState<AnalysisResult | null>(null);
   const [agentTrace, setAgentTrace] = useState<any | null>(null);
-  const [activeTab, setActiveTab] = useState<Tab>('timeline');
+  const [activeTab, setActiveTab] = useState<Tab>('session');
   const [activeAnnotation, setActiveAnnotation] = useState<number>(0);
   const [loading, setLoading] = useState(true);
 
@@ -131,7 +131,7 @@ export default function ReplayPage() {
   const loadSession = useCallback(async (id: string) => {
     setSelectedId(id);
     setActiveAnnotation(0);
-    setActiveTab('timeline');
+    setActiveTab('session');
     const [anns, anal, trace] = await Promise.all([
       fetchAnnotations(id),
       fetchAnalysis(id),
@@ -193,13 +193,13 @@ export default function ReplayPage() {
             <>
               {/* Tab bar */}
               <div className="signals-controls" style={{ marginBottom: 16 }}>
-                {(['timeline', 'gallery', 'analysis', 'trace'] as Tab[]).map((tab) => (
+                {(['session', 'gallery', 'analysis', 'trace'] as Tab[]).map((tab) => (
                   <button
                     key={tab}
                     className={`signals-platform-btn ${activeTab === tab ? 'signals-platform-active' : ''}`}
                     onClick={() => setActiveTab(tab)}
                   >
-                    {tab === 'timeline' ? `Timeline (${annotations.length})` :
+                    {tab === 'session' ? `Session (${annotations.length})` :
                      tab === 'gallery' ? `Screenshots (${screenshotAnnotations.length})` :
                      tab === 'analysis' ? `Analysis${analysis ? ` (${analysis.summary.issueCount})` : ''}` :
                      `Agent Trace${agentTrace ? '' : ' (none)'}`}
@@ -207,9 +207,26 @@ export default function ReplayPage() {
                 ))}
               </div>
 
-              {/* ── Timeline tab ──────────────────────────────── */}
-              {activeTab === 'timeline' && (
+              {/* ── Session tab: video + timeline + annotations ── */}
+              {activeTab === 'session' && (
                 <div>
+                  {/* Video player */}
+                  <div className="replay-video-container">
+                    <video
+                      className="replay-video"
+                      src={`${R2_BASE}/playtest/${selectedId}/recording.webm`}
+                      controls
+                      playsInline
+                      preload="metadata"
+                    />
+                    <div className="replay-video-meta">
+                      <span>{selected?.city} / {selected?.scene_type}</span>
+                      <span>{selected?.language}</span>
+                      <span>{annotations.length} annotation{annotations.length !== 1 ? 's' : ''}</span>
+                      <span>{screenshotAnnotations.length} screenshot{screenshotAnnotations.length !== 1 ? 's' : ''}</span>
+                    </div>
+                  </div>
+
                   {annotations.length === 0 ? (
                     <div className="triage-empty">No annotations in this session</div>
                   ) : (
@@ -325,7 +342,7 @@ export default function ReplayPage() {
                     <div className="replay-gallery">
                       {screenshotAnnotations.map((ann) => (
                         <div key={ann.id} className="replay-gallery-card" onClick={() => {
-                          setActiveTab('timeline');
+                          setActiveTab('session');
                           setActiveAnnotation(annotations.indexOf(ann));
                         }}>
                           {ann.screenshotUrl ? (

--- a/apps/client/app/globals.css
+++ b/apps/client/app/globals.css
@@ -7625,49 +7625,96 @@ main.app-shell.app-shell--wide {
   pointer-events: auto;
 }
 
-.playtest-toolbar {
+/* ── Floating pill toolbar ──────────────────────────────────────── */
+
+.playtest-pill {
   position: absolute;
-  top: 0;
-  left: 50%;
-  transform: translateX(-50%);
+  bottom: 20px;
+  right: 20px;
   z-index: 950;
+  pointer-events: auto;
+}
+
+.playtest-pill-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: rgba(0, 0, 0, 0.75);
+  backdrop-filter: blur(12px);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 24px;
+  padding: 8px 16px;
+  color: #fff;
+  font-size: 13px;
+  cursor: pointer;
+  font-family: inherit;
+  transition: background 0.15s, transform 0.15s;
+}
+
+.playtest-pill-toggle:hover {
+  background: rgba(0, 0, 0, 0.85);
+  transform: scale(1.03);
+}
+
+.playtest-pill-label {
+  font-weight: 500;
+}
+
+.playtest-pill-badge {
+  background: var(--orange, #ff6b2c);
+  color: #fff;
+  font-size: 11px;
+  font-weight: 700;
+  border-radius: 10px;
+  padding: 1px 7px;
+  min-width: 18px;
+  text-align: center;
+}
+
+.playtest-pill-controls {
   display: flex;
   flex-direction: column;
-  align-items: center;
+  gap: 8px;
+  background: rgba(0, 0, 0, 0.82);
+  backdrop-filter: blur(14px);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 16px;
+  padding: 12px;
+  min-width: 200px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
 }
 
-.playtest-toolbar-toggle {
-  background: rgba(0, 0, 0, 0.7);
+.playtest-pill-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.playtest-pill-time {
+  font-size: 13px;
+  font-weight: 600;
   color: #fff;
-  border: none;
-  border-radius: 0 0 8px 8px;
-  padding: 4px 20px;
+  font-variant-numeric: tabular-nums;
+}
+
+.playtest-pill-notes {
   font-size: 12px;
+  color: rgba(255, 255, 255, 0.5);
+  margin-left: auto;
+}
+
+.playtest-pill-close {
+  background: none;
+  border: none;
+  color: rgba(255, 255, 255, 0.4);
+  font-size: 14px;
   cursor: pointer;
-  backdrop-filter: blur(8px);
+  padding: 2px 4px;
+  margin-left: 4px;
 }
 
-.playtest-toolbar-inner {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  background: rgba(0, 0, 0, 0.8);
-  backdrop-filter: blur(12px);
-  padding: 8px 16px;
-  border-radius: 0 0 12px 12px;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
-}
-
-.playtest-toolbar-group {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 0 8px;
-  border-right: 1px solid rgba(255, 255, 255, 0.15);
-}
-
-.playtest-toolbar-group:last-child {
-  border-right: none;
+.playtest-pill-close:hover {
+  color: #fff;
 }
 
 .playtest-btn {
@@ -8654,4 +8701,27 @@ main.app-shell.app-shell--wide {
   font-size: 0.75rem;
   color: var(--muted, #888);
   line-height: 1.4;
+}
+
+.replay-video-container {
+  margin-bottom: 16px;
+  border-radius: 12px;
+  overflow: hidden;
+  background: #0d0d1a;
+}
+
+.replay-video {
+  width: 100%;
+  display: block;
+  max-height: 400px;
+  background: #0d0d1a;
+}
+
+.replay-video-meta {
+  display: flex;
+  gap: 12px;
+  padding: 8px 12px;
+  font-size: 0.75rem;
+  color: var(--muted, #888);
+  background: rgba(255,255,255,0.03);
 }

--- a/apps/client/components/playtest/PlaytestOverlay.tsx
+++ b/apps/client/components/playtest/PlaytestOverlay.tsx
@@ -6,35 +6,27 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 export interface Annotation {
   id: string;
-  timestamp: number; // seconds into recording
+  timestamp: number;
   type: 'draw' | 'comment';
-  /** SVG path data for drawings */
   pathData?: string;
   color?: string;
-  /** Comment text (user's original + AI clarifications) */
   text?: string;
   clarified?: boolean;
   category?: string;
   severity?: number;
-  /** Screenshot data URL at annotation moment */
   screenshot?: string;
-  /** Position on viewport (0-1 range) */
   x?: number;
   y?: number;
 }
 
 interface Props {
-  /** Ref to the game viewport element to record */
   targetRef: React.RefObject<HTMLElement | null>;
-  /** Session ID for labeling */
   sessionId: string;
-  /** Called when user submits the session */
   onSubmit: (data: {
     recording: Blob;
     annotations: Annotation[];
     screenshots: Map<string, Blob>;
   }) => void;
-  /** Optional: AI clarification handler */
   onRequestClarification?: (comment: Annotation) => Promise<string | null>;
 }
 
@@ -43,31 +35,29 @@ type Tool = 'none' | 'pen' | 'highlight' | 'comment';
 /* ── Component ────────────────────────────────────────────────────── */
 
 export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClarification }: Props) {
-  // Recording state
   const [isRecording, setIsRecording] = useState(false);
-  const [isPaused, setIsPaused] = useState(false);
   const [recordingTime, setRecordingTime] = useState(0);
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
   const chunksRef = useRef<Blob[]>([]);
   const startTimeRef = useRef(0);
   const timerRef = useRef<ReturnType<typeof setInterval>>();
 
-  // Annotation state
+  // Frame capture: hidden canvas mirrors the game viewport via rAF
+  const frameCaptureRef = useRef<HTMLCanvasElement | null>(null);
+  const frameLoopRef = useRef<number>(0);
+
   const [activeTool, setActiveTool] = useState<Tool>('none');
   const [penColor, setPenColor] = useState('#ff6b2c');
   const [annotations, setAnnotations] = useState<Annotation[]>([]);
   const [commentText, setCommentText] = useState('');
   const [commentPos, setCommentPos] = useState<{ x: number; y: number } | null>(null);
-  const [showToolbar, setShowToolbar] = useState(true);
+  const [expanded, setExpanded] = useState(false);
   const [aiReply, setAiReply] = useState<string | null>(null);
   const [aiLoading, setAiLoading] = useState(false);
 
-  // Canvas ref for drawing
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const isDrawing = useRef(false);
   const currentPath = useRef<string[]>([]);
-
-  // Screenshot blobs keyed by annotation ID
   const screenshotBlobsRef = useRef<Map<string, Blob>>(new Map());
 
   const currentTimestamp = useCallback(() => {
@@ -75,14 +65,63 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
     return Math.floor((Date.now() - startTimeRef.current) / 1000);
   }, []);
 
+  const fmt = (s: number) =>
+    `${String(Math.floor(s / 60)).padStart(2, '0')}:${String(s % 60).padStart(2, '0')}`;
+
+  /* ── Frame capture: mirror viewport to hidden canvas ──────────── */
+
+  const startFrameCapture = useCallback(() => {
+    const target = targetRef.current;
+    if (!target) return;
+
+    // Create a hidden canvas that mirrors the DOM
+    let fc = frameCaptureRef.current;
+    if (!fc) {
+      fc = document.createElement('canvas');
+      fc.style.display = 'none';
+      document.body.appendChild(fc);
+      frameCaptureRef.current = fc;
+    }
+
+    const captureFrame = () => {
+      if (!target) return;
+      const rect = target.getBoundingClientRect();
+      if (fc!.width !== rect.width || fc!.height !== rect.height) {
+        fc!.width = rect.width;
+        fc!.height = rect.height;
+      }
+
+      // Use the target's internal canvases if available (game renders to <canvas>)
+      const gameCanvases = target.querySelectorAll('canvas');
+      const ctx = fc!.getContext('2d');
+      if (ctx && gameCanvases.length > 0) {
+        ctx.clearRect(0, 0, fc!.width, fc!.height);
+        // Draw game background
+        ctx.fillStyle = '#0d0d1a';
+        ctx.fillRect(0, 0, fc!.width, fc!.height);
+        // Composite all game canvases
+        for (const gc of gameCanvases) {
+          try {
+            const gcRect = gc.getBoundingClientRect();
+            ctx.drawImage(gc,
+              gcRect.left - rect.left, gcRect.top - rect.top,
+              gcRect.width, gcRect.height,
+            );
+          } catch { /* tainted canvas — skip */ }
+        }
+      }
+      frameLoopRef.current = requestAnimationFrame(captureFrame);
+    };
+
+    frameLoopRef.current = requestAnimationFrame(captureFrame);
+  }, [targetRef]);
+
   /* ── Screenshot capture ──────────────────────────────────────── */
 
-  /** Capture the game viewport + drawing overlay as a PNG blob. */
   const captureScreenshot = useCallback(async (annotationId: string): Promise<void> => {
     const target = targetRef.current;
     if (!target) return;
     try {
-      // Create an offscreen canvas matching the viewport
       const rect = target.getBoundingClientRect();
       const offscreen = document.createElement('canvas');
       offscreen.width = rect.width;
@@ -90,63 +129,51 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
       const ctx = offscreen.getContext('2d');
       if (!ctx) return;
 
-      // Capture the game viewport via the MediaRecorder's video stream frame
-      // (if recording), or fall back to a white placeholder
-      const stream = mediaRecorderRef.current?.stream;
-      const videoTrack = stream?.getVideoTracks()[0];
-      if (videoTrack && 'ImageCapture' in window) {
-        try {
-          const capture = new (window as any).ImageCapture(videoTrack);
-          const bitmap = await capture.grabFrame();
-          ctx.drawImage(bitmap, 0, 0, rect.width, rect.height);
-          bitmap.close();
-        } catch {
-          // ImageCapture not supported or failed — fill with dark bg
-          ctx.fillStyle = '#0d0d1a';
-          ctx.fillRect(0, 0, rect.width, rect.height);
-        }
+      // Try frame capture canvas first (most reliable)
+      const fc = frameCaptureRef.current;
+      if (fc && fc.width > 0) {
+        ctx.drawImage(fc, 0, 0, rect.width, rect.height);
       } else {
+        // Fallback: try to capture game canvases directly
         ctx.fillStyle = '#0d0d1a';
         ctx.fillRect(0, 0, rect.width, rect.height);
+        const gameCanvases = target.querySelectorAll('canvas');
+        for (const gc of gameCanvases) {
+          try {
+            const gcRect = gc.getBoundingClientRect();
+            ctx.drawImage(gc, gcRect.left - rect.left, gcRect.top - rect.top, gcRect.width, gcRect.height);
+          } catch { /* skip tainted */ }
+        }
       }
 
-      // Composite the drawing canvas overlay on top
+      // Composite drawing overlay
       const drawingCanvas = canvasRef.current;
       if (drawingCanvas) {
         ctx.drawImage(drawingCanvas, 0, 0);
       }
 
-      // Convert to blob and store
       const blob = await new Promise<Blob | null>((resolve) =>
         offscreen.toBlob(resolve, 'image/png'),
       );
       if (blob) {
         screenshotBlobsRef.current.set(annotationId, blob);
       }
-    } catch {
-      // Screenshot capture is best-effort — don't block annotation
-    }
+    } catch { /* best-effort */ }
   }, [targetRef]);
 
-  /* ── Recording controls ──────────────────────────────────────── */
+  /* ── Recording: auto-start using canvas.captureStream() ────── */
 
-  const startRecording = useCallback(async () => {
-    const target = targetRef.current;
-    if (!target) return;
+  const startRecording = useCallback(() => {
+    const fc = frameCaptureRef.current;
+    if (!fc) return;
 
     try {
-      // Capture the game viewport as a media stream
-      const stream = await (navigator.mediaDevices as any).getDisplayMedia({
-        video: { displaySurface: 'browser' },
-        audio: true,
-        preferCurrentTab: true,
-      });
-
+      const stream = fc.captureStream(15); // 15 fps — good quality, small files
       const recorder = new MediaRecorder(stream, {
         mimeType: MediaRecorder.isTypeSupported('video/webm;codecs=vp9')
           ? 'video/webm;codecs=vp9'
           : 'video/webm',
-        videoBitsPerSecond: 1_000_000, // 1 Mbps — keeps recordings under 100MB for ~10 min
+        videoBitsPerSecond: 1_000_000,
       });
 
       chunksRef.current = [];
@@ -154,55 +181,48 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
         if (e.data.size > 0) chunksRef.current.push(e.data);
       };
 
-      recorder.onstop = () => {
-        stream.getTracks().forEach((t: MediaStreamTrack) => t.stop());
-      };
-
-      recorder.start(1000); // chunk every 1s
+      recorder.start(1000);
       mediaRecorderRef.current = recorder;
       startTimeRef.current = Date.now();
       setIsRecording(true);
-      setIsPaused(false);
 
       timerRef.current = setInterval(() => {
         setRecordingTime(Math.floor((Date.now() - startTimeRef.current) / 1000));
       }, 1000);
     } catch (err) {
-      console.error('Failed to start recording:', err);
-    }
-  }, [targetRef]);
-
-  const pauseRecording = useCallback(() => {
-    if (mediaRecorderRef.current?.state === 'recording') {
-      mediaRecorderRef.current.pause();
-      setIsPaused(true);
-    }
-  }, []);
-
-  const resumeRecording = useCallback(() => {
-    if (mediaRecorderRef.current?.state === 'paused') {
-      mediaRecorderRef.current.resume();
-      setIsPaused(false);
+      console.error('Failed to start canvas recording:', err);
     }
   }, []);
 
   const stopAndSubmit = useCallback(() => {
     if (timerRef.current) clearInterval(timerRef.current);
-
     const recorder = mediaRecorderRef.current;
-    if (!recorder) return;
+    if (!recorder) {
+      // No recording — submit annotations only
+      const emptyBlob = new Blob([], { type: 'video/webm' });
+      onSubmit({ recording: emptyBlob, annotations, screenshots: screenshotBlobsRef.current });
+      return;
+    }
 
     recorder.onstop = () => {
-      recorder.stream.getTracks().forEach((t) => t.stop());
       const blob = new Blob(chunksRef.current, { type: 'video/webm' });
       onSubmit({ recording: blob, annotations, screenshots: screenshotBlobsRef.current });
     };
-
     if (recorder.state !== 'inactive') recorder.stop();
     setIsRecording(false);
   }, [annotations, onSubmit]);
 
-  /* ── Drawing (pen / highlight) ───────────────────────────────── */
+  // Auto-start: begin frame capture + recording when component mounts
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      startFrameCapture();
+      // Small delay to let frame capture initialize
+      setTimeout(() => startRecording(), 500);
+    }, 1000); // Wait for game to render first frame
+    return () => clearTimeout(timer);
+  }, [startFrameCapture, startRecording]);
+
+  /* ── Drawing ───────────────────────────────────────────────────── */
 
   const getCanvasPos = useCallback(
     (e: React.PointerEvent): [number, number] => {
@@ -226,12 +246,10 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
         });
         return;
       }
-
       if (activeTool !== 'pen' && activeTool !== 'highlight') return;
       isDrawing.current = true;
       const [x, y] = getCanvasPos(e);
       currentPath.current = [`M ${x} ${y}`];
-
       const ctx = canvasRef.current?.getContext('2d');
       if (!ctx) return;
       ctx.beginPath();
@@ -240,8 +258,7 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
       ctx.lineWidth = activeTool === 'highlight' ? 20 : 3;
       ctx.lineCap = 'round';
       ctx.lineJoin = 'round';
-      if (activeTool === 'highlight') ctx.globalAlpha = 0.35;
-      else ctx.globalAlpha = 1;
+      ctx.globalAlpha = activeTool === 'highlight' ? 0.35 : 1;
     },
     [activeTool, penColor, getCanvasPos],
   );
@@ -251,7 +268,6 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
       if (!isDrawing.current) return;
       const [x, y] = getCanvasPos(e);
       currentPath.current.push(`L ${x} ${y}`);
-
       const ctx = canvasRef.current?.getContext('2d');
       if (!ctx) return;
       ctx.lineTo(x, y);
@@ -263,69 +279,49 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
   const handlePointerUp = useCallback(() => {
     if (!isDrawing.current) return;
     isDrawing.current = false;
-
     const ctx = canvasRef.current?.getContext('2d');
     if (ctx) ctx.globalAlpha = 1;
-
     if (currentPath.current.length > 1) {
       const id = `draw-${Date.now()}`;
-      const annotation: Annotation = {
-        id,
-        timestamp: currentTimestamp(),
-        type: 'draw',
-        pathData: currentPath.current.join(' '),
-        color: penColor,
-        screenshot: id,
-      };
-      setAnnotations((prev) => [...prev, annotation]);
-      // Capture screenshot with the drawing included (fire-and-forget)
+      setAnnotations((prev) => [...prev, {
+        id, timestamp: currentTimestamp(), type: 'draw',
+        pathData: currentPath.current.join(' '), color: penColor, screenshot: id,
+      }]);
       void captureScreenshot(id);
     }
     currentPath.current = [];
   }, [penColor, currentTimestamp, captureScreenshot]);
 
-  /* ── Comment submission with optional AI clarification ────────── */
+  /* ── Comment ───────────────────────────────────────────────────── */
 
   const submitComment = useCallback(async () => {
     if (!commentText.trim() || !commentPos) return;
-
     const id = `comment-${Date.now()}`;
     const annotation: Annotation = {
-      id,
-      timestamp: currentTimestamp(),
-      type: 'comment',
-      text: commentText.trim(),
-      x: commentPos.x,
-      y: commentPos.y,
-      clarified: false,
-      screenshot: id,
+      id, timestamp: currentTimestamp(), type: 'comment',
+      text: commentText.trim(), x: commentPos.x, y: commentPos.y,
+      clarified: false, screenshot: id,
     };
-
     setAnnotations((prev) => [...prev, annotation]);
     setCommentText('');
     setAiReply(null);
-    // Capture screenshot at comment moment
     void captureScreenshot(id);
 
-    // Request AI clarification if handler provided
     if (onRequestClarification) {
       setAiLoading(true);
       try {
         const reply = await onRequestClarification(annotation);
         if (reply) setAiReply(reply);
-      } catch {
-        // AI clarification is optional, don't block
-      } finally {
+      } catch { /* optional */ } finally {
         setAiLoading(false);
       }
     } else {
       setCommentPos(null);
     }
-  }, [commentText, commentPos, currentTimestamp, onRequestClarification]);
+  }, [commentText, commentPos, currentTimestamp, onRequestClarification, captureScreenshot]);
 
   const handleAiResponse = useCallback(
     (response: string) => {
-      // Update the last comment with clarification
       setAnnotations((prev) => {
         const updated = [...prev];
         const last = updated[updated.length - 1];
@@ -352,44 +348,43 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
     setCommentPos(null);
   }, []);
 
-  /* ── Resize canvas to match viewport ─────────────────────────── */
+  /* ── Resize canvas ─────────────────────────────────────────────── */
 
   useEffect(() => {
     const canvas = canvasRef.current;
     const target = targetRef.current;
     if (!canvas || !target) return;
-
     const resize = () => {
       const rect = target.getBoundingClientRect();
       canvas.width = rect.width;
       canvas.height = rect.height;
     };
-
     resize();
     const observer = new ResizeObserver(resize);
     observer.observe(target);
     return () => observer.disconnect();
   }, [targetRef]);
 
-  /* ── Cleanup ─────────────────────────────────────────────────── */
+  /* ── Cleanup ───────────────────────────────────────────────────── */
 
   useEffect(() => {
     return () => {
       if (timerRef.current) clearInterval(timerRef.current);
+      if (frameLoopRef.current) cancelAnimationFrame(frameLoopRef.current);
       if (mediaRecorderRef.current?.state !== 'inactive') {
         mediaRecorderRef.current?.stop();
+      }
+      // Remove hidden canvas
+      if (frameCaptureRef.current) {
+        frameCaptureRef.current.remove();
+        frameCaptureRef.current = null;
       }
     };
   }, []);
 
-  /* ── Format time ─────────────────────────────────────────────── */
-
-  const fmt = (s: number) =>
-    `${String(Math.floor(s / 60)).padStart(2, '0')}:${String(s % 60).padStart(2, '0')}`;
-
   const COLORS = ['#ff6b2c', '#ef4444', '#3b82f6', '#22c55e', '#eab308', '#ffffff'];
 
-  /* ── Render ──────────────────────────────────────────────────── */
+  /* ── Render ────────────────────────────────────────────────────── */
 
   return (
     <>
@@ -406,40 +401,32 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
         />
       )}
 
-      {/* Comment pins on viewport */}
-      {annotations
-        .filter((a) => a.type === 'comment')
-        .map((a) => (
-          <div
-            key={a.id}
-            className="playtest-pin"
-            style={{ left: `${(a.x ?? 0) * 100}%`, top: `${(a.y ?? 0) * 100}%` }}
-            title={a.text}
-          >
-            <span className="playtest-pin-dot" />
-            <span className="playtest-pin-time">{fmt(a.timestamp)}</span>
-          </div>
-        ))}
+      {/* Comment pins */}
+      {annotations.filter((a) => a.type === 'comment').map((a) => (
+        <div
+          key={a.id}
+          className="playtest-pin"
+          style={{ left: `${(a.x ?? 0) * 100}%`, top: `${(a.y ?? 0) * 100}%` }}
+          title={a.text}
+        >
+          <span className="playtest-pin-dot" />
+          <span className="playtest-pin-time">{fmt(a.timestamp)}</span>
+        </div>
+      ))}
 
-      {/* Comment input popover */}
+      {/* Comment popover */}
       {commentPos && (
         <div
           className="playtest-comment-popover"
-          style={{
-            left: `${commentPos.x * 100}%`,
-            top: `${commentPos.y * 100}%`,
-          }}
+          style={{ left: `${commentPos.x * 100}%`, top: `${commentPos.y * 100}%` }}
         >
           <textarea
             className="playtest-comment-input"
-            placeholder="What happened here?"
+            placeholder="What felt off?"
             value={commentText}
             onChange={(e) => setCommentText(e.target.value)}
             onKeyDown={(e) => {
-              if (e.key === 'Enter' && !e.shiftKey) {
-                e.preventDefault();
-                submitComment();
-              }
+              if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); submitComment(); }
             }}
             autoFocus
           />
@@ -462,15 +449,10 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
             </div>
           )}
           <div className="playtest-comment-actions">
-            <button className="playtest-btn-small" onClick={submitComment}>
-              Pin
-            </button>
+            <button className="playtest-btn-small" onClick={submitComment}>Pin</button>
             <button
               className="playtest-btn-small playtest-btn-muted"
-              onClick={() => {
-                setCommentPos(null);
-                setCommentText('');
-              }}
+              onClick={() => { setCommentPos(null); setCommentText(''); }}
             >
               Cancel
             </button>
@@ -478,91 +460,77 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
         </div>
       )}
 
-      {/* Toolbar — collapsible from top */}
-      <div className={`playtest-toolbar ${showToolbar ? 'playtest-toolbar-open' : ''}`}>
-        <button
-          className="playtest-toolbar-toggle"
-          onClick={() => setShowToolbar((v) => !v)}
-          aria-label="Toggle playtest toolbar"
-        >
-          {showToolbar ? '\u25B2' : '\u25BC'}
-        </button>
+      {/* ── Floating pill toolbar (bottom-right) ──────────────────── */}
+      <div className={`playtest-pill ${expanded ? 'playtest-pill-expanded' : ''}`}>
+        {/* Collapsed: just recording indicator + expand button */}
+        {!expanded && (
+          <button className="playtest-pill-toggle" onClick={() => setExpanded(true)}>
+            {isRecording && <span className="playtest-recording-indicator" />}
+            <span className="playtest-pill-label">
+              {isRecording ? fmt(recordingTime) : 'Playtest'}
+            </span>
+            {annotations.length > 0 && (
+              <span className="playtest-pill-badge">{annotations.length}</span>
+            )}
+          </button>
+        )}
 
-        {showToolbar && (
-          <div className="playtest-toolbar-inner">
-            {/* Recording controls */}
-            <div className="playtest-toolbar-group">
-              {!isRecording ? (
-                <button className="playtest-btn playtest-btn-record" onClick={startRecording}>
-                  Record
-                </button>
-              ) : (
-                <>
-                  <span className="playtest-recording-indicator" />
-                  <span className="playtest-time">{fmt(recordingTime)}</span>
-                  {isPaused ? (
-                    <button className="playtest-btn" onClick={resumeRecording}>
-                      Resume
-                    </button>
-                  ) : (
-                    <button className="playtest-btn" onClick={pauseRecording}>
-                      Pause
-                    </button>
-                  )}
-                </>
-              )}
+        {/* Expanded: full controls */}
+        {expanded && (
+          <div className="playtest-pill-controls">
+            {/* Recording status */}
+            <div className="playtest-pill-row">
+              {isRecording && <span className="playtest-recording-indicator" />}
+              <span className="playtest-pill-time">{fmt(recordingTime)}</span>
+              <span className="playtest-pill-notes">
+                {annotations.length} note{annotations.length !== 1 ? 's' : ''}
+              </span>
+              <button
+                className="playtest-pill-close"
+                onClick={() => setExpanded(false)}
+                aria-label="Collapse"
+              >
+                &#x2715;
+              </button>
             </div>
 
-            {/* Annotation tools */}
-            <div className="playtest-toolbar-group">
+            {/* Tools */}
+            <div className="playtest-pill-row">
               <button
                 className={`playtest-tool ${activeTool === 'pen' ? 'playtest-tool-active' : ''}`}
                 onClick={() => setActiveTool(activeTool === 'pen' ? 'none' : 'pen')}
                 title="Pen"
-              >
-                &#9998;
-              </button>
+              >&#9998;</button>
               <button
                 className={`playtest-tool ${activeTool === 'highlight' ? 'playtest-tool-active' : ''}`}
                 onClick={() => setActiveTool(activeTool === 'highlight' ? 'none' : 'highlight')}
                 title="Highlight"
-              >
-                &#9618;
-              </button>
+              >&#9618;</button>
               <button
                 className={`playtest-tool ${activeTool === 'comment' ? 'playtest-tool-active' : ''}`}
                 onClick={() => setActiveTool(activeTool === 'comment' ? 'none' : 'comment')}
                 title="Comment"
-              >
-                &#128172;
-              </button>
-
-              {/* Color picker */}
-              {(activeTool === 'pen' || activeTool === 'highlight') && (
-                <div className="playtest-colors">
-                  {COLORS.map((c) => (
-                    <button
-                      key={c}
-                      className={`playtest-color-swatch ${penColor === c ? 'playtest-color-active' : ''}`}
-                      style={{ background: c }}
-                      onClick={() => setPenColor(c)}
-                    />
-                  ))}
-                </div>
-              )}
+              >&#128172;</button>
             </div>
+
+            {/* Color picker (when drawing) */}
+            {(activeTool === 'pen' || activeTool === 'highlight') && (
+              <div className="playtest-pill-row">
+                {COLORS.map((c) => (
+                  <button
+                    key={c}
+                    className={`playtest-color-swatch ${penColor === c ? 'playtest-color-active' : ''}`}
+                    style={{ background: c }}
+                    onClick={() => setPenColor(c)}
+                  />
+                ))}
+              </div>
+            )}
 
             {/* Submit */}
-            <div className="playtest-toolbar-group">
-              <span className="playtest-annotation-count">
-                {annotations.length} note{annotations.length !== 1 ? 's' : ''}
-              </span>
-              {isRecording && (
-                <button className="playtest-btn playtest-btn-submit" onClick={stopAndSubmit}>
-                  Submit Session
-                </button>
-              )}
-            </div>
+            <button className="playtest-btn playtest-btn-submit" onClick={stopAndSubmit}>
+              Done
+            </button>
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

Three UX improvements that make playtesting seamless for real testers:

### 1. No more screen share dialog
Replaced `getDisplayMedia` (triggered browser permission popup) with `canvas.captureStream()` on a hidden frame-capture canvas. The game viewport is mirrored via `requestAnimationFrame`, compositing all game `<canvas>` elements. Recording starts automatically when the session loads — tester just plays.

### 2. Floating pill toolbar
Replaced the full-width top bar with a compact floating pill in the bottom-right corner:
- **Collapsed**: recording dot + time + annotation badge count
- **Expanded**: pen, highlight, comment tools + color picker + "Done" button
- Feels like a game overlay, not a QA instrument

### 3. Video replay in backstage
Session tab in `/backstage/replay` now shows:
- HTML5 video player loading `recording.webm` from R2
- Session metadata (city, scene, language, annotation/screenshot counts)
- Annotation timeline below with prev/next navigation
- Screenshot viewer with SVG drawing overlay

## Test plan
- [ ] Open playtest URL — recording should start without any permission dialog
- [ ] Floating pill visible in bottom-right (collapsed by default)
- [ ] Click pill → expands to show tools
- [ ] Draw/highlight/comment tools work
- [ ] Click "Done" → uploads to R2
- [ ] `/backstage/replay` → select session → video player loads + plays
- [ ] Timeline navigation works alongside video

🤖 Generated with [Claude Code](https://claude.com/claude-code)