### PR TITLE
fix: opening video + pill visibility on mobile

### DIFF
--- a/apps/client/app/globals.css
+++ b/apps/client/app/globals.css
@@ -7618,9 +7618,9 @@ main.app-shell.app-shell--wide {
 /* ── Playtest Overlay ──────────────────────────────────────────── */
 
 .playtest-canvas {
-  position: absolute;
+  position: fixed;
   inset: 0;
-  z-index: 900;
+  z-index: 9990;
   touch-action: none;
   pointer-events: auto;
 }
@@ -7628,10 +7628,10 @@ main.app-shell.app-shell--wide {
 /* ── Floating pill toolbar ──────────────────────────────────────── */
 
 .playtest-pill {
-  position: absolute;
-  bottom: 20px;
-  right: 20px;
-  z-index: 950;
+  position: fixed;
+  bottom: 24px;
+  right: 16px;
+  z-index: 9999;
   pointer-events: auto;
 }
 
@@ -7838,8 +7838,8 @@ main.app-shell.app-shell--wide {
 /* ── Comment pins ──────────────────────────────────────────────── */
 
 .playtest-pin {
-  position: absolute;
-  z-index: 910;
+  position: fixed;
+  z-index: 9991;
   transform: translate(-50%, -100%);
   display: flex;
   flex-direction: column;
@@ -7868,8 +7868,8 @@ main.app-shell.app-shell--wide {
 /* ── Comment popover ───────────────────────────────────────────── */
 
 .playtest-comment-popover {
-  position: absolute;
-  z-index: 960;
+  position: fixed;
+  z-index: 9995;
   transform: translate(-50%, 8px);
   background: rgba(15, 15, 15, 0.92);
   backdrop-filter: blur(12px);

--- a/assets/manifest/canonical-asset-manifest.json
+++ b/assets/manifest/canonical-asset-manifest.json
@@ -42,7 +42,7 @@
       "rights": "internal-demo",
       "promptTemplate": null,
       "status": "ready",
-      "uri": "/assets/tong_intro.webm"
+      "uri": "/assets/app/tong_opening.mp4"
     },
     {
       "key": "city.seoul.location.food-street.backdrop.default",

--- a/assets/manifest/runtime-asset-manifest.json
+++ b/assets/manifest/runtime-asset-manifest.json
@@ -27,7 +27,7 @@
       "usage": "intro-cinematic",
       "source": "repo",
       "status": "ready",
-      "uri": "/assets/tong_intro.webm"
+      "uri": "/assets/app/tong_opening.mp4"
     },
     {
       "key": "city.seoul.location.food-street.backdrop.default",


### PR DESCRIPTION
Fixes from real mobile playtest. Opening video now uses tong_opening.mp4. All playtest overlay elements use position:fixed to work across game phase re-renders.