### PR TITLE
fix: issue #216 - Playtest feedback loop: clarify only when needed and promote sessions in

### DIFF
--- a/apps/client/app/api/ai/playtest-clarify/route.ts
+++ b/apps/client/app/api/ai/playtest-clarify/route.ts
@@ -1,71 +1,122 @@
-import { streamText } from 'ai';
-import { openai } from '@ai-sdk/openai';
 import { z } from 'zod';
 
 export const runtime = 'nodejs';
 export const maxDuration = 30;
 
-/**
- * Inline AI clarification for playtest annotations.
- *
- * When a user drops a comment during a playtest session, this endpoint
- * checks if the comment is clear enough to action, and if not, asks a
- * targeted follow-up question.
- *
- * Input: { comment, sceneContext, timestamp }
- * Output: streamed text — either a clarifying question or "CLEAR" if no follow-up needed.
- */
+const requestSchema = z.object({
+  comment: z.string().trim().min(1),
+  timestamp: z.number().optional(),
+  sessionId: z.string().optional(),
+  context: z.object({
+    sceneContext: z.string().optional(),
+    screenshotUrl: z.string().url().optional(),
+    stateLogExcerpt: z.string().optional(),
+    city: z.string().optional(),
+    sceneType: z.string().optional(),
+    language: z.string().optional(),
+    locationId: z.string().optional(),
+  }).optional(),
+});
 
-const SYSTEM_PROMPT = `You are a playtest facilitator for a language learning game called Tong.
-The user is playing through a scene and has dropped an annotation comment. Your job is to make sure the comment is actionable for the development team.
+type ClarifyResponse =
+  | { status: 'CLEAR'; reason: string }
+  | {
+      status: 'FOLLOW_UP';
+      reason: string;
+      followUp: {
+        question: string;
+        options: string[];
+        allowOther: true;
+      };
+    };
 
-Rules:
-- If the comment is already clear and specific, respond with exactly: CLEAR
-- If the comment is vague or could mean multiple things, ask ONE short, specific follow-up question
-- Never ask more than one question at a time
-- Keep your question under 30 words
-- Frame questions as concrete options when possible: "Was it the font size, the translation, or something else?"
-- Don't be annoying — if the user says "this is fine" or "skip", accept it
-- You are NOT teaching — you are gathering bug reports / UX feedback
+const VAGUE_MARKERS = [
+  'weird',
+  'confusing',
+  'bad',
+  'off',
+  'wrong',
+  'not good',
+  'doesnt work',
+  "doesn't work",
+  'broken',
+];
 
-Examples of vague comments that need follow-up:
-- "this is weird" → "Was it the layout, the text content, or how it responded to your tap?"
-- "confusing" → "Was the instruction unclear, or did the UI not behave as expected?"
-- "too hard" → "Was the vocabulary too advanced, or were the exercise controls unclear?"
+const SPECIFIC_MARKERS = [
+  'button',
+  'tap',
+  'tooltip',
+  'translation',
+  'font',
+  'layout',
+  'cut off',
+  'overflow',
+  'subtitles',
+  'audio',
+  'loading',
+  'crash',
+];
 
-Examples of clear comments that DON'T need follow-up:
-- "the Korean text is cut off on the right side" → CLEAR
-- "I expected tapping the character to show a translation tooltip" → CLEAR
-- "this exercise should have audio" → CLEAR`;
+function chooseOptions(comment: string, sceneHint: string): string[] {
+  const lower = comment.toLowerCase();
+  if (lower.includes('text') || lower.includes('translation') || lower.includes('subtitle')) {
+    return ['The text is hard to read', 'The translation meaning is wrong', 'The text appears in the wrong place'];
+  }
+  if (lower.includes('tap') || lower.includes('click') || lower.includes('button')) {
+    return ['Tap did not respond', 'Tap responded too slowly', 'The wrong action happened'];
+  }
+  if (sceneHint.includes('hangout')) {
+    return ['The dialogue felt unclear', 'I was unsure what action to take', 'The pacing felt off'];
+  }
+  return ['The UI layout is confusing', 'The behavior is not what I expected', 'I cannot tell what to do next'];
+}
 
-export async function POST(req: Request) {
-  const body = await req.json();
-  const { comment, sceneContext, timestamp, sessionId } = body;
+function getDecision(comment: string, context?: z.infer<typeof requestSchema>['context']): ClarifyResponse {
+  const trimmed = comment.trim();
+  const lower = trimmed.toLowerCase();
+  const hasSpecificMarker = SPECIFIC_MARKERS.some((marker) => lower.includes(marker));
+  const hasVagueMarker = VAGUE_MARKERS.some((marker) => lower.includes(marker));
+  const hasRichContext = Boolean(context?.screenshotUrl || context?.stateLogExcerpt || context?.sceneContext);
 
-  if (!comment) {
-    return new Response(JSON.stringify({ error: 'comment is required' }), {
-      status: 400,
-      headers: { 'Content-Type': 'application/json' },
-    });
+  if ((hasSpecificMarker && trimmed.length >= 14) || (trimmed.length >= 28 && hasRichContext && !hasVagueMarker)) {
+    return {
+      status: 'CLEAR',
+      reason: hasRichContext ? 'comment-specific-with-context' : 'comment-specific',
+    };
   }
 
-  const userMessage = [
-    `Session: ${sessionId || 'unknown'}`,
-    `Timestamp: ${timestamp || 'unknown'}`,
-    sceneContext ? `Scene context: ${sceneContext}` : '',
-    `User comment: "${comment}"`,
-    '',
-    'Is this comment clear enough to action, or do you need to ask a follow-up question?',
-  ]
-    .filter(Boolean)
-    .join('\n');
+  if (!hasVagueMarker && trimmed.length >= 24) {
+    return {
+      status: 'CLEAR',
+      reason: 'long-enough-to-action',
+    };
+  }
 
-  const result = streamText({
-    model: openai('gpt-4o-mini'),
-    system: SYSTEM_PROMPT,
-    messages: [{ role: 'user', content: userMessage }],
-    maxTokens: 100,
+  const sceneHint = [context?.sceneType, context?.sceneContext].filter(Boolean).join(' ').toLowerCase();
+  return {
+    status: 'FOLLOW_UP',
+    reason: hasVagueMarker ? 'ambiguous-feedback' : 'needs-scope',
+    followUp: {
+      question: 'Which part should we prioritize fixing first?',
+      options: chooseOptions(trimmed, sceneHint).slice(0, 3),
+      allowOther: true,
+    },
+  };
+}
+
+export async function POST(req: Request) {
+  const body = await req.json().catch(() => null);
+  const parsed = requestSchema.safeParse(body);
+  if (!parsed.success) {
+    return new Response(
+      JSON.stringify({ error: 'invalid_payload', issues: parsed.error.issues }),
+      { status: 400, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+
+  const decision = getDecision(parsed.data.comment, parsed.data.context);
+  return new Response(JSON.stringify(decision), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
   });
-
-  return result.toDataStreamResponse();
 }

--- a/apps/client/components/playtest/PlaytestOverlay.tsx
+++ b/apps/client/components/playtest/PlaytestOverlay.tsx
@@ -20,7 +20,18 @@ export interface Annotation {
   screenshot?: string;
   x?: number;
   y?: number;
+  clarification?: {
+    question: string;
+    selectedOption?: string;
+    otherText?: string;
+  };
 }
+
+type ClarificationRequest = {
+  question: string;
+  options: string[];
+  allowOther: boolean;
+};
 
 interface Props {
   targetRef: React.RefObject<HTMLElement | null>;
@@ -32,7 +43,7 @@ interface Props {
     stateLog: unknown;
     filmstrip: { ts: number; blob: Blob }[];
   }) => void;
-  onRequestClarification?: (comment: Annotation) => Promise<string | null>;
+  onRequestClarification?: (comment: Annotation) => Promise<ClarificationRequest | null>;
 }
 
 type Tool = 'none' | 'draw' | 'comment';
@@ -61,6 +72,8 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editText, setEditText] = useState('');
   const [aiReply, setAiReply] = useState<string | null>(null);
+  const [clarifyOptions, setClarifyOptions] = useState<string[]>([]);
+  const [selectedClarifyOption, setSelectedClarifyOption] = useState<string | null>(null);
   const [aiLoading, setAiLoading] = useState(false);
   const [aiInputText, setAiInputText] = useState('');
 
@@ -551,8 +564,10 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
       try {
         const reply = await onRequestClarification(annotation);
         if (reply) {
-          setAiReply(reply);
+          setAiReply(reply.question);
+          setClarifyOptions(reply.options || []);
           setAiInputText('');
+          setSelectedClarifyOption(null);
           setPanelView('ai-reply');
           return;
         }
@@ -568,17 +583,31 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
       const updated = [...prev];
       const last = updated[updated.length - 1];
       if (last?.type === 'comment') {
-        const text = aiInputText.trim()
-          ? `${last.text}\n---\nAI: ${aiReply}\nUser: ${aiInputText.trim()}`
+        const freeform = aiInputText.trim();
+        const selected = selectedClarifyOption?.trim();
+        const clarifySummary = [selected, freeform].filter(Boolean).join(' | ');
+        const text = clarifySummary
+          ? `${last.text}\n---\nClarification: ${clarifySummary}`
           : last.text;
-        updated[updated.length - 1] = { ...last, text, clarified: true };
+        updated[updated.length - 1] = {
+          ...last,
+          text,
+          clarified: true,
+          clarification: {
+            question: aiReply || 'Follow-up clarification',
+            selectedOption: selected || undefined,
+            otherText: freeform || undefined,
+          },
+        };
       }
       return updated;
     });
     setAiReply(null);
     setAiInputText('');
+    setClarifyOptions([]);
+    setSelectedClarifyOption(null);
     setPanelView('tools');
-  }, [aiReply, aiInputText]);
+  }, [aiReply, aiInputText, selectedClarifyOption]);
 
   /* ── Edit/delete ────────────────────────────────────────────────── */
 
@@ -927,10 +956,24 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
             {panelView === 'ai-reply' && aiReply && (
               <div className="playtest-pill-comment">
                 <p className="playtest-ai-text">{aiReply}</p>
+                {clarifyOptions.length > 0 && (
+                  <div className="playtest-pill-row" style={{ gap: 6, flexWrap: 'wrap', marginBottom: 6 }}>
+                    {clarifyOptions.slice(0, 3).map((option) => (
+                      <button
+                        key={option}
+                        className={`playtest-btn-small ${selectedClarifyOption === option ? '' : 'playtest-btn-muted'}`}
+                        onClick={() => setSelectedClarifyOption(option)}
+                        type="button"
+                      >
+                        {option}
+                      </button>
+                    ))}
+                  </div>
+                )}
                 <input
                   className="playtest-comment-input"
                   style={{ minHeight: 'auto', padding: '8px' }}
-                  placeholder="Reply to AI (optional)..."
+                  placeholder="Other (optional)..."
                   value={aiInputText}
                   onChange={(e) => setAiInputText(e.target.value)}
                   onKeyDown={(e) => { if (e.key === 'Enter') handleAiResponse(); }}

--- a/apps/client/components/playtest/PlaytestWrapper.tsx
+++ b/apps/client/components/playtest/PlaytestWrapper.tsx
@@ -11,6 +11,7 @@ const API_BASE = process.env.NEXT_PUBLIC_TONG_API_BASE || 'http://localhost:8787
  */
 export function PlaytestWrapper({ children }: { children: React.ReactNode }) {
   const [sessionId, setSessionId] = useState<string | null>(null);
+  const [sessionContext, setSessionContext] = useState<Record<string, unknown> | null>(null);
   const [uploading, setUploading] = useState(false);
   const [submitted, setSubmitted] = useState(false);
   const frameRef = useRef<HTMLDivElement>(null);
@@ -20,7 +21,10 @@ export function PlaytestWrapper({ children }: { children: React.ReactNode }) {
       const raw = sessionStorage.getItem('tong_playtest_session');
       if (raw) {
         const data = JSON.parse(raw);
-        if (data.sessionId) setSessionId(data.sessionId);
+        if (data.sessionId) {
+          setSessionId(data.sessionId);
+          setSessionContext(data);
+        }
       }
     } catch {
       // Not a playtest session
@@ -71,7 +75,7 @@ export function PlaytestWrapper({ children }: { children: React.ReactNode }) {
   );
 
   const handleClarification = useCallback(
-    async (comment: Annotation): Promise<string | null> => {
+    async (comment: Annotation): Promise<{ question: string; options: string[]; allowOther: boolean } | null> => {
       try {
         const res = await fetch('/api/ai/playtest-clarify', {
           method: 'POST',
@@ -80,44 +84,33 @@ export function PlaytestWrapper({ children }: { children: React.ReactNode }) {
             comment: comment.text,
             timestamp: comment.timestamp,
             sessionId,
+            context: {
+              sceneContext: typeof sessionContext?.sceneContext === 'string' ? sessionContext.sceneContext : undefined,
+              city: typeof sessionContext?.city === 'string' ? sessionContext.city : undefined,
+              sceneType: typeof sessionContext?.sceneType === 'string' ? sessionContext.sceneType : undefined,
+              language: typeof sessionContext?.language === 'string' ? sessionContext.language : undefined,
+              locationId: typeof sessionContext?.locationId === 'string' ? sessionContext.locationId : undefined,
+              screenshotUrl: comment.id ? `${API_BASE}/api/v1/playtest/sessions/${sessionId}/screenshots/${comment.id}.png` : undefined,
+            },
           }),
         });
 
         if (!res.ok) return null;
-
-        // Read the streaming response as text
-        const reader = res.body?.getReader();
-        if (!reader) return null;
-
-        let text = '';
-        const decoder = new TextDecoder();
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-          text += decoder.decode(value, { stream: true });
-        }
-
-        // Parse Vercel AI SDK data stream format — extract text chunks
-        const lines = text.split('\n').filter(Boolean);
-        let reply = '';
-        for (const line of lines) {
-          // Vercel AI SDK streams as "0:text\n" format
-          if (line.startsWith('0:')) {
-            try {
-              reply += JSON.parse(line.slice(2));
-            } catch {
-              reply += line.slice(2);
-            }
-          }
-        }
-
-        if (!reply || reply.trim() === 'CLEAR') return null;
-        return reply.trim();
+        const payload = await res.json() as {
+          status?: 'CLEAR' | 'FOLLOW_UP';
+          followUp?: { question?: string; options?: string[]; allowOther?: boolean };
+        };
+        if (payload.status !== 'FOLLOW_UP' || !payload.followUp?.question) return null;
+        return {
+          question: payload.followUp.question,
+          options: (payload.followUp.options || []).slice(0, 3),
+          allowOther: payload.followUp.allowOther !== false,
+        };
       } catch {
         return null;
       }
     },
-    [sessionId],
+    [sessionContext, sessionId],
   );
 
   const isActive = Boolean(sessionId) && !submitted && !uploading;

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -2578,6 +2578,100 @@ async function handleRequest(request: Request): Promise<Response> {
       });
     }
 
+    if (pathname.match(/^\/api\/v1\/playtest\/sessions\/[^/]+\/promote-issue$/) && request.method === 'POST') {
+      const sessionId = pathname.split('/')[5];
+      const env = (globalThis as any).__env;
+      if (!env?.DB) return jsonResponse(500, { error: 'db_not_configured' });
+      if (!env?.TONG_RUNS_BUCKET) return jsonResponse(500, { error: 'r2_not_configured' });
+
+      const session = await env.DB.prepare(
+        `SELECT * FROM playtest_sessions WHERE session_id = ?`
+      ).bind(sessionId).first();
+      if (!session) return jsonResponse(404, { error: 'session_not_found', sessionId });
+
+      const body = await readJsonBody(request);
+      const publicBase = env?.TONG_RUNS_PUBLIC_BASE_URL || 'https://runs.tong.berlayar.ai';
+      const annotationsObj = await env.TONG_RUNS_BUCKET.get(`playtest/${sessionId}/annotations.json`);
+      const analysisObj = await env.TONG_RUNS_BUCKET.get(`playtest/${sessionId}/analysis.json`);
+
+      let annotationSummary = '- No annotations captured.';
+      if (annotationsObj) {
+        try {
+          const parsed = JSON.parse(await annotationsObj.text());
+          const annotations = Array.isArray(parsed) ? parsed : parsed?.annotations || [];
+          const commentRows = annotations
+            .filter((ann: Record<string, unknown>) => ann?.type === 'comment')
+            .slice(0, 8)
+            .map((ann: Record<string, unknown>) => {
+              const rawText = typeof ann.text === 'string' ? ann.text.replace(/\n/g, ' ') : '(no text)';
+              const ts = ann.timestamp ?? 'n/a';
+              const shot = ann.id ? `${publicBase}/playtest/${sessionId}/screenshots/${ann.id}.png` : '';
+              return `- [t=${ts}s] ${rawText}${shot ? ` ([screenshot](${shot}))` : ''}`;
+            });
+          if (commentRows.length > 0) annotationSummary = commentRows.join('\n');
+        } catch {
+          annotationSummary = '- Annotation payload exists but could not be parsed.';
+        }
+      }
+
+      let analysisSummary = '- No analysis artifact found.';
+      if (analysisObj) {
+        try {
+          const analysis = JSON.parse(await analysisObj.text());
+          const top = Array.isArray(analysis?.topIssues) ? analysis.topIssues.slice(0, 3) : [];
+          if (top.length > 0) {
+            analysisSummary = top.map((item: Record<string, unknown>) => `- ${item.title || item.summary || 'Issue'} (${item.severity || 'unknown severity'})`).join('\n');
+          } else {
+            analysisSummary = '- Analysis artifact present (no topIssues list).';
+          }
+        } catch {
+          analysisSummary = '- Analysis artifact exists but could not be parsed.';
+        }
+      }
+
+      const issueTitle = body?.title || `Playtest follow-up: ${session.scene_type || 'session'} (${sessionId})`;
+      const issueBody = [
+        '## Summary',
+        body?.summary || 'Promoted from playtest artifacts for triage.',
+        '',
+        '## Session Context',
+        `- Session ID: \`${sessionId}\``,
+        `- City: ${session.city || 'unknown'}`,
+        `- Scene Type: ${session.scene_type || 'unknown'}`,
+        `- Language: ${session.language || 'unknown'}`,
+        `- Location: ${session.location_id || 'unknown'}`,
+        '',
+        '## Artifact Links',
+        `- Recording: ${publicBase}/playtest/${sessionId}/recording.webm`,
+        `- Filmstrip manifest: ${publicBase}/playtest/${sessionId}/filmstrip/manifest.json`,
+        `- State log: ${publicBase}/playtest/${sessionId}/state-log.json`,
+        `- Annotations: ${publicBase}/playtest/${sessionId}/annotations.json`,
+        '',
+        '## Annotated Feedback',
+        annotationSummary,
+        '',
+        '## Analysis Summary',
+        analysisSummary,
+        '',
+        '## Suggested Acceptance Checks',
+        '- Reproduce using the same session artifacts and timestamped notes.',
+        '- Verify expected vs actual behavior in the targeted scene.',
+        '- Confirm any selected clarification option and freeform "Other" note are reflected.',
+      ].join('\n');
+
+      return jsonResponse(200, {
+        ok: true,
+        mode: 'draft',
+        issueDraft: {
+          title: issueTitle,
+          body: issueBody,
+          labels: Array.isArray(body?.labels) ? body.labels : ['playtest'],
+          owner: body?.owner || 'erniesg',
+          repo: body?.repo || 'tong',
+        },
+      });
+    }
+
     return jsonResponse(404, { error: 'not_found', pathname });
   } catch (error) {
     return jsonResponse(500, {

--- a/packages/contracts/types.ts
+++ b/packages/contracts/types.ts
@@ -1183,3 +1183,37 @@ export interface VolcTTSSynthesizeResponse {
   encoding: string;
   durationMs?: number;
 }
+
+export interface PlaytestClarificationContext {
+  sceneContext?: string;
+  screenshotUrl?: string;
+  stateLogExcerpt?: string;
+  city?: string;
+  sceneType?: string;
+  language?: AppLanguage;
+  locationId?: string;
+}
+
+export interface PlaytestClarifyRequest {
+  comment: string;
+  timestamp?: number;
+  sessionId?: string;
+  context?: PlaytestClarificationContext;
+}
+
+export interface PlaytestClarifyFollowUp {
+  question: string;
+  options: string[];
+  allowOther: true;
+}
+
+export type PlaytestClarifyResponse =
+  | {
+      status: 'CLEAR';
+      reason: string;
+    }
+  | {
+      status: 'FOLLOW_UP';
+      reason: string;
+      followUp: PlaytestClarifyFollowUp;
+    };


### PR DESCRIPTION
### Motivation

- Clarifier endpoint was a plain text/streaming surface that asked follow-ups even when session screenshots/state made the feedback actionable.  
- Playtest overlay accepted only freeform clarification replies, increasing player burden and losing structured signal.  
- There was no repo-native path to promote a session or analyzed finding into an issue-ready draft with artifact links and context.

### Description

- Add contract types for playtest clarification request/response in `packages/contracts/types.ts` (`PlaytestClarifyRequest`, `PlaytestClarifyResponse`, `PlaytestClarificationContext`).
- Replace the previous streaming clarifier with a deterministic API at `apps/client/app/api/ai/playtest-clarify/route.ts` that accepts contextual payloads and returns either `CLEAR` or `FOLLOW_UP` with a short question, 2–3 `options`, and `allowOther: true`.
- Update the client UI to surface quick-pick follow-up options and persist structured clarification into annotation payloads (`apps/client/components/playtest/PlaytestOverlay.tsx` and `apps/client/components/playtest/PlaytestWrapper.tsx`), and send richer session context (scene/city/language/location/screenshot URL) to the clarifier.
- Add a worker-side promotion endpoint `POST /api/v1/playtest/sessions/:sessionId/promote-issue` in `apps/worker/src/index.ts` that assembles an issue-draft payload with session metadata, artifact links, annotation excerpts, and a small analysis summary for maintainer-triggered promotion.

### Testing

- Ran the repo QA flow and validation: generated queue plan and executed `validate-issue` then `validate-issue --verify-fix` for `erniesg/tong#216` with evidence plan `contract-assertions, network-trace`, producing run artifacts under `artifacts/qa-runs/functional-qa/erniesg-tong-216/` (validation run `20260419T081822Z`, verify-fix run `20260419T082228Z`).
- Verified clarifier contract via local client dev server: started client (`npm --prefix apps/client run dev`) and executed automated POST checks (curl): specific contextual comment returned `{"status":"CLEAR",...}` and ambiguous comment returned `{"status":"FOLLOW_UP","followUp":{...,"allowOther":true}}` (network traces captured; responses saved to verify-run evidence files).
- Type check: `npx tsc -p apps/client/tsconfig.json --noEmit` succeeded.
- Smoke/setup checks: `npm run demo:smoke` failed due to a missing runtime asset (`/assets/app/tong_opening.mp4`) which is unrelated to the contract/UI code changes but blocks full demo smoke in this environment.
- Worker runtime: attempted `npm --prefix apps/worker run dev` but `wrangler` was not present in this environment, so the promotion endpoint was exercised only via static inspection and unit-like checks; the endpoint implementation is present and returns an `issueDraft` payload but was not executed against a live worker runtime here.
- QA publication: ran `qa_runtime.py publish-github` for the verify-fix run which posted a structured update to the issue thread (see generated comment: https://github.com/erniesg/tong/issues/216#issuecomment-4275505347).

Note: This PR does not auto-close the issue; it implements the contract, UI quick-pick flow, and promotion-path and leaves final review/acceptance (including any reviewer-visible browser capture for timing-sensitive UI proofs) to maintainers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e48ed9951c832aa5173268b1069a1f)