### PR TITLE
fix: issue #216 - Playtest feedback loop: structured clarifier and session→issue promotion

### DIFF
--- a/apps/client/app/api/ai/playtest-clarify/route.ts
+++ b/apps/client/app/api/ai/playtest-clarify/route.ts
@@ -1,4 +1,4 @@
-import { streamText } from 'ai';
+import { generateObject } from 'ai';
 import { openai } from '@ai-sdk/openai';
 import { z } from 'zod';
 
@@ -12,8 +12,10 @@ export const maxDuration = 30;
  * checks if the comment is clear enough to action, and if not, asks a
  * targeted follow-up question.
  *
- * Input: { comment, sceneContext, timestamp }
- * Output: streamed text — either a clarifying question or "CLEAR" if no follow-up needed.
+ * Input: context-rich annotation payload.
+ * Output: structured JSON:
+ *  - { status: 'CLEAR' }
+ *  - { status: 'FOLLOW_UP', question, options, allowOther: true }
  */
 
 const SYSTEM_PROMPT = `You are a playtest facilitator for a language learning game called Tong.
@@ -38,34 +40,98 @@ Examples of clear comments that DON'T need follow-up:
 - "I expected tapping the character to show a translation tooltip" → CLEAR
 - "this exercise should have audio" → CLEAR`;
 
+const requestSchema = z.object({
+  comment: z.string().min(1),
+  sessionId: z.string().optional(),
+  timestamp: z.number().optional(),
+  sceneContext: z.string().optional(),
+  sessionMetadata: z.record(z.unknown()).optional(),
+  screenshotContext: z.object({
+    hasScreenshot: z.boolean().optional(),
+    screenshotUrl: z.string().optional(),
+    x: z.number().optional(),
+    y: z.number().optional(),
+  }).optional(),
+  stateLogExcerpt: z.array(z.record(z.unknown())).optional(),
+});
+
+const responseSchema = z.union([
+  z.object({
+    status: z.literal('CLEAR'),
+    rationale: z.string().optional(),
+  }),
+  z.object({
+    status: z.literal('FOLLOW_UP'),
+    question: z.string().min(4).max(180),
+    options: z.array(z.string().min(1).max(80)).min(2).max(3),
+    allowOther: z.literal(true),
+    rationale: z.string().optional(),
+  }),
+]);
+
 export async function POST(req: Request) {
   const body = await req.json();
-  const { comment, sceneContext, timestamp, sessionId } = body;
+  const parsed = requestSchema.safeParse(body);
 
-  if (!comment) {
+  if (!parsed.success) {
     return new Response(JSON.stringify({ error: 'comment is required' }), {
       status: 400,
       headers: { 'Content-Type': 'application/json' },
     });
   }
 
+  const {
+    comment,
+    sceneContext,
+    timestamp,
+    sessionId,
+    sessionMetadata,
+    screenshotContext,
+    stateLogExcerpt,
+  } = parsed.data;
+
   const userMessage = [
     `Session: ${sessionId || 'unknown'}`,
     `Timestamp: ${timestamp || 'unknown'}`,
     sceneContext ? `Scene context: ${sceneContext}` : '',
+    sessionMetadata ? `Session metadata: ${JSON.stringify(sessionMetadata)}` : '',
+    screenshotContext ? `Screenshot context: ${JSON.stringify(screenshotContext)}` : '',
+    stateLogExcerpt?.length ? `Recent state log excerpt: ${JSON.stringify(stateLogExcerpt)}` : '',
     `User comment: "${comment}"`,
     '',
-    'Is this comment clear enough to action, or do you need to ask a follow-up question?',
+    'Return either CLEAR, or FOLLOW_UP with one short question and exactly 2-3 options grounded in visible context. Always set allowOther=true for follow-ups.',
   ]
     .filter(Boolean)
     .join('\n');
 
-  const result = streamText({
-    model: openai('gpt-4o-mini'),
-    system: SYSTEM_PROMPT,
-    messages: [{ role: 'user', content: userMessage }],
-    maxTokens: 100,
-  });
+  try {
+    const result = await generateObject({
+      model: openai('gpt-4o-mini'),
+      system: `${SYSTEM_PROMPT}
 
-  return result.toDataStreamResponse();
+Output JSON only. Use this schema:
+{ "status": "CLEAR", "rationale": "optional short note" }
+or
+{ "status": "FOLLOW_UP", "question": "short question", "options": ["option a", "option b"], "allowOther": true, "rationale": "optional short note" }`,
+      messages: [{ role: 'user', content: userMessage }],
+      schema: responseSchema,
+      maxTokens: 220,
+    });
+
+    return Response.json(result.object, {
+      status: 200,
+      headers: { 'Cache-Control': 'no-store' },
+    });
+  } catch {
+    return Response.json({
+      status: 'FOLLOW_UP',
+      question: 'Which part felt off most: wording, layout, or behavior after your action?',
+      options: ['Wording/copy', 'Layout/visual placement', 'Interaction behavior'],
+      allowOther: true,
+      rationale: 'fallback',
+    }, {
+      status: 200,
+      headers: { 'Cache-Control': 'no-store' },
+    });
+  }
 }

--- a/apps/client/components/playtest/PlaytestOverlay.tsx
+++ b/apps/client/components/playtest/PlaytestOverlay.tsx
@@ -20,6 +20,20 @@ export interface Annotation {
   screenshot?: string;
   x?: number;
   y?: number;
+  clarification?: {
+    question: string;
+    options: string[];
+    selectedOption?: string;
+    otherText?: string;
+    rationale?: string;
+  };
+}
+
+export interface ClarificationPrompt {
+  question: string;
+  options: string[];
+  allowOther: boolean;
+  rationale?: string;
 }
 
 interface Props {
@@ -32,7 +46,7 @@ interface Props {
     stateLog: unknown;
     filmstrip: { ts: number; blob: Blob }[];
   }) => void;
-  onRequestClarification?: (comment: Annotation) => Promise<string | null>;
+  onRequestClarification?: (comment: Annotation) => Promise<ClarificationPrompt | null>;
 }
 
 type Tool = 'none' | 'draw' | 'comment';
@@ -60,9 +74,10 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
   const [panelView, setPanelView] = useState<PanelView>('tools');
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editText, setEditText] = useState('');
-  const [aiReply, setAiReply] = useState<string | null>(null);
+  const [aiPrompt, setAiPrompt] = useState<ClarificationPrompt | null>(null);
   const [aiLoading, setAiLoading] = useState(false);
   const [aiInputText, setAiInputText] = useState('');
+  const [aiSelectedOption, setAiSelectedOption] = useState<string | null>(null);
 
   // Comment placement: tap screen to place, then type
   const [placingComment, setPlacingComment] = useState(false);
@@ -551,8 +566,9 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
       try {
         const reply = await onRequestClarification(annotation);
         if (reply) {
-          setAiReply(reply);
+          setAiPrompt(reply);
           setAiInputText('');
+          setAiSelectedOption(null);
           setPanelView('ai-reply');
           return;
         }
@@ -568,17 +584,31 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
       const updated = [...prev];
       const last = updated[updated.length - 1];
       if (last?.type === 'comment') {
-        const text = aiInputText.trim()
-          ? `${last.text}\n---\nAI: ${aiReply}\nUser: ${aiInputText.trim()}`
-          : last.text;
-        updated[updated.length - 1] = { ...last, text, clarified: true };
+        const segments: string[] = [];
+        if (aiPrompt?.question) segments.push(`Follow-up: ${aiPrompt.question}`);
+        if (aiSelectedOption) segments.push(`Selected: ${aiSelectedOption}`);
+        if (aiInputText.trim()) segments.push(`Other: ${aiInputText.trim()}`);
+        const clarificationText = segments.length ? `\n---\n${segments.join('\n')}` : '';
+        updated[updated.length - 1] = {
+          ...last,
+          text: `${last.text}${clarificationText}`,
+          clarified: Boolean(aiPrompt),
+          clarification: aiPrompt ? {
+            question: aiPrompt.question,
+            options: aiPrompt.options,
+            selectedOption: aiSelectedOption || undefined,
+            otherText: aiInputText.trim() || undefined,
+            rationale: aiPrompt.rationale,
+          } : undefined,
+        };
       }
       return updated;
     });
-    setAiReply(null);
+    setAiPrompt(null);
     setAiInputText('');
+    setAiSelectedOption(null);
     setPanelView('tools');
-  }, [aiReply, aiInputText]);
+  }, [aiInputText, aiPrompt, aiSelectedOption]);
 
   /* ── Edit/delete ────────────────────────────────────────────────── */
 
@@ -813,7 +843,13 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
               {panelView !== 'tools' && (
                 <button
                   className="playtest-pill-back"
-                  onClick={() => { setPanelView('tools'); setAiReply(null); setCommentText(''); }}
+                  onClick={() => {
+                    setPanelView('tools');
+                    setAiPrompt(null);
+                    setAiSelectedOption(null);
+                    setAiInputText('');
+                    setCommentText('');
+                  }}
                   aria-label="Back"
                 >
                   &#8249;
@@ -924,18 +960,33 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
             )}
 
             {/* ── AI reply view ────────────────────────────────────── */}
-            {panelView === 'ai-reply' && aiReply && (
+            {panelView === 'ai-reply' && aiPrompt && (
               <div className="playtest-pill-comment">
-                <p className="playtest-ai-text">{aiReply}</p>
-                <input
-                  className="playtest-comment-input"
-                  style={{ minHeight: 'auto', padding: '8px' }}
-                  placeholder="Reply to AI (optional)..."
-                  value={aiInputText}
-                  onChange={(e) => setAiInputText(e.target.value)}
-                  onKeyDown={(e) => { if (e.key === 'Enter') handleAiResponse(); }}
-                  autoFocus
-                />
+                <p className="playtest-ai-text">{aiPrompt.question}</p>
+                {aiPrompt.options.length > 0 && (
+                  <div className="playtest-pill-row" style={{ flexWrap: 'wrap', gap: 8 }}>
+                    {aiPrompt.options.map((option) => (
+                      <button
+                        key={option}
+                        className={`playtest-btn-small ${aiSelectedOption === option ? '' : 'playtest-btn-muted'}`}
+                        onClick={() => setAiSelectedOption(option)}
+                      >
+                        {option}
+                      </button>
+                    ))}
+                  </div>
+                )}
+                {aiPrompt.allowOther && (
+                  <input
+                    className="playtest-comment-input"
+                    style={{ minHeight: 'auto', padding: '8px' }}
+                    placeholder="Other (optional)"
+                    value={aiInputText}
+                    onChange={(e) => setAiInputText(e.target.value)}
+                    onKeyDown={(e) => { if (e.key === 'Enter') handleAiResponse(); }}
+                    autoFocus
+                  />
+                )}
                 <div className="playtest-pill-row" style={{ justifyContent: 'flex-end' }}>
                   <button className="playtest-btn-small playtest-btn-muted" onClick={handleAiResponse}>Skip</button>
                   <button className="playtest-btn-small" onClick={handleAiResponse}>Save</button>

--- a/apps/client/components/playtest/PlaytestWrapper.tsx
+++ b/apps/client/components/playtest/PlaytestWrapper.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { PlaytestOverlay, type Annotation } from './PlaytestOverlay';
+import { PlaytestOverlay, type Annotation, type ClarificationPrompt } from './PlaytestOverlay';
+import { sessionLogger } from '@/lib/debug/session-logger';
 
 const API_BASE = process.env.NEXT_PUBLIC_TONG_API_BASE || 'http://localhost:8787';
 
@@ -11,6 +12,7 @@ const API_BASE = process.env.NEXT_PUBLIC_TONG_API_BASE || 'http://localhost:8787
  */
 export function PlaytestWrapper({ children }: { children: React.ReactNode }) {
   const [sessionId, setSessionId] = useState<string | null>(null);
+  const [sessionMeta, setSessionMeta] = useState<Record<string, unknown> | null>(null);
   const [uploading, setUploading] = useState(false);
   const [submitted, setSubmitted] = useState(false);
   const frameRef = useRef<HTMLDivElement>(null);
@@ -20,7 +22,10 @@ export function PlaytestWrapper({ children }: { children: React.ReactNode }) {
       const raw = sessionStorage.getItem('tong_playtest_session');
       if (raw) {
         const data = JSON.parse(raw);
-        if (data.sessionId) setSessionId(data.sessionId);
+        if (data.sessionId) {
+          setSessionId(data.sessionId);
+          setSessionMeta(data);
+        }
       }
     } catch {
       // Not a playtest session
@@ -71,8 +76,14 @@ export function PlaytestWrapper({ children }: { children: React.ReactNode }) {
   );
 
   const handleClarification = useCallback(
-    async (comment: Annotation): Promise<string | null> => {
+    async (comment: Annotation): Promise<ClarificationPrompt | null> => {
       try {
+        const currentSession = sessionLogger.getCurrent();
+        const stateLogExcerpt = currentSession?.entries
+          ?.filter((entry) => entry.kind === 'state_snapshot' || entry.kind === 'qa_trace')
+          .slice(-5)
+          .map((entry) => ({ ts: entry.ts, kind: entry.kind, data: entry.data })) || [];
+
         const res = await fetch('/api/ai/playtest-clarify', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -80,44 +91,34 @@ export function PlaytestWrapper({ children }: { children: React.ReactNode }) {
             comment: comment.text,
             timestamp: comment.timestamp,
             sessionId,
+            sceneContext: sessionMeta?.sceneType ? String(sessionMeta.sceneType) : undefined,
+            sessionMetadata: sessionMeta || undefined,
+            screenshotContext: {
+              hasScreenshot: Boolean(comment.screenshot),
+              x: comment.x,
+              y: comment.y,
+            },
+            stateLogExcerpt,
           }),
         });
 
         if (!res.ok) return null;
+        const payload = await res.json();
+        if (payload?.status !== 'FOLLOW_UP') return null;
 
-        // Read the streaming response as text
-        const reader = res.body?.getReader();
-        if (!reader) return null;
-
-        let text = '';
-        const decoder = new TextDecoder();
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-          text += decoder.decode(value, { stream: true });
-        }
-
-        // Parse Vercel AI SDK data stream format — extract text chunks
-        const lines = text.split('\n').filter(Boolean);
-        let reply = '';
-        for (const line of lines) {
-          // Vercel AI SDK streams as "0:text\n" format
-          if (line.startsWith('0:')) {
-            try {
-              reply += JSON.parse(line.slice(2));
-            } catch {
-              reply += line.slice(2);
-            }
-          }
-        }
-
-        if (!reply || reply.trim() === 'CLEAR') return null;
-        return reply.trim();
+        return {
+          question: String(payload.question || ''),
+          options: Array.isArray(payload.options)
+            ? payload.options.slice(0, 3).map((option: unknown) => String(option))
+            : [],
+          allowOther: payload.allowOther !== false,
+          rationale: payload.rationale ? String(payload.rationale) : undefined,
+        };
       } catch {
         return null;
       }
     },
-    [sessionId],
+    [sessionId, sessionMeta],
   );
 
   const isActive = Boolean(sessionId) && !submitted && !uploading;

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -648,6 +648,106 @@ function generatePlaytestId(length = 12): string {
   return Array.from(bytes, (b) => PLAYTEST_ID_ALPHABET[b % PLAYTEST_ID_ALPHABET.length]).join('');
 }
 
+type PlaytestIssuePromotionDraft = {
+  title: string;
+  body: string;
+  issueRef: string;
+  links: {
+    session: string;
+    annotations?: string;
+    recording?: string;
+    filmstrip?: string;
+    stateLog?: string;
+    analysis?: string;
+  };
+};
+
+function truncateText(value: string | undefined, max = 180): string {
+  if (!value) return '';
+  return value.length > max ? `${value.slice(0, max - 1)}…` : value;
+}
+
+function buildPlaytestIssueDraft(input: {
+  owner: string;
+  repo: string;
+  sessionId: string;
+  sessionRow?: Record<string, unknown> | null;
+  annotations: any[];
+  focusAnnotation?: any;
+  publicBase: string;
+  analysisUrl?: string;
+}): PlaytestIssuePromotionDraft {
+  const {
+    owner, repo, sessionId, sessionRow, annotations, focusAnnotation, publicBase, analysisUrl,
+  } = input;
+  const city = String(sessionRow?.city || 'unknown');
+  const sceneType = String(sessionRow?.scene_type || 'unknown');
+  const language = String(sessionRow?.language || 'unknown');
+  const locationId = String(sessionRow?.location_id || 'unknown');
+  const hangoutId = String(sessionRow?.hangout_id || 'n/a');
+  const issueRef = `${owner}/${repo}`;
+
+  const selectedComment = focusAnnotation?.text
+    ? String(focusAnnotation.text)
+    : String((annotations.find((annotation) => annotation?.type === 'comment') || {}).text || '');
+  const summary = truncateText(selectedComment, 90) || `Playtest issue from session ${sessionId}`;
+  const title = `playtest: ${summary}`;
+
+  const annotationRows = annotations
+    .filter((annotation) => annotation?.type === 'comment')
+    .slice(0, 8)
+    .map((annotation) => {
+      const ts = annotation.timestamp ?? '?';
+      const text = truncateText(String(annotation.text || ''));
+      return `- [${ts}s] ${text}`;
+    });
+
+  const links = {
+    session: `${publicBase}/playtest/${sessionId}`,
+    annotations: `${publicBase}/playtest/${sessionId}/annotations.json`,
+    recording: `${publicBase}/playtest/${sessionId}/recording.webm`,
+    filmstrip: `${publicBase}/playtest/${sessionId}/filmstrip/manifest.json`,
+    stateLog: `${publicBase}/playtest/${sessionId}/state-log.json`,
+    analysis: analysisUrl,
+  };
+
+  const body = [
+    `## Summary`,
+    summary,
+    '',
+    `## Playtest session`,
+    `- Session ID: \`${sessionId}\``,
+    `- City: \`${city}\``,
+    `- Scene type: \`${sceneType}\``,
+    `- Language: \`${language}\``,
+    `- Location: \`${locationId}\``,
+    `- Hangout: \`${hangoutId}\``,
+    '',
+    `## Annotation highlights`,
+    annotationRows.length ? annotationRows.join('\n') : '- No comment annotations found.',
+    '',
+    `## Reviewer-openable artifacts`,
+    `- Session root: ${links.session}`,
+    `- Annotations JSON: ${links.annotations}`,
+    `- Recording: ${links.recording}`,
+    `- Filmstrip manifest: ${links.filmstrip}`,
+    `- State log: ${links.stateLog}`,
+    links.analysis ? `- Analysis: ${links.analysis}` : '',
+    '',
+    `## Expected vs actual`,
+    `- Expected: behavior and UX match the in-scene prompt and interaction affordances.`,
+    `- Actual: see annotation highlights and linked artifacts for exact mismatches.`,
+    '',
+    `## Suggested acceptance checks`,
+    `- Reproduce from session artifacts above and confirm issue behavior.`,
+    `- Verify fix against the same session moment(s) and annotation timestamps.`,
+    '',
+    `Generated from playtest session ${sessionId}.`,
+  ].filter(Boolean).join('\n');
+
+  return { title, body, issueRef, links };
+}
+
 function getLang(search: URLSearchParams): Lang {
   const lang = (search.get('lang') || 'ko') as Lang;
   if (lang === 'ko' || lang === 'ja' || lang === 'zh') return lang;
@@ -2575,6 +2675,103 @@ async function handleRequest(request: Request): Promise<Response> {
       return new Response(data, {
         status: 200,
         headers: { 'Content-Type': 'application/json; charset=utf-8', ...CORS_HEADERS },
+      });
+    }
+
+    // Create a GitHub-issue-ready draft (or issue) from a playtest session
+    if (pathname.match(/^\/api\/v1\/playtest\/sessions\/[^/]+\/promote$/) && request.method === 'POST') {
+      const sessionId = pathname.split('/')[5];
+      const env = (globalThis as any).__env;
+      const body = await readJsonBody(request);
+      const owner = String(body.owner || env?.GITHUB_REPO_OWNER || 'erniesg');
+      const repo = String(body.repo || env?.GITHUB_REPO_NAME || 'tong');
+      const createIssue = Boolean(body.createIssue);
+      const labels = Array.isArray(body.labels) ? body.labels.map((label: unknown) => String(label)) : [];
+      const annotationId = body.annotationId ? String(body.annotationId) : null;
+      const publicBase = env?.TONG_RUNS_PUBLIC_BASE_URL || 'https://runs.tong.berlayar.ai';
+
+      let sessionRow: Record<string, unknown> | null = null;
+      if (env?.DB) {
+        sessionRow = await env.DB.prepare(
+          `SELECT * FROM playtest_sessions WHERE session_id = ?`
+        ).bind(sessionId).first() as Record<string, unknown> | null;
+      }
+
+      const annotationsObj = env?.TONG_RUNS_BUCKET
+        ? await env.TONG_RUNS_BUCKET.get(`playtest/${sessionId}/annotations.json`)
+        : null;
+      const annotationsText = annotationsObj ? await annotationsObj.text() : '[]';
+      let annotationsRaw: any = [];
+      try {
+        const parsed = JSON.parse(annotationsText);
+        annotationsRaw = Array.isArray(parsed) ? parsed : (Array.isArray(parsed.annotations) ? parsed.annotations : []);
+      } catch {
+        annotationsRaw = [];
+      }
+      const focusAnnotation = annotationId
+        ? annotationsRaw.find((annotation: any) => String(annotation?.id) === annotationId)
+        : undefined;
+
+      const analysisUrl = `${publicBase}/playtest/${sessionId}/analysis.json`;
+      const draft = buildPlaytestIssueDraft({
+        owner,
+        repo,
+        sessionId,
+        sessionRow,
+        annotations: annotationsRaw,
+        focusAnnotation,
+        publicBase,
+        analysisUrl,
+      });
+
+      if (!createIssue) {
+        return jsonResponse(200, { ok: true, mode: 'draft', draft });
+      }
+
+      if (!env?.GITHUB_TOKEN) {
+        return jsonResponse(400, {
+          ok: false,
+          error: 'missing_github_token',
+          message: 'Set GITHUB_TOKEN to create issues; returning draft only.',
+          draft,
+        });
+      }
+
+      const githubResponse = await fetch(`https://api.github.com/repos/${owner}/${repo}/issues`, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${env.GITHUB_TOKEN}`,
+          'Content-Type': 'application/json',
+          'Accept': 'application/vnd.github+json',
+          'User-Agent': 'tong-playtest-promoter',
+        },
+        body: JSON.stringify({
+          title: draft.title,
+          body: draft.body,
+          labels,
+        }),
+      });
+
+      if (!githubResponse.ok) {
+        const githubError = await githubResponse.text();
+        return jsonResponse(502, {
+          ok: false,
+          error: 'github_issue_create_failed',
+          status: githubResponse.status,
+          githubError,
+          draft,
+        });
+      }
+
+      const created = await githubResponse.json() as { html_url?: string; number?: number };
+      return jsonResponse(201, {
+        ok: true,
+        mode: 'created',
+        draft,
+        issue: {
+          number: created.number,
+          htmlUrl: created.html_url,
+        },
       });
     }
 


### PR DESCRIPTION
### Motivation
- Playtest annotation clarifier returned unstructured streamed text so the client could not decide when to ask follow-ups or present quick-pick options. 
- The playtest flow stored artifacts but had no repo-native path to promote high-signal findings into reviewer-ready GitHub issues.

### Description
- Upgrade `/api/ai/playtest-clarify` to accept richer context (`sessionMetadata`, `screenshotContext`, `stateLogExcerpt`) and return a schema-driven JSON response of either `CLEAR` or `FOLLOW_UP` with `question`, `options` (2–3), and `allowOther: true` (file: `apps/client/app/api/ai/playtest-clarify/route.ts`).
- Update playtest client flow so `PlaytestWrapper` sends context-rich payloads and parses structured clarifier responses, and `PlaytestOverlay` renders tap-friendly 2–3 option buttons plus an optional freeform `Other` input and persists the chosen clarification into the annotation object (files: `apps/client/components/playtest/PlaytestWrapper.tsx`, `apps/client/components/playtest/PlaytestOverlay.tsx`).
- Add a worker-side helper and endpoint `POST /api/v1/playtest/sessions/:id/promote` that generates a GitHub-issue-ready draft (and can create an issue when `GITHUB_TOKEN` is configured) including session id, artifact links, annotation highlights, and suggested acceptance checks (file: `apps/worker/src/index.ts`).
- Kept the scope limited to the client-runtime worktree and added a safe fallback (structured fallback question) when the model call fails.
- Fixes #216

### Testing
- Ran a baseline validate run and recorded the reproduced contract gap under `artifacts/qa-runs/functional-qa/erniesg-tong-216/20260419T081922Z` and then a verify-fix run under `artifacts/qa-runs/functional-qa/erniesg-tong-216/20260419T082707Z` with finalized manifests and evidence files.
- Built and type-checked the client with `npm --prefix apps/client run build` which completed successfully in this environment (runtime asset fetch fell back but is out of scope for this change). 
- Exercised the clarifier endpoint locally with `curl -X POST http://localhost:3000/api/ai/playtest-clarify` and confirmed HTTP 200 JSON `FOLLOW_UP` payload with `question`, `options`, and `allowOther:true`; response captured in run logs `artifacts/qa-runs/functional-qa/erniesg-tong-216/20260419T082707Z/logs/clarify-response-body.json` and headers log.
- Verified dev flow: `npm --prefix apps/client run dev` and manual playtest submission shows quick-pick clarification UI and persisted annotation clarification fields, and `POST /api/v1/playtest/sessions/:id/promote` returns a draft (or creates an issue when `GITHUB_TOKEN` is set); reviewer-visible QA update published as a comment at: https://github.com/erniesg/tong/issues/216#issuecomment-4275511890

How to test locally
- `npm --prefix apps/client run build` then `npm --prefix apps/client run dev` to start the app, POST a test payload to `/api/ai/playtest-clarify` with a vague comment and context to confirm structured JSON, use the Playtest overlay to submit a vague comment to confirm options/Other appear and persist, and call `POST /api/v1/playtest/sessions/:id/promote` with `createIssue:false` to inspect the generated draft.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e48ed9951c832aa5173268b1069a1f)