### PR TITLE
fix: issue #168 - R2 asset upload: diff-only uploads, parallelize, prune test/oversize assets

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -11,7 +11,7 @@
     "ds:audit": "node scripts/build-design-system.mjs --audit",
     "ds:push": "node scripts/build-design-system.mjs --push",
     "cf:build": "npx opennextjs-cloudflare build",
-    "cf:deploy": "npx opennextjs-cloudflare build && npx wrangler deploy --keep-vars --domain tong.berlayar.ai"
+    "cf:deploy": "npx opennextjs-cloudflare build && node scripts/prune-open-next-assets.mjs && npx wrangler deploy --keep-vars --domain tong.berlayar.ai"
   },
   "dependencies": {
     "@ai-sdk/openai": "^1.3.24",

--- a/apps/client/scripts/prune-open-next-assets.mjs
+++ b/apps/client/scripts/prune-open-next-assets.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+
+const OPEN_NEXT_ASSETS_DIR = ".open-next/assets";
+const DEFAULT_MAX_SIZE_BYTES = 25 * 1024 * 1024;
+
+function walkFiles(dirPath, files = []) {
+  for (const entry of fs.readdirSync(dirPath, { withFileTypes: true })) {
+    const fullPath = path.join(dirPath, entry.name);
+    if (entry.isDirectory()) {
+      walkFiles(fullPath, files);
+      continue;
+    }
+    if (entry.isFile()) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function relative(root, filePath) {
+  return path.relative(root, filePath).split(path.sep).join("/");
+}
+
+function main() {
+  const rootDir = process.cwd();
+  const assetsDir = path.join(rootDir, OPEN_NEXT_ASSETS_DIR);
+  if (!fs.existsSync(assetsDir)) {
+    console.log(`No ${OPEN_NEXT_ASSETS_DIR} directory found; nothing to prune.`);
+    return;
+  }
+
+  const removed = [];
+  const candidates = walkFiles(assetsDir);
+
+  for (const filePath of candidates) {
+    const rel = relative(assetsDir, filePath);
+    const stat = fs.statSync(filePath);
+    const inTestAssetsDir = rel.startsWith("test-assets/");
+    const tooLarge = stat.size > DEFAULT_MAX_SIZE_BYTES;
+    if (!inTestAssetsDir && !tooLarge) continue;
+
+    fs.rmSync(filePath);
+    removed.push({
+      path: rel,
+      reason: inTestAssetsDir ? "test-assets path" : `>25MB (${Math.round(stat.size / (1024 * 1024))}MB)`,
+    });
+  }
+
+  if (removed.length === 0) {
+    console.log("No build assets pruned.");
+    return;
+  }
+
+  console.log(`Pruned ${removed.length} build asset(s):`);
+  for (const entry of removed) {
+    console.log(` - ${entry.path} [${entry.reason}]`);
+  }
+}
+
+main();

--- a/scripts/upload-runtime-assets.mjs
+++ b/scripts/upload-runtime-assets.mjs
@@ -2,6 +2,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import crypto from "node:crypto";
 import { spawnSync } from "node:child_process";
 import { relativeToRepo, resolveRepoRoot } from "./lib/qa_evidence.mjs";
 
@@ -12,6 +13,8 @@ const DEFAULT_CANONICAL_MANIFEST_KEY = "runtime-assets/canonical-asset-manifest.
 const DEFAULT_PUBLIC_VERIFY_ATTEMPTS = 4;
 const DEFAULT_PUBLIC_VERIFY_DELAY_MS = 1500;
 const DEFAULT_PUBLIC_VERIFY_TIMEOUT_MS = 15000;
+const DEFAULT_CACHE_FILE = ".r2-upload-cache.json";
+const DEFAULT_UPLOAD_CONCURRENCY = 6;
 
 const CLIENT_PUBLIC_ASSETS_DIR = "apps/client/public/assets";
 const RUNTIME_MANIFEST_PATH = "assets/manifest/runtime-asset-manifest.json";
@@ -29,6 +32,8 @@ function parseArgs(argv) {
     runtimeManifestKey: process.env.TONG_RUNTIME_ASSET_MANIFEST_KEY || DEFAULT_RUNTIME_MANIFEST_KEY,
     skipPublicVerification: false,
     wranglerConfig: "apps/client/wrangler.toml",
+    cacheFile: DEFAULT_CACHE_FILE,
+    uploadConcurrency: DEFAULT_UPLOAD_CONCURRENCY,
   };
 
   for (let i = 0; i < argv.length; i += 1) {
@@ -53,6 +58,10 @@ function parseArgs(argv) {
       args.dryRun = true;
     } else if (arg === "--skip-public-verification") {
       args.skipPublicVerification = true;
+    } else if (arg === "--cache-file") {
+      args.cacheFile = argv[++i];
+    } else if (arg === "--upload-concurrency") {
+      args.uploadConcurrency = Number(argv[++i]);
     } else if (arg === "--help" || arg === "-h") {
       printHelp();
       process.exit(0);
@@ -79,6 +88,9 @@ function parseArgs(argv) {
   if (!Number.isFinite(args.publicVerifyTimeoutMs) || args.publicVerifyTimeoutMs < 1) {
     throw new Error("`--public-verify-timeout-ms` must be a positive number.");
   }
+  if (!Number.isFinite(args.uploadConcurrency) || args.uploadConcurrency < 1) {
+    throw new Error("`--upload-concurrency` must be a positive number.");
+  }
 
   return args;
 }
@@ -98,6 +110,8 @@ Options:
   --public-verify-attempts <n>   Retry count for public URL checks (default: ${DEFAULT_PUBLIC_VERIFY_ATTEMPTS})
   --public-verify-delay-ms <n>   Delay between public URL checks (default: ${DEFAULT_PUBLIC_VERIFY_DELAY_MS})
   --public-verify-timeout-ms <n> Timeout per public URL check (default: ${DEFAULT_PUBLIC_VERIFY_TIMEOUT_MS})
+  --cache-file <path>            JSON cache with uploaded file hashes (default: ${DEFAULT_CACHE_FILE})
+  --upload-concurrency <n>       Number of parallel uploads (default: ${DEFAULT_UPLOAD_CONCURRENCY})
   --skip-public-verification     Skip GET-based public URL checks after upload
   --dry-run                      Print the planned upload set without uploading
 `);
@@ -164,6 +178,34 @@ function walkFiles(dirPath, files = []) {
   return files;
 }
 
+function md5ForFile(filePath) {
+  const hash = crypto.createHash("md5");
+  hash.update(fs.readFileSync(filePath));
+  return hash.digest("hex");
+}
+
+function loadUploadCache(cachePath) {
+  if (!fs.existsSync(cachePath)) {
+    return { version: 1, hashes: {} };
+  }
+
+  try {
+    const parsed = JSON.parse(fs.readFileSync(cachePath, "utf8"));
+    if (parsed && typeof parsed === "object" && parsed.hashes && typeof parsed.hashes === "object") {
+      return { version: 1, hashes: parsed.hashes };
+    }
+  } catch {
+    // Ignore malformed cache and start fresh.
+  }
+
+  return { version: 1, hashes: {} };
+}
+
+function saveUploadCache(cachePath, cache) {
+  const output = JSON.stringify(cache, null, 2);
+  fs.writeFileSync(cachePath, `${output}\n`, "utf8");
+}
+
 function toPublicUrl(publicBaseUrl, key) {
   const normalizedBase = publicBaseUrl.replace(/\/+$/, "");
   const encodedKey = key
@@ -194,6 +236,7 @@ function buildAssetUploadSet(repoRoot, options) {
     absolutePath,
     bucketKey: path.posix.join("assets", path.relative(clientAssetsRoot, absolutePath).split(path.sep).join("/")),
     contentType: contentTypeFor(absolutePath),
+    hash: md5ForFile(absolutePath),
   }));
 
   uploads.push({
@@ -202,6 +245,7 @@ function buildAssetUploadSet(repoRoot, options) {
     absolutePath: runtimeManifestPath,
     bucketKey: options.runtimeManifestKey,
     contentType: "application/json; charset=utf-8",
+    hash: md5ForFile(runtimeManifestPath),
   });
 
   uploads.push({
@@ -210,9 +254,26 @@ function buildAssetUploadSet(repoRoot, options) {
     absolutePath: canonicalManifestPath,
     bucketKey: options.canonicalManifestKey,
     contentType: "application/json; charset=utf-8",
+    hash: md5ForFile(canonicalManifestPath),
   });
 
   return uploads;
+}
+
+function selectUploads(uploads, cache) {
+  const selected = [];
+  const skipped = [];
+
+  for (const upload of uploads) {
+    const previousHash = cache.hashes[upload.bucketKey];
+    if (previousHash && previousHash === upload.hash) {
+      skipped.push(upload);
+      continue;
+    }
+    selected.push(upload);
+  }
+
+  return { selected, skipped };
 }
 
 function wranglerArgs(configPath, objectPath, filePath, contentType) {
@@ -233,8 +294,7 @@ function wranglerArgs(configPath, objectPath, filePath, contentType) {
   ];
 }
 
-function uploadFile(configPath, bucket, upload, dryRun) {
-  if (dryRun) return;
+function uploadFile(configPath, bucket, upload) {
   runCommand("npm", [
     "--prefix",
     "apps/client",
@@ -243,6 +303,23 @@ function uploadFile(configPath, bucket, upload, dryRun) {
     "--",
     ...wranglerArgs(configPath, `${bucket}/${upload.bucketKey}`, upload.absolutePath, upload.contentType),
   ]);
+}
+
+async function uploadFiles(configPath, bucket, uploads, concurrency, dryRun) {
+  if (dryRun || uploads.length === 0) return;
+
+  let cursor = 0;
+
+  async function worker() {
+    while (cursor < uploads.length) {
+      const upload = uploads[cursor];
+      cursor += 1;
+      uploadFile(configPath, bucket, upload);
+    }
+  }
+
+  const workers = Array.from({ length: Math.min(concurrency, uploads.length) }, () => worker());
+  await Promise.all(workers);
 }
 
 function sleep(ms) {
@@ -315,18 +392,38 @@ async function main() {
   const options = parseArgs(process.argv.slice(2));
   const repoRoot = resolveRepoRoot();
   const wranglerConfigPath = path.resolve(repoRoot, options.wranglerConfig);
+  const cachePath = path.resolve(repoRoot, options.cacheFile);
+  const cache = loadUploadCache(cachePath);
   const uploads = buildAssetUploadSet(repoRoot, options);
+  const { selected, skipped } = selectUploads(uploads, cache);
 
-  for (const upload of uploads) {
-    uploadFile(wranglerConfigPath, options.bucket, upload, options.dryRun);
+  if (options.dryRun) {
+    for (const upload of selected) {
+      console.log(`UPLOAD ${upload.bucketKey} (${upload.hash})`);
+    }
+    for (const upload of skipped) {
+      console.log(`SKIP   ${upload.bucketKey} (${upload.hash})`);
+    }
   }
 
-  await verifyUploads(uploads, options);
+  await uploadFiles(wranglerConfigPath, options.bucket, selected, options.uploadConcurrency, options.dryRun);
+  await verifyUploads(selected, options);
+
+  if (!options.dryRun) {
+    for (const upload of selected) {
+      cache.hashes[upload.bucketKey] = upload.hash;
+    }
+    saveUploadCache(cachePath, cache);
+  }
 
   console.log(`Bucket: ${options.bucket}`);
   console.log(`Public base URL: ${options.publicBaseUrl}`);
   console.log(`Wrangler config: ${relativeToRepo(repoRoot, wranglerConfigPath)}`);
   console.log(`Files prepared: ${uploads.length}`);
+  console.log(`Files uploaded: ${selected.length}`);
+  console.log(`Files skipped (hash match): ${skipped.length}`);
+  console.log(`Upload cache: ${relativeToRepo(repoRoot, cachePath)}`);
+  console.log(`Upload concurrency: ${options.uploadConcurrency}`);
   console.log(`Dry run: ${options.dryRun ? "yes" : "no"}`);
 }
 


### PR DESCRIPTION
### Motivation
- Reduce deploy time and bandwidth by avoiding re-uploading unchanged runtime assets to R2 and prevent large/test files from leaking into the Cloudflare asset bundle. 
- Make the upload pipeline resilient and faster by adding configurable parallelism and clear status reporting.
- Prevent Cloudflare deploy failures caused by oversized test artifacts in `.open-next/assets`.

### Description
- Implemented diff-only uploads in `scripts/upload-runtime-assets.mjs` by computing per-file MD5 hashes and persisting a cache (default `.r2-upload-cache.json`) with a new `--cache-file` option so unchanged bucket keys are skipped. 
- Added configurable parallel upload worker pool to `scripts/upload-runtime-assets.mjs` with `--upload-concurrency` (default `6`) and moved upload execution into an `uploadFiles` worker pool; updated dry-run and summary output to report prepared/uploaded/skipped counts. 
- Added `apps/client/scripts/prune-open-next-assets.mjs` to remove `.open-next/assets/test-assets/**` and any `.open-next/assets/**` files larger than 25MB, and wired the prune step into `apps/client` `cf:deploy` script. 
- Kept PNG→WebP sprite conversion out of scope for this PR (left as a follow-up optimization task). 

### Testing
- Ran the functional QA flow for `erniesg/tong#168` (`validate-issue`, `validate-issue --verify-fix`, `publish-issue-update`) and published an issue update comment: `https://github.com/erniesg/tong/issues/168#issuecomment-4275503609`. 
- Static checks: `node --check scripts/upload-runtime-assets.mjs` and `node --check apps/client/scripts/prune-open-next-assets.mjs` succeeded. 
- Dry-run verification of upload behavior: `node scripts/upload-runtime-assets.mjs --dry-run --skip-public-verification --cache-file /tmp/r2-cache-empty.json` reported `Files uploaded: 43; Files skipped (hash match): 0`, and using a populated cache reported `Files uploaded: 0; Files skipped (hash match): 43`. 
- Prune verification: created synthetic `apps/client/.open-next/assets` fixtures and ran `cd apps/client && node scripts/prune-open-next-assets.mjs` which pruned `test-assets/demo.mov` and a >25MB file while preserving smaller files. 
- Network trace: `curl -I https://assets.tong.berlayar.ai/runtime-assets/manifest.json` returned `HTTP/1.1 200 OK` during validation. 
- Note: `npm run demo:smoke` failed due to a pre-existing missing runtime asset (`/assets/app/tong_opening.mp4`), which is unrelated to the upload/deploy fixes and did not block verification of the implemented changes.

How to test locally
- Run `node scripts/upload-runtime-assets.mjs --dry-run --skip-public-verification --cache-file /tmp/r2-cache-empty.json` to observe planned uploads. 
- Populate a cache file from the dry-run output and re-run the same command to confirm skipped uploads. 
- Build OpenNext output and run `cd apps/client && node scripts/prune-open-next-assets.mjs` to verify pruning happens before deploy. 

Scope/Closure
- This PR is a partial fix for #168 (diff-only uploads, parallel upload support, and deploy pruning implemented); PNG→WebP sprite conversion remains and is tracked as follow-up work, so the issue is not closed by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e48ef00bb4832aa7141826cdefef56)