### PR TITLE
fix: issue #168 - fix: R2 asset upload — diff-only uploads, parallel uploads, exclude test files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ artifacts/thumbnails/
 artifacts/scenes/
 test-results/
 .xhs-cookie
+.r2-upload-cache.json
 
 # Large binary assets — store externally, not in git
 *.mp4

--- a/scripts/upload-runtime-assets.mjs
+++ b/scripts/upload-runtime-assets.mjs
@@ -2,6 +2,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import crypto from "node:crypto";
 import { spawnSync } from "node:child_process";
 import { relativeToRepo, resolveRepoRoot } from "./lib/qa_evidence.mjs";
 
@@ -12,6 +13,9 @@ const DEFAULT_CANONICAL_MANIFEST_KEY = "runtime-assets/canonical-asset-manifest.
 const DEFAULT_PUBLIC_VERIFY_ATTEMPTS = 4;
 const DEFAULT_PUBLIC_VERIFY_DELAY_MS = 1500;
 const DEFAULT_PUBLIC_VERIFY_TIMEOUT_MS = 15000;
+const DEFAULT_UPLOAD_CONCURRENCY = 6;
+const DEFAULT_CACHE_PATH = ".r2-upload-cache.json";
+const DEFAULT_MAX_UPLOAD_BYTES = 25 * 1024 * 1024;
 
 const CLIENT_PUBLIC_ASSETS_DIR = "apps/client/public/assets";
 const RUNTIME_MANIFEST_PATH = "assets/manifest/runtime-asset-manifest.json";
@@ -28,6 +32,9 @@ function parseArgs(argv) {
     publicVerifyTimeoutMs: DEFAULT_PUBLIC_VERIFY_TIMEOUT_MS,
     runtimeManifestKey: process.env.TONG_RUNTIME_ASSET_MANIFEST_KEY || DEFAULT_RUNTIME_MANIFEST_KEY,
     skipPublicVerification: false,
+    uploadConcurrency: DEFAULT_UPLOAD_CONCURRENCY,
+    cachePath: DEFAULT_CACHE_PATH,
+    maxUploadBytes: DEFAULT_MAX_UPLOAD_BYTES,
     wranglerConfig: "apps/client/wrangler.toml",
   };
 
@@ -49,6 +56,12 @@ function parseArgs(argv) {
       args.publicVerifyDelayMs = Number(argv[++i]);
     } else if (arg === "--public-verify-timeout-ms") {
       args.publicVerifyTimeoutMs = Number(argv[++i]);
+    } else if (arg === "--upload-concurrency") {
+      args.uploadConcurrency = Number(argv[++i]);
+    } else if (arg === "--cache-path") {
+      args.cachePath = argv[++i];
+    } else if (arg === "--max-upload-mb") {
+      args.maxUploadBytes = Math.round(Number(argv[++i]) * 1024 * 1024);
     } else if (arg === "--dry-run") {
       args.dryRun = true;
     } else if (arg === "--skip-public-verification") {
@@ -79,6 +92,15 @@ function parseArgs(argv) {
   if (!Number.isFinite(args.publicVerifyTimeoutMs) || args.publicVerifyTimeoutMs < 1) {
     throw new Error("`--public-verify-timeout-ms` must be a positive number.");
   }
+  if (!Number.isFinite(args.uploadConcurrency) || args.uploadConcurrency < 1) {
+    throw new Error("`--upload-concurrency` must be a positive number.");
+  }
+  if (!args.cachePath) {
+    throw new Error("`--cache-path` must not be empty.");
+  }
+  if (!Number.isFinite(args.maxUploadBytes) || args.maxUploadBytes < 1) {
+    throw new Error("`--max-upload-mb` must be a positive number.");
+  }
 
   return args;
 }
@@ -98,6 +120,9 @@ Options:
   --public-verify-attempts <n>   Retry count for public URL checks (default: ${DEFAULT_PUBLIC_VERIFY_ATTEMPTS})
   --public-verify-delay-ms <n>   Delay between public URL checks (default: ${DEFAULT_PUBLIC_VERIFY_DELAY_MS})
   --public-verify-timeout-ms <n> Timeout per public URL check (default: ${DEFAULT_PUBLIC_VERIFY_TIMEOUT_MS})
+  --upload-concurrency <n>       Concurrent upload workers (default: ${DEFAULT_UPLOAD_CONCURRENCY})
+  --cache-path <path>            Cache file for object checksums (default: ${DEFAULT_CACHE_PATH})
+  --max-upload-mb <n>            Skip single assets larger than this size (default: ${Math.round(DEFAULT_MAX_UPLOAD_BYTES / 1024 / 1024)})
   --skip-public-verification     Skip GET-based public URL checks after upload
   --dry-run                      Print the planned upload set without uploading
 `);
@@ -164,6 +189,12 @@ function walkFiles(dirPath, files = []) {
   return files;
 }
 
+function md5ForFile(filePath) {
+  const hash = crypto.createHash("md5");
+  hash.update(fs.readFileSync(filePath));
+  return hash.digest("hex");
+}
+
 function toPublicUrl(publicBaseUrl, key) {
   const normalizedBase = publicBaseUrl.replace(/\/+$/, "");
   const encodedKey = key
@@ -194,6 +225,8 @@ function buildAssetUploadSet(repoRoot, options) {
     absolutePath,
     bucketKey: path.posix.join("assets", path.relative(clientAssetsRoot, absolutePath).split(path.sep).join("/")),
     contentType: contentTypeFor(absolutePath),
+    fileSizeBytes: fs.statSync(absolutePath).size,
+    checksum: md5ForFile(absolutePath),
   }));
 
   uploads.push({
@@ -202,6 +235,8 @@ function buildAssetUploadSet(repoRoot, options) {
     absolutePath: runtimeManifestPath,
     bucketKey: options.runtimeManifestKey,
     contentType: "application/json; charset=utf-8",
+    fileSizeBytes: fs.statSync(runtimeManifestPath).size,
+    checksum: md5ForFile(runtimeManifestPath),
   });
 
   uploads.push({
@@ -210,9 +245,60 @@ function buildAssetUploadSet(repoRoot, options) {
     absolutePath: canonicalManifestPath,
     bucketKey: options.canonicalManifestKey,
     contentType: "application/json; charset=utf-8",
+    fileSizeBytes: fs.statSync(canonicalManifestPath).size,
+    checksum: md5ForFile(canonicalManifestPath),
   });
 
   return uploads;
+}
+
+function loadUploadCache(cachePath) {
+  if (!fs.existsSync(cachePath)) return {};
+  try {
+    const parsed = JSON.parse(fs.readFileSync(cachePath, "utf8"));
+    if (parsed && typeof parsed === "object") {
+      return parsed;
+    }
+  } catch {
+    // Ignore malformed cache and rebuild it.
+  }
+  return {};
+}
+
+function saveUploadCache(cachePath, cache) {
+  fs.writeFileSync(cachePath, `${JSON.stringify(cache, null, 2)}\n`, "utf8");
+}
+
+function shouldSkipByPath(bucketKey) {
+  return bucketKey.includes("/test-assets/") || bucketKey.includes("/__tests__/");
+}
+
+function partitionUploads(uploads, cache, options) {
+  const toUpload = [];
+  const skippedUnchanged = [];
+  const skippedFiltered = [];
+  const skippedOversize = [];
+
+  for (const upload of uploads) {
+    if (upload.kind === "asset" && shouldSkipByPath(upload.bucketKey)) {
+      skippedFiltered.push(upload);
+      continue;
+    }
+    if (upload.kind === "asset" && upload.fileSizeBytes > options.maxUploadBytes) {
+      skippedOversize.push(upload);
+      continue;
+    }
+
+    const cachedChecksum = cache[upload.bucketKey];
+    if (cachedChecksum && cachedChecksum === upload.checksum) {
+      skippedUnchanged.push(upload);
+      continue;
+    }
+
+    toUpload.push(upload);
+  }
+
+  return { toUpload, skippedUnchanged, skippedFiltered, skippedOversize };
 }
 
 function wranglerArgs(configPath, objectPath, filePath, contentType) {
@@ -234,7 +320,10 @@ function wranglerArgs(configPath, objectPath, filePath, contentType) {
 }
 
 function uploadFile(configPath, bucket, upload, dryRun) {
-  if (dryRun) return;
+  if (dryRun) {
+    console.log(`DRY RUN upload: ${upload.bucketKey}`);
+    return;
+  }
   runCommand("npm", [
     "--prefix",
     "apps/client",
@@ -243,6 +332,22 @@ function uploadFile(configPath, bucket, upload, dryRun) {
     "--",
     ...wranglerArgs(configPath, `${bucket}/${upload.bucketKey}`, upload.absolutePath, upload.contentType),
   ]);
+  console.log(`Uploaded: ${upload.bucketKey}`);
+}
+
+async function uploadFilesParallel(configPath, bucket, uploads, options) {
+  if (uploads.length === 0) return;
+
+  let index = 0;
+  const workers = new Array(Math.min(options.uploadConcurrency, uploads.length)).fill(null).map(async () => {
+    while (index < uploads.length) {
+      const currentIndex = index;
+      index += 1;
+      uploadFile(configPath, bucket, uploads[currentIndex], options.dryRun);
+    }
+  });
+
+  await Promise.all(workers);
 }
 
 function sleep(ms) {
@@ -315,25 +420,41 @@ async function main() {
   const options = parseArgs(process.argv.slice(2));
   const repoRoot = resolveRepoRoot();
   const wranglerConfigPath = path.resolve(repoRoot, options.wranglerConfig);
+  const cachePath = path.resolve(repoRoot, options.cachePath);
+  const cache = loadUploadCache(cachePath);
   const uploads = buildAssetUploadSet(repoRoot, options);
+  const { toUpload, skippedUnchanged, skippedFiltered, skippedOversize } = partitionUploads(uploads, cache, options);
+  const nextCache = { ...cache };
 
-  for (const upload of uploads) {
-    uploadFile(wranglerConfigPath, options.bucket, upload, options.dryRun);
+  await uploadFilesParallel(wranglerConfigPath, options.bucket, toUpload, options);
+  for (const upload of toUpload) {
+    nextCache[upload.bucketKey] = upload.checksum;
   }
+  if (!options.dryRun) saveUploadCache(cachePath, nextCache);
 
-  await verifyUploads(uploads, options);
+  await verifyUploads(toUpload, options);
 
   console.log(`Bucket: ${options.bucket}`);
   console.log(`Public base URL: ${options.publicBaseUrl}`);
   console.log(`Wrangler config: ${relativeToRepo(repoRoot, wranglerConfigPath)}`);
   console.log(`Files prepared: ${uploads.length}`);
+  console.log(`Files uploaded: ${toUpload.length}`);
+  console.log(`Files skipped (unchanged): ${skippedUnchanged.length}`);
+  console.log(`Files skipped (filtered): ${skippedFiltered.length}`);
+  console.log(`Files skipped (oversize): ${skippedOversize.length}`);
+  console.log(`Upload concurrency: ${options.uploadConcurrency}`);
+  console.log(`Cache file: ${relativeToRepo(repoRoot, cachePath)}`);
   console.log(`Dry run: ${options.dryRun ? "yes" : "no"}`);
 }
 
-try {
-  await main();
-  process.exit(0);
-} catch (error) {
-  console.error(String(error.message || error));
-  process.exit(1);
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    await main();
+    process.exit(0);
+  } catch (error) {
+    console.error(String(error.message || error));
+    process.exit(1);
+  }
 }
+
+export { buildAssetUploadSet, loadUploadCache, md5ForFile, partitionUploads, saveUploadCache, shouldSkipByPath };

--- a/scripts/upload-runtime-assets.test.mjs
+++ b/scripts/upload-runtime-assets.test.mjs
@@ -1,0 +1,72 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { loadUploadCache, md5ForFile, partitionUploads, shouldSkipByPath } from "./upload-runtime-assets.mjs";
+
+test("shouldSkipByPath catches test asset paths", () => {
+  assert.equal(shouldSkipByPath("assets/test-assets/tong_prores_alpha.mov"), true);
+  assert.equal(shouldSkipByPath("assets/characters/tong/tong_neutral.png"), false);
+});
+
+test("loadUploadCache returns empty object when cache missing or malformed", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "tong-upload-cache-"));
+  const missingPath = path.join(tempDir, "missing.json");
+  assert.deepEqual(loadUploadCache(missingPath), {});
+
+  const malformedPath = path.join(tempDir, "malformed.json");
+  fs.writeFileSync(malformedPath, "{bad json", "utf8");
+  assert.deepEqual(loadUploadCache(malformedPath), {});
+});
+
+test("md5ForFile returns stable checksum", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "tong-upload-md5-"));
+  const filePath = path.join(tempDir, "a.txt");
+  fs.writeFileSync(filePath, "tong", "utf8");
+  assert.equal(md5ForFile(filePath), "fbd32c35bb4c8d46f8fc02a274abf1ef");
+});
+
+test("partitionUploads skips unchanged, test files, and oversize assets", () => {
+  const uploads = [
+    {
+      kind: "asset",
+      bucketKey: "assets/characters/tong/tong_neutral.png",
+      checksum: "same",
+      fileSizeBytes: 10,
+    },
+    {
+      kind: "asset",
+      bucketKey: "assets/test-assets/tong_prores_alpha.mov",
+      checksum: "new-a",
+      fileSizeBytes: 10,
+    },
+    {
+      kind: "asset",
+      bucketKey: "assets/characters/tong/huge.png",
+      checksum: "new-b",
+      fileSizeBytes: 50,
+    },
+    {
+      kind: "runtime-manifest",
+      bucketKey: "runtime-assets/manifest.json",
+      checksum: "new-c",
+      fileSizeBytes: 1,
+    },
+  ];
+
+  const result = partitionUploads(
+    uploads,
+    {
+      "assets/characters/tong/tong_neutral.png": "same",
+    },
+    { maxUploadBytes: 25 },
+  );
+
+  assert.equal(result.toUpload.length, 1);
+  assert.equal(result.toUpload[0].bucketKey, "runtime-assets/manifest.json");
+  assert.equal(result.skippedUnchanged.length, 1);
+  assert.equal(result.skippedFiltered.length, 1);
+  assert.equal(result.skippedOversize.length, 1);
+});


### PR DESCRIPTION
### Motivation

- Reduce unnecessary Cloudflare R2 uploads by skipping unchanged files and avoid long deploys caused by reuploading all assets.  
- Prevent test/dev files from leaking into production asset bundles and guard against single oversized objects that block CF deploys.  
- Speed up uploads by introducing concurrency and provide a reproducible, testable contract for the upload pipeline while leaving heavy image conversions (PNG → WebP) for a follow-up. 

### Description

- Implemented a checksum-backed diff cache and per-file MD5 checks in `scripts/upload-runtime-assets.mjs` (configurable cache path, default `.r2-upload-cache.json`).
- Added upload partitioning and guards (`partitionUploads`) to skip `test-assets`/`__tests__` paths and to skip single files larger than a configurable `--max-upload-mb` threshold (default 25MB).
- Added concurrent uploader worker pool (`--upload-concurrency`, default 6) and a dry-run mode that reports uploaded/skipped counts; added import guard so the module can be unit-tested without executing main upload logic.  
- Added unit/contract tests in `scripts/upload-runtime-assets.test.mjs` covering cache load, checksum stability, and partitioning behavior, and added `.r2-upload-cache.json` to `.gitignore`.

### Testing

- Ran the functional QA validate flow: initial validation reproduced the lack of diffing and sequential uploads and recorded portability as `repo-only` with no remote dependencies.  
- Added and ran unit tests with `node --test scripts/upload-runtime-assets.test.mjs`, which passed (tests for cache loading, `md5ForFile`, path filtering, and partitioning all succeeded).  
- Exercised the uploader in dry-run mode to verify behavior: `node scripts/upload-runtime-assets.mjs --dry-run --cache-path /tmp/r2-upload-cache-168.json --skip-public-verification` produced expected `Files uploaded`/`Files skipped` counts, and reseeding the cache produced `Files uploaded: 0` with unchanged files skipped.  
- Verified filter and oversize guards with synthetic files (1MB test asset and a 26MB oversize file) in `apps/client/public/assets` and confirmed `skipped (filtered)` and `skipped (oversize)` counts in a dry-run; note that real `wrangler` network uploads were not executed in this environment because `CLOUDFLARE_API_TOKEN` was not available.  

Reviewer-visible evidence

- QA publish / issue update: https://github.com/erniesg/tong/issues/168#issuecomment-4275506024

Scope

- This PR implements diff-only uploads, parallel uploads, and test/oversize exclusion guards but does not perform bulk image conversion from PNG → WebP (left for a follow-up work item).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e48ef00bb4832aa7141826cdefef56)