### PR TITLE
fix: add opt-in YouTube watch telemetry ingest endpoint and contract (erniesg/tong#103)

### DIFF
--- a/apps/server/src/index.mjs
+++ b/apps/server/src/index.mjs
@@ -2,7 +2,12 @@ import fs from 'node:fs';
 import http from 'node:http';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { loadGeneratedSnapshot, runMockIngestion, writeGeneratedSnapshots } from './ingestion.mjs';
+import {
+  convertYoutubeWatchTelemetryToEvents,
+  loadGeneratedSnapshot,
+  runMockIngestion,
+  writeGeneratedSnapshots,
+} from './ingestion.mjs';
 import {
   generateImage,
   generateBackdrop,
@@ -2060,6 +2065,30 @@ function runIngestionForUser(userId = DEFAULT_USER_ID, options = {}) {
     writeGeneratedSnapshots(result);
   }
 
+  state.ingestionByUser.set(userId, result);
+  saveDurableState();
+  return result;
+}
+
+function runIngestionForUserWithEvents(userId = DEFAULT_USER_ID, events = []) {
+  const sourceItems = events.map((event, idx) => ({
+    id: event.mediaId || event.eventId || `youtube_${idx + 1}`,
+    source: event.source === 'spotify' ? 'spotify' : 'youtube',
+    title: event.title || event.mediaId || `media_${idx + 1}`,
+    lang: event.lang || 'ko',
+    minutes: Number(event.minutes || 0),
+    text: event.text || event.title || '',
+    mediaId: event.mediaId || `youtube_${idx + 1}`,
+    playedAtIso: event.consumedAtIso || new Date().toISOString(),
+    tokens: Array.isArray(event.tokens) ? event.tokens : [],
+    eventId: event.eventId || `evt_${idx + 1}`,
+  }));
+  const snapshot = {
+    windowStartIso: sourceItems[0]?.playedAtIso || new Date().toISOString(),
+    windowEndIso: sourceItems[sourceItems.length - 1]?.playedAtIso || new Date().toISOString(),
+    sourceItems,
+  };
+  const result = runMockIngestion(snapshot, { userId });
   state.ingestionByUser.set(userId, result);
   saveDurableState();
   return result;
@@ -4819,6 +4848,35 @@ const server = http.createServer(async (req, res) => {
       const includeSources = normalizeIngestionSources(body.includeSources);
       const result = runIngestionForUser(userId, { includeSources });
       jsonResponse(res, 200, formatIngestionRunResponse(result));
+      return;
+    }
+
+    if (pathname === '/api/v1/telemetry/youtube/watch' && req.method === 'POST') {
+      const body = await readJsonBody(req);
+      const conversion = convertYoutubeWatchTelemetryToEvents(body);
+      const userId = conversion.userId || body.userId || getUserIdFromQuery(url.searchParams);
+      if (conversion.acceptedEvents.length === 0) {
+        jsonResponse(res, 202, {
+          ok: true,
+          userId,
+          acceptedEvents: [],
+          droppedSessions: conversion.droppedSessions,
+          summary: conversion.summary,
+          ingestion: null,
+          reason: 'no-consented-active-watch-events',
+        });
+        return;
+      }
+
+      const ingestion = runIngestionForUserWithEvents(userId, conversion.acceptedEvents);
+      jsonResponse(res, 200, {
+        ok: true,
+        userId,
+        acceptedEvents: conversion.acceptedEvents,
+        droppedSessions: conversion.droppedSessions,
+        summary: conversion.summary,
+        ingestion: formatIngestionRunResponse(ingestion),
+      });
       return;
     }
 

--- a/apps/server/src/ingestion.mjs
+++ b/apps/server/src/ingestion.mjs
@@ -220,6 +220,56 @@ function parseIso(input, fallbackIso) {
   return value;
 }
 
+function clamp01(value) {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(1, value));
+}
+
+function parseSeconds(value, fallback = 0) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.max(0, parsed);
+}
+
+function mergeSegmentRanges(segments = []) {
+  const ranges = segments
+    .map((segment) => {
+      const start = parseSeconds(segment?.startOffsetSec, 0);
+      const end = parseSeconds(segment?.endOffsetSec, start);
+      return end > start ? { start, end } : null;
+    })
+    .filter(Boolean)
+    .sort((a, b) => a.start - b.start || a.end - b.end);
+
+  const merged = [];
+  for (const range of ranges) {
+    const last = merged[merged.length - 1];
+    if (!last || range.start > last.end) {
+      merged.push({ ...range });
+      continue;
+    }
+    last.end = Math.max(last.end, range.end);
+  }
+  return merged;
+}
+
+function extractYouTubeVideoId(videoId, videoUrl) {
+  const rawVideoId = String(videoId || '').trim();
+  if (rawVideoId) return rawVideoId;
+  const rawUrl = String(videoUrl || '').trim();
+  if (!rawUrl) return '';
+  try {
+    const parsed = new URL(rawUrl);
+    if (parsed.searchParams.get('v')) {
+      return parsed.searchParams.get('v') || '';
+    }
+    const shortMatch = parsed.pathname.match(/^\/([A-Za-z0-9_-]{6,})$/);
+    return shortMatch?.[1] || rawUrl;
+  } catch {
+    return rawUrl;
+  }
+}
+
 function detectLang(term) {
   if (HANGUL_REGEX.test(term)) return 'ko';
   if (KANA_REGEX.test(term)) return 'ja';
@@ -414,6 +464,95 @@ export function buildMediaEventsFromSnapshot(snapshot, userId = 'demo-user-1') {
       text: item.text || '',
     };
   });
+}
+
+export function convertYoutubeWatchTelemetryToEvents(payload = {}) {
+  const telemetry = payload && typeof payload === 'object' ? payload : {};
+  const userId = String(telemetry.userId || 'demo-user-1').trim() || 'demo-user-1';
+  const consent = telemetry.optIn && typeof telemetry.optIn === 'object' ? telemetry.optIn : {};
+  const hasConsent = Boolean(consent.enabled && consent.grantedAtIso);
+  const consentVersion = String(consent.consentVersion || '').trim() || 'v1';
+  const retentionDays = Math.max(1, Number(consent.retentionDays || 30) || 30);
+  const syncToServer = consent.syncToServer !== false;
+  const sessions = Array.isArray(telemetry.sessions) ? telemetry.sessions : [];
+  const acceptedEvents = [];
+  const droppedSessions = [];
+
+  if (!hasConsent || !syncToServer) {
+    return {
+      userId,
+      acceptedEvents,
+      droppedSessions: sessions.map((session) => ({
+        sessionId: session?.sessionId || '',
+        reason: hasConsent ? 'sync-disabled' : 'missing-opt-in',
+      })),
+      summary: {
+        acceptedSessions: 0,
+        droppedSessions: sessions.length,
+        totalMinutes: 0,
+      },
+    };
+  }
+
+  for (const [idx, session] of sessions.entries()) {
+    const playbackSegments = Array.isArray(session?.activePlaybackSegments) ? session.activePlaybackSegments : [];
+    const mergedSegments = mergeSegmentRanges(playbackSegments);
+    const activeSeconds = mergedSegments.reduce((sum, segment) => sum + (segment.end - segment.start), 0);
+    const activeMinutes = Number((activeSeconds / 60).toFixed(2));
+    const videoDurationSeconds = parseSeconds(session?.videoDurationSeconds, 0);
+    const completionRatio = clamp01(videoDurationSeconds > 0 ? activeSeconds / videoDurationSeconds : Number(session?.completionRatio || 0));
+    const mediaId = extractYouTubeVideoId(session?.videoId, session?.videoUrl);
+
+    if (!mediaId || activeMinutes <= 0) {
+      droppedSessions.push({
+        sessionId: session?.sessionId || `session_${idx + 1}`,
+        reason: !mediaId ? 'missing-video-id' : 'no-active-playback',
+      });
+      continue;
+    }
+
+    const consumedAtIso = session?.sessionEndIso || session?.lastEventAtIso || session?.sessionStartIso || consent.grantedAtIso;
+    const title = String(session?.title || mediaId).trim() || mediaId;
+    const subtitleTrack = String(session?.subtitleTrack || '').trim() || null;
+    const sourceLang = session?.sourceLang || 'ko';
+    const text = subtitleTrack ? `${title} ${subtitleTrack}` : title;
+    const tokens = extractTokens(text);
+    acceptedEvents.push({
+      eventId: session?.sessionId || `yt_watch_${idx + 1}`,
+      userId,
+      source: 'youtube',
+      mediaId,
+      title,
+      lang: sourceLang,
+      minutes: activeMinutes,
+      consumedAtIso,
+      tokens,
+      text,
+      telemetry: {
+        optInGrantedAtIso: consent.grantedAtIso,
+        consentVersion,
+        retentionDays,
+        syncToServer,
+        videoUrl: session?.videoUrl || null,
+        sessionStartIso: session?.sessionStartIso || null,
+        sessionEndIso: session?.sessionEndIso || null,
+        activePlaybackSeconds: Number(activeSeconds.toFixed(3)),
+        completionRatio: Number(completionRatio.toFixed(4)),
+        subtitleTrack,
+      },
+    });
+  }
+
+  return {
+    userId,
+    acceptedEvents,
+    droppedSessions,
+    summary: {
+      acceptedSessions: acceptedEvents.length,
+      droppedSessions: droppedSessions.length,
+      totalMinutes: Number(acceptedEvents.reduce((sum, event) => sum + Number(event.minutes || 0), 0).toFixed(2)),
+    },
+  };
 }
 
 export function runMockIngestion(snapshot, options = {}) {

--- a/docs/handoff-notes.md
+++ b/docs/handoff-notes.md
@@ -276,3 +276,11 @@ Template:
   - Reuse the existing scripted messaging renderer from #124 for a new deterministic 9:16 mock capture route.
   - Extend `ScriptedMessagingPlayer` controls/additive API (no second renderer) so mock-ui can drive play/pause/restart/jump deterministically.
   - Keep global style churn minimal and document route/query fixtures in demo run-of-show.
+
+## 2026-04-17 (Issue 103 opt-in YouTube telemetry intent)
+- Date: 2026-04-17
+- Branch/worktree: `work` (server-ingestion lane crossing into shared `packages/contracts/**` and `apps/server/src/index.mjs`)
+- Intent:
+  - Add contracts/fixtures and ingestion normalization for explicit opt-in YouTube watch telemetry sessions.
+  - Add an API ingestion path that accepts consented telemetry payloads, prevents active-playback double counting, and feeds the existing ingestion pipeline.
+  - Keep scope limited to `erniesg/tong#103` evidence and verification flow.

--- a/packages/contracts/api-contract.md
+++ b/packages/contracts/api-contract.md
@@ -259,6 +259,67 @@ Shape:
 Related modeling fixture:
 - `packages/contracts/fixtures/planner.lesson-context.sample.json` captures generated lesson/scene recommendation inputs derived from canonical media events for ingestion experiments.
 
+## YouTube Watch Telemetry Fixture (Opt-in Extension Feed)
+Path:
+`packages/contracts/fixtures/youtube.watch-telemetry.sample.json`
+
+Notes:
+- Represents an explicit user opt-in plus session-level watch telemetry.
+- `activePlaybackSegments` are merged by the server so overlapping ranges are not double-counted.
+- Downstream ingestion receives canonical media events with `minutes`, `completionRatio`, subtitle language hints, and consent metadata.
+
+## POST `/api/v1/telemetry/youtube/watch`
+Request (shape excerpt):
+```json
+{
+  "userId": "demo-user-1",
+  "optIn": {
+    "enabled": true,
+    "grantedAtIso": "2026-04-16T09:00:00.000Z",
+    "consentVersion": "youtube-watch-v1",
+    "retentionDays": 30,
+    "syncToServer": true
+  },
+  "sessions": [
+    {
+      "sessionId": "yt_watch_1001",
+      "videoId": "abc123xyz",
+      "videoUrl": "https://www.youtube.com/watch?v=abc123xyz",
+      "sourceLang": "ko",
+      "subtitleTrack": "ko",
+      "sessionStartIso": "2026-04-16T09:10:00.000Z",
+      "sessionEndIso": "2026-04-16T09:42:00.000Z",
+      "videoDurationSeconds": 1800,
+      "activePlaybackSegments": [
+        { "startOffsetSec": 0, "endOffsetSec": 240, "reason": "playing" },
+        { "startOffsetSec": 300, "endOffsetSec": 920, "reason": "playing" }
+      ]
+    }
+  ]
+}
+```
+
+Response:
+```json
+{
+  "ok": true,
+  "userId": "demo-user-1",
+  "acceptedEvents": [],
+  "droppedSessions": [],
+  "summary": {
+    "acceptedSessions": 1,
+    "droppedSessions": 0,
+    "totalMinutes": 17.67
+  },
+  "ingestion": {
+    "success": true,
+    "generatedAtIso": "2026-04-17T00:00:00.000Z",
+    "sourceCount": { "youtube": 1, "spotify": 0 },
+    "topTerms": []
+  }
+}
+```
+
 ## GET `/api/v1/tools`
 Response:
 ```json

--- a/packages/contracts/fixtures/youtube.watch-telemetry.sample.json
+++ b/packages/contracts/fixtures/youtube.watch-telemetry.sample.json
@@ -1,0 +1,42 @@
+{
+  "userId": "demo-user-1",
+  "optIn": {
+    "enabled": true,
+    "grantedAtIso": "2026-04-16T09:00:00.000Z",
+    "consentVersion": "youtube-watch-v1",
+    "retentionDays": 30,
+    "syncToServer": true
+  },
+  "sessions": [
+    {
+      "sessionId": "yt_watch_1001",
+      "videoId": "abc123xyz",
+      "videoUrl": "https://www.youtube.com/watch?v=abc123xyz",
+      "title": "K-variety snack challenge",
+      "sourceLang": "ko",
+      "subtitleTrack": "ko",
+      "sessionStartIso": "2026-04-16T09:10:00.000Z",
+      "sessionEndIso": "2026-04-16T09:42:00.000Z",
+      "videoDurationSeconds": 1800,
+      "activePlaybackSegments": [
+        { "startOffsetSec": 0, "endOffsetSec": 240, "reason": "playing" },
+        { "startOffsetSec": 300, "endOffsetSec": 920, "reason": "playing" },
+        { "startOffsetSec": 880, "endOffsetSec": 1200, "reason": "foreground" }
+      ]
+    },
+    {
+      "sessionId": "yt_watch_1002",
+      "videoId": "jpn777tokyo",
+      "videoUrl": "https://youtu.be/jpn777tokyo",
+      "title": "Tokyo street interview",
+      "sourceLang": "ja",
+      "subtitleTrack": "ja",
+      "sessionStartIso": "2026-04-16T18:00:00.000Z",
+      "sessionEndIso": "2026-04-16T18:22:00.000Z",
+      "videoDurationSeconds": 1560,
+      "activePlaybackSegments": [
+        { "startOffsetSec": 60, "endOffsetSec": 610, "reason": "playing" }
+      ]
+    }
+  ]
+}

--- a/packages/contracts/types.ts
+++ b/packages/contracts/types.ts
@@ -523,6 +523,69 @@ export interface MediaIngestionEvent {
   consumedAtIso: string;
   tokens: string[];
   text?: string;
+  telemetry?: {
+    optInGrantedAtIso?: string;
+    consentVersion?: string;
+    retentionDays?: number;
+    syncToServer?: boolean;
+    videoUrl?: string | null;
+    sessionStartIso?: string | null;
+    sessionEndIso?: string | null;
+    activePlaybackSeconds?: number;
+    completionRatio?: number;
+    subtitleTrack?: string | null;
+  };
+}
+
+export interface YouTubeWatchTelemetryOptIn {
+  enabled: boolean;
+  grantedAtIso: string;
+  consentVersion: string;
+  retentionDays: number;
+  syncToServer: boolean;
+}
+
+export interface YouTubeWatchTelemetrySegment {
+  startOffsetSec: number;
+  endOffsetSec: number;
+  reason?: 'playing' | 'seeking' | 'foreground' | 'manual';
+}
+
+export interface YouTubeWatchTelemetrySession {
+  sessionId: string;
+  videoId?: string;
+  videoUrl?: string;
+  title?: string;
+  sourceLang?: TargetLanguage;
+  subtitleTrack?: string;
+  sessionStartIso: string;
+  sessionEndIso: string;
+  videoDurationSeconds?: number;
+  completionRatio?: number;
+  activePlaybackSegments: YouTubeWatchTelemetrySegment[];
+}
+
+export interface YouTubeWatchTelemetryIngestRequest {
+  userId: string;
+  optIn: YouTubeWatchTelemetryOptIn;
+  sessions: YouTubeWatchTelemetrySession[];
+}
+
+export interface YouTubeWatchTelemetryIngestResponse {
+  ok: boolean;
+  userId: string;
+  acceptedEvents: MediaIngestionEvent[];
+  droppedSessions: Array<{
+    sessionId: string;
+    reason: string;
+  }>;
+  summary: {
+    acceptedSessions: number;
+    droppedSessions: number;
+    totalMinutes: number;
+  };
+  ingestion: IngestionRunResponse | null;
+  reason?: string;
 }
 
 export interface IngestionSnapshot {

--- a/scripts/demo_smoke_check.mjs
+++ b/scripts/demo_smoke_check.mjs
@@ -94,6 +94,7 @@ const requiredFiles = [
   "packages/contracts/fixtures/scene.food-hangout.sample.json",
   "packages/contracts/fixtures/scene.shanghai-texting-reward.sample.json",
   "packages/contracts/fixtures/media.events.sample.json",
+  "packages/contracts/fixtures/youtube.watch-telemetry.sample.json",
   "packages/contracts/fixtures/tools.list.sample.json",
   "packages/contracts/fixtures/tools.invoke.sample.json",
   "packages/contracts/fixtures/demo.secret-status.sample.json",


### PR DESCRIPTION
### Motivation
- The extension could observe playback state but there was no repo-visible API/contract to accept explicit user opt-in YouTube watch telemetry, blocking downstream personalization/frequency ingestion.

### Description
- Add telemetry contract types and a sample fixture at `packages/contracts/types.ts` and `packages/contracts/fixtures/youtube.watch-telemetry.sample.json`, and document the new fixture/endpoint in `packages/contracts/api-contract.md`.
- Implement `convertYoutubeWatchTelemetryToEvents` in `apps/server/src/ingestion.mjs` to gate on consent, merge overlapping `activePlaybackSegments` (prevent double-counting), compute `minutes` and `completionRatio`, and emit canonical `MediaIngestionEvent`s with telemetry metadata.
- Add `POST /api/v1/telemetry/youtube/watch` in `apps/server/src/index.mjs` that converts accepted sessions into ingestion snapshots, calls the existing ingestion runner, and returns `acceptedEvents`, `droppedSessions`, `summary`, and `ingestion` result.
- Update demo smoke required fixtures and handoff notes; QA evidence (network trace and contract assertions) was published: https://github.com/erniesg/tong/issues/103#issuecomment-4269994564. Fixes erniesg/tong#103.

### Testing
- Syntax and smoke checks: `node --check apps/server/src/index.mjs && node --check apps/server/src/ingestion.mjs && node --check scripts/demo_smoke_check.mjs` executed successfully, while `npm run demo:smoke` still fails due to an unrelated missing runtime asset (`/assets/app/tong_opening.mp4`).
- API flow tests: ran `npm run test:api-flow` against the local server and the mock API flow passed (endpoints exercised successfully).
- Verify-fix assertions: started the server and posted the fixture with `curl -X POST http://127.0.0.1:8787/api/v1/telemetry/youtube/watch -H 'content-type: application/json' --data-binary @packages/contracts/fixtures/youtube.watch-telemetry.sample.json` and validated that the response returned `200`, `ok: true`, `summary.acceptedSessions >= 2`, the first accepted event `minutes === 19` (overlap merge proof), and `ingestion.success === true` (all contract assertions passed).
- How to test locally: 1) `node apps/server/src/index.mjs`; 2) `curl -sS -X POST http://127.0.0.1:8787/api/v1/telemetry/youtube/watch -H 'content-type: application/json' --data-binary @packages/contracts/fixtures/youtube.watch-telemetry.sample.json`; 3) verify `acceptedEvents`, `summary.acceptedSessions > 0`, and `ingestion.success: true` in the JSON response.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e26a78d40c832a9ed1190c962dc4db)