### PR TITLE
fix: playtest overlay — 5 bugs from iOS mobile testing

### DIFF
--- a/apps/client/app/globals.css
+++ b/apps/client/app/globals.css
@@ -1842,12 +1842,7 @@ main.app-shell.app-shell--wide {
   animation: tongFadeIn 1s ease 0.2s forwards;
 }
 
-/* Mobile: mp4 fallback has baked bg — use cover so no CSS bg peeks through */
-@media (max-width: 768px) {
-  .tg-tong-intro-video {
-    object-fit: cover;
-  }
-}
+/* Transparent video: contain preserves alpha — no cover needed */
 
 .tg-tong-intro-canvas {
   position: absolute;
@@ -7842,41 +7837,50 @@ main.app-shell.app-shell--wide {
   z-index: 9991;
   transform: translate(-50%, -100%);
   display: flex;
-  flex-direction: column;
   align-items: center;
-  pointer-events: none;
+  gap: 6px;
+  pointer-events: auto;
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 .playtest-pin-dot {
   width: 12px;
   height: 12px;
-  background: var(--accent);
+  min-width: 12px;
+  background: var(--orange, #ff6b2c);
   border: 2px solid #fff;
   border-radius: 50%;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
 }
 
-.playtest-pin-time {
-  font-size: 10px;
+.playtest-pin-label {
+  font-size: 11px;
   color: #fff;
-  background: rgba(0, 0, 0, 0.6);
-  padding: 1px 4px;
-  border-radius: 3px;
-  margin-top: 2px;
+  background: rgba(0, 0, 0, 0.75);
+  backdrop-filter: blur(6px);
+  padding: 3px 8px;
+  border-radius: 6px;
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
 }
 
 /* ── Comment popover ───────────────────────────────────────────── */
 
-.playtest-comment-popover {
+.playtest-comment-bar {
   position: fixed;
-  z-index: 9995;
-  transform: translate(-50%, 8px);
+  bottom: 80px;
+  left: 12px;
+  right: 12px;
+  z-index: 10000;
   background: rgba(15, 15, 15, 0.92);
   backdrop-filter: blur(12px);
   border: 1px solid rgba(255, 255, 255, 0.12);
-  border-radius: 10px;
+  border-radius: 12px;
   padding: 10px;
-  width: 260px;
   box-shadow: 0 8px 30px rgba(0, 0, 0, 0.4);
 }
 

--- a/apps/client/components/playtest/PlaytestOverlay.tsx
+++ b/apps/client/components/playtest/PlaytestOverlay.tsx
@@ -54,6 +54,7 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
   const [expanded, setExpanded] = useState(false);
   const [aiReply, setAiReply] = useState<string | null>(null);
   const [aiLoading, setAiLoading] = useState(false);
+  const draggingPin = useRef<{ id: string; startX: number; startY: number; origX: number; origY: number } | null>(null);
 
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const isDrawing = useRef(false);
@@ -236,16 +237,6 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
 
   const handlePointerDown = useCallback(
     (e: React.PointerEvent) => {
-      if (activeTool === 'comment') {
-        const canvas = canvasRef.current;
-        if (!canvas) return;
-        const rect = canvas.getBoundingClientRect();
-        setCommentPos({
-          x: (e.clientX - rect.left) / rect.width,
-          y: (e.clientY - rect.top) / rect.height,
-        });
-        return;
-      }
       if (activeTool !== 'pen' && activeTool !== 'highlight') return;
       isDrawing.current = true;
       const [x, y] = getCanvasPos(e);
@@ -348,22 +339,54 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
     setCommentPos(null);
   }, []);
 
+  /* ── Draggable pins ────────────────────────────────────────────── */
+
+  const handlePinDragStart = useCallback((id: string, clientX: number, clientY: number) => {
+    const ann = annotations.find((a) => a.id === id);
+    if (!ann) return;
+    draggingPin.current = { id, startX: clientX, startY: clientY, origX: ann.x ?? 0.5, origY: ann.y ?? 0.5 };
+  }, [annotations]);
+
+  const handlePinDragMove = useCallback((clientX: number, clientY: number) => {
+    const d = draggingPin.current;
+    if (!d) return;
+    const dx = (clientX - d.startX) / window.innerWidth;
+    const dy = (clientY - d.startY) / window.innerHeight;
+    const newX = Math.max(0, Math.min(1, d.origX + dx));
+    const newY = Math.max(0, Math.min(1, d.origY + dy));
+    setAnnotations((prev) =>
+      prev.map((a) => a.id === d.id ? { ...a, x: newX, y: newY } : a),
+    );
+  }, []);
+
+  const handlePinDragEnd = useCallback(() => {
+    draggingPin.current = null;
+  }, []);
+
+  useEffect(() => {
+    const onMove = (e: PointerEvent) => handlePinDragMove(e.clientX, e.clientY);
+    const onUp = () => handlePinDragEnd();
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onUp);
+    return () => {
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+    };
+  }, [handlePinDragMove, handlePinDragEnd]);
+
   /* ── Resize canvas ─────────────────────────────────────────────── */
 
   useEffect(() => {
     const canvas = canvasRef.current;
-    const target = targetRef.current;
-    if (!canvas || !target) return;
+    if (!canvas) return;
     const resize = () => {
-      const rect = target.getBoundingClientRect();
-      canvas.width = rect.width;
-      canvas.height = rect.height;
+      canvas.width = window.innerWidth;
+      canvas.height = window.innerHeight;
     };
     resize();
-    const observer = new ResizeObserver(resize);
-    observer.observe(target);
-    return () => observer.disconnect();
-  }, [targetRef]);
+    window.addEventListener('resize', resize);
+    return () => window.removeEventListener('resize', resize);
+  }, [activeTool]);
 
   /* ── Auto-save on navigate away / tab close ──────────────────── */
 
@@ -430,7 +453,7 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
   return (
     <>
       {/* Drawing canvas overlay — always mounted when a tool is active */}
-      {activeTool !== 'none' && (
+      {(activeTool === 'pen' || activeTool === 'highlight') && (
         <canvas
           ref={canvasRef}
           className="playtest-canvas"
@@ -439,7 +462,7 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
           onPointerUp={handlePointerUp}
           onPointerLeave={handlePointerUp}
           onTouchStart={(e) => {
-            e.preventDefault(); // Prevent scroll + ensure canvas gets touch
+            e.preventDefault();
             const touch = e.touches[0];
             if (touch) handlePointerDown({ clientX: touch.clientX, clientY: touch.clientY } as any);
           }}
@@ -452,35 +475,38 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
             e.preventDefault();
             handlePointerUp();
           }}
-          style={{ cursor: activeTool === 'comment' ? 'crosshair' : 'default', touchAction: 'none' }}
+          style={{ touchAction: 'none' }}
         />
       )}
 
-      {/* Comment pins */}
+      {/* Draggable comment pins */}
       {annotations.filter((a) => a.type === 'comment').map((a) => (
         <div
           key={a.id}
           className="playtest-pin"
-          style={{ left: `${(a.x ?? 0) * 100}vw`, top: `${(a.y ?? 0) * 100}vh` }}
+          style={{
+            left: `${(a.x ?? 0.5) * 100}vw`,
+            top: `${(a.y ?? 0.5) * 100}vh`,
+            cursor: 'grab',
+            touchAction: 'none',
+          }}
           title={a.text}
+          onPointerDown={(e) => {
+            e.preventDefault();
+            handlePinDragStart(a.id, e.clientX, e.clientY);
+          }}
         >
           <span className="playtest-pin-dot" />
-          <span className="playtest-pin-time">{fmt(a.timestamp)}</span>
+          <span className="playtest-pin-label">{a.text}</span>
         </div>
       ))}
 
-      {/* Comment popover — positioned in viewport coords */}
+      {/* Comment input bar — anchored to bottom of screen */}
       {commentPos && (
-        <div
-          className="playtest-comment-popover"
-          style={{
-            left: `${Math.min(commentPos.x * 100, 70)}vw`,
-            top: `${Math.min(commentPos.y * 100, 60)}vh`,
-          }}
-        >
+        <div className="playtest-comment-bar">
           <textarea
             className="playtest-comment-input"
-            placeholder="What felt off?"
+            placeholder="What felt off? Type your note..."
             value={commentText}
             onChange={(e) => setCommentText(e.target.value)}
             onKeyDown={(e) => {
@@ -565,8 +591,16 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
                 title="Highlight"
               >&#9618;</button>
               <button
-                className={`playtest-tool ${activeTool === 'comment' ? 'playtest-tool-active' : ''}`}
-                onClick={() => setActiveTool(activeTool === 'comment' ? 'none' : 'comment')}
+                className={`playtest-tool ${commentPos ? 'playtest-tool-active' : ''}`}
+                onClick={() => {
+                  setActiveTool('none');
+                  if (commentPos) {
+                    setCommentPos(null);
+                    setCommentText('');
+                  } else {
+                    setCommentPos({ x: 0.5, y: 0.5 });
+                  }
+                }}
                 title="Comment"
               >&#128172;</button>
             </div>


### PR DESCRIPTION
## Summary

Fixes 5 bugs reported from iOS mobile playtest at `tong.berlayar.ai/playtest/crBKkNiZy2tZ`:

- **Video not transparent**: Deployed HEVC MOV (1.3MB) had no alpha channel. Replaced with correct `tong_hevc_alpha_final.mov` (3.8MB). Both WebM + HEVC now show 62.3% transparent pixels.
- **Video too big on mobile**: Removed `object-fit: cover` CSS media query override. Now `contain` everywhere.
- **Drawing canvas inhibited**: Canvas pixel dimensions now use `window.innerWidth/Height` instead of wrapper div. `useEffect` depends on `activeTool` so it fires when canvas mounts.
- **Comment box broken**: Tapping comment icon immediately shows a bottom-anchored input bar (`z-index: 10000`). No more tap-to-place-then-type.
- **Comment pins not draggable**: Pins now have pointer drag handlers, show label text with `cursor: grab`.

> **Note**: The HEVC MOV is a runtime asset (gitignored). Needs `npm run runtime-assets:upload` before deploy.

## QA Evidence

Validated via Playwright headless Chromium (390x844 mobile viewport, 2x DPR):

| Issue | Verdict | Evidence |
|-------|---------|----------|
| Video transparency | PASS | Frame extraction: `yuva420p`, 62.3% transparent |
| Video sizing | PASS | `objectFit: contain` confirmed |
| Canvas coverage | PASS | Canvas 390x844 = viewport 390x844 |
| Comment input | PASS | Bar appeared immediately, textarea visible |
| Draggable pins | PASS | Pin moved from (195px,422px) → (275px,362px) |

Full QA bundle: `artifacts/qa-runs/functional-qa/playtest-overlay-5-bug-fix.../20260402T180651Z/`

## Test plan

- [ ] Verify transparent Tong video on iOS Safari (HEVC alpha)
- [ ] Verify transparent Tong video on Chrome (WebM alpha)
- [ ] Test drawing with pen/highlight tools covers full mobile viewport
- [ ] Test comment icon → immediate text input → pin placement
- [ ] Test dragging pinned comments on mobile touch
- [ ] Run `npm run runtime-assets:upload` to deploy HEVC MOV

🤖 Generated with [Claude Code](https://claude.com/claude-code)