### PR TITLE
fix: playtest pill not visible on mobile + auto-upload on navigate away

### DIFF
--- a/apps/client/components/playtest/PlaytestOverlay.tsx
+++ b/apps/client/components/playtest/PlaytestOverlay.tsx
@@ -365,6 +365,48 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
     return () => observer.disconnect();
   }, [targetRef]);
 
+  /* ── Auto-save on navigate away / tab close ──────────────────── */
+
+  useEffect(() => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (annotations.length > 0 || chunksRef.current.length > 0) {
+        // Try to upload what we have via sendBeacon
+        const data = JSON.stringify(annotations);
+        navigator.sendBeacon?.(
+          `${typeof window !== 'undefined' ? (window as any).__NEXT_DATA__?.runtimeConfig?.NEXT_PUBLIC_TONG_API_BASE || '' : ''}/api/v1/playtest/sessions/${sessionId}/upload`,
+          new Blob([
+            JSON.stringify({ annotations: data }),
+          ], { type: 'application/json' }),
+        );
+        e.preventDefault();
+      }
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'hidden' && annotations.length > 0) {
+        // Page going to background — save annotations via sendBeacon
+        const formData = new FormData();
+        formData.append('annotations', JSON.stringify(annotations));
+        if (chunksRef.current.length > 0) {
+          const blob = new Blob(chunksRef.current, { type: 'video/webm' });
+          formData.append('recording', blob, `${sessionId}.webm`);
+        }
+        // sendBeacon with FormData
+        navigator.sendBeacon?.(
+          `${process.env.NEXT_PUBLIC_TONG_API_BASE || 'https://tong-api.erniesg.workers.dev'}/api/v1/playtest/sessions/${sessionId}/upload`,
+          formData,
+        );
+      }
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [annotations, sessionId]);
+
   /* ── Cleanup ───────────────────────────────────────────────────── */
 
   useEffect(() => {
@@ -374,7 +416,6 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
       if (mediaRecorderRef.current?.state !== 'inactive') {
         mediaRecorderRef.current?.stop();
       }
-      // Remove hidden canvas
       if (frameCaptureRef.current) {
         frameCaptureRef.current.remove();
         frameCaptureRef.current = null;

--- a/apps/client/components/playtest/PlaytestWrapper.tsx
+++ b/apps/client/components/playtest/PlaytestWrapper.tsx
@@ -108,7 +108,7 @@ export function PlaytestWrapper({ children }: { children: React.ReactNode }) {
   if (!sessionId) return <>{children}</>;
 
   return (
-    <div ref={frameRef} style={{ position: 'relative' }}>
+    <div ref={frameRef} style={{ position: 'relative', width: '100%', minHeight: '100dvh' }}>
       {children}
       <PlaytestOverlay
         targetRef={frameRef}


### PR DESCRIPTION
## Summary

Two fixes from real mobile playtest:

### 1. Pill invisible on mobile
PlaytestWrapper div had `position: relative` but no explicit sizing, so the absolutely-positioned pill calculated its position relative to a collapsed div and rendered off-screen. Fixed with `width: 100%; minHeight: 100dvh`.

### 2. Data loss on tab close
If a tester closes the tab or navigates away, all annotations and recording chunks were lost. Added:
- `beforeunload` handler — warns user, uploads annotations via `sendBeacon`
- `visibilitychange` handler — when page goes to background, uploads FormData (annotations + recording chunks) via `sendBeacon`

### Also noted (not fixed here)
- Opening video (`tong_intro.webm`) may not autoplay on iOS Safari despite `muted` attribute — user sees Tong mascot image instead. This is a pre-existing iOS autoplay restriction, not a playtest pipeline issue.

## Test plan
- [ ] Open playtest URL on iPhone — floating pill visible in bottom-right
- [ ] Expand pill — tools accessible
- [ ] Navigate away — annotations uploaded via sendBeacon
- [ ] Close tab — beforeunload fires upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)