### PR TITLE
chore(ci): dedupe playtest autofix dispatches

### DIFF
--- a/.github/workflows/playtest-autofix.yml
+++ b/.github/workflows/playtest-autofix.yml
@@ -1,4 +1,5 @@
 name: Playtest Autofix
+run-name: "Playtest Autofix / ${{ inputs.issue_ref }} / ${{ inputs.session_id }}"
 
 on:
   workflow_dispatch:
@@ -30,6 +31,10 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+
+concurrency:
+  group: playtest-autofix-${{ github.event.inputs.issue_ref || github.ref_name }}-${{ github.event.inputs.branch || github.ref_name }}
+  cancel-in-progress: true
 
 jobs:
   autofix:


### PR DESCRIPTION
## What changed
- add a clearer \ to \ so GitHub notifications identify the issue and session directly
- add workflow \ keyed by issue and target branch so overlapping redispatches cancel older in-progress runs instead of piling up

## Why
During autofix hardening, repeated dispatches on the same issue/branch can generate noisy run history and redundant notifications. This keeps the latest run authoritative without changing autofix behavior.

## Validation
- parsed \ with Ruby YAML locally
