### PR TITLE
fix: issue #190 - [2.1] Shanghai location + vocabulary

### DIFF
--- a/apps/client/lib/content/cities.ts
+++ b/apps/client/lib/content/cities.ts
@@ -1,0 +1,38 @@
+export interface CityRegistryEntry {
+  id: 'seoul' | 'tokyo' | 'shanghai';
+  name: {
+    en: string;
+    local: string;
+  };
+  language: 'ko' | 'ja' | 'zh';
+  locationIds: string[];
+}
+
+export const CITY_REGISTRY: Record<CityRegistryEntry['id'], CityRegistryEntry> = {
+  seoul: {
+    id: 'seoul',
+    name: { en: 'Seoul', local: '서울' },
+    language: 'ko',
+    locationIds: ['food_street', 'cafe', 'convenience_store', 'subway_hub', 'practice_studio'],
+  },
+  tokyo: {
+    id: 'tokyo',
+    name: { en: 'Tokyo', local: '東京' },
+    language: 'ja',
+    locationIds: ['train_station', 'izakaya', 'konbini', 'tea_house', 'ramen_shop'],
+  },
+  shanghai: {
+    id: 'shanghai',
+    name: { en: 'Shanghai', local: '上海' },
+    language: 'zh',
+    locationIds: ['metro_station', 'bbq_stall', 'convenience_store', 'milk_tea_shop', 'xiaolongbao'],
+  },
+};
+
+export function getCityRegistryEntry(cityId: CityRegistryEntry['id']): CityRegistryEntry {
+  return CITY_REGISTRY[cityId];
+}
+
+export function getCitiesRegistry(): CityRegistryEntry[] {
+  return Object.values(CITY_REGISTRY);
+}

--- a/apps/client/lib/content/locations.ts
+++ b/apps/client/lib/content/locations.ts
@@ -1,5 +1,6 @@
 import type { Location } from '../types/objectives';
 import { POJANGMACHA } from './pojangmacha';
+import { SHANGHAI_XIAOLONGBAO } from './shanghai/location';
 
 /**
  * Location registry mapping "cityId:locationId" → Location object.
@@ -187,27 +188,8 @@ const LOCATION_REGISTRY: Record<string, Location> = {
     grammarTargets: [],
   },
 
-  'shanghai:dumpling_shop': {
-    id: 'dumpling_shop',
-    cityId: 'shanghai',
-    name: { en: 'Dumpling Shop', zh: '小笼包店' },
-    domain: 'restaurant',
-    order: 4,
-    backgroundImageUrl: '',
-    ambientDescription: 'A busy xiaolongbao restaurant with bamboo steamers stacked high.',
-    levels: [
-      {
-        level: 0,
-        name: 'Dumpling Feast',
-        description: 'Order dumplings at a traditional restaurant',
-        objectives: [],
-        estimatedSessionMinutes: 10,
-        assessmentCriteria: { minAccuracy: 0.6, minItemsCompleted: 3, requiredObjectives: [] },
-      },
-    ],
-    vocabularyTargets: [],
-    grammarTargets: [],
-  },
+  'shanghai:dumpling_shop': SHANGHAI_XIAOLONGBAO,
+  'shanghai:xiaolongbao': SHANGHAI_XIAOLONGBAO,
 
   /* ── Tokyo stub locations ───────────────────────────────── */
   'tokyo:train_station': {
@@ -322,19 +304,24 @@ const LOCATION_REGISTRY: Record<string, Location> = {
 };
 
 /** Get a location by city and location ID. Returns null if not found. */
-export function getLocation(
-  cityId: string,
-  locationId: string,
-): Location | null {
-  return LOCATION_REGISTRY[`${cityId}:${locationId}`] ?? null;
+function resolveLocationKey(cityIdOrKey: string, locationId?: string): string {
+  return locationId ? `${cityIdOrKey}:${locationId}` : cityIdOrKey;
 }
 
-/** Get a location or fall back to POJANGMACHA. */
+/** Get a location by city and location ID, or by a single composite key. Returns null if not found. */
+export function getLocation(
+  cityIdOrKey: string,
+  locationId?: string,
+): Location | null {
+  return LOCATION_REGISTRY[resolveLocationKey(cityIdOrKey, locationId)] ?? null;
+}
+
+/** Get a location or fall back to POJANGMACHA. Supports city/location args or a composite key. */
 export function getLocationOrDefault(
-  cityId: string,
-  locationId: string,
+  cityIdOrKey: string,
+  locationId?: string,
 ): Location {
-  return LOCATION_REGISTRY[`${cityId}:${locationId}`] ?? POJANGMACHA;
+  return LOCATION_REGISTRY[resolveLocationKey(cityIdOrKey, locationId)] ?? POJANGMACHA;
 }
 
 /** Register a location in the registry. */

--- a/apps/client/lib/content/shanghai/location.ts
+++ b/apps/client/lib/content/shanghai/location.ts
@@ -1,0 +1,230 @@
+import { runtimeAssetUrl } from '../../runtime-assets';
+import type { GrammarTarget, LearningObjective, Location, VocabularyTarget } from '../../types/objectives';
+
+const LEVEL_0_OBJECTIVES: LearningObjective[] = [
+  {
+    id: 'zh-sh-xlb-script-core-hanzi',
+    levelNumber: 0,
+    category: 'script',
+    title: 'Recognize core hanzi for menu decisions',
+    description: 'Read and identify 方, 案, 不, 一, 样, 愿, 意, 装, 小, 笼, 包 in context.',
+    targetItems: ['方', '案', '不', '一', '样', '愿', '意', '装', '小', '笼', '包'],
+    targetCount: 11,
+    assessmentThreshold: 0.85,
+    prerequisites: [],
+    tags: ['hanzi', 'script', 'shanghai', 'xiaolongbao'],
+  },
+];
+
+const LEVEL_1_OBJECTIVES: LearningObjective[] = [
+  {
+    id: 'zh-sh-xlb-pron-tone-pairs',
+    levelNumber: 1,
+    category: 'pronunciation',
+    title: 'Practice key tone pairs',
+    description: "Drill fāng'àn (方案) and yuànyì (愿意) with stable tone production.",
+    targetItems: ["fāng'àn", 'yuànyì'],
+    targetCount: 2,
+    assessmentThreshold: 0.8,
+    prerequisites: ['zh-sh-xlb-script-core-hanzi'],
+    tags: ['pinyin', 'tones', 'tone-pairs'],
+  },
+  {
+    id: 'zh-sh-xlb-pron-minimal-pair-zhuang-pao',
+    levelNumber: 1,
+    category: 'pronunciation',
+    title: 'Disambiguate 装 and 跑',
+    description: 'Use minimal-pair listening and speaking drills to separate zhuāng vs pǎo.',
+    targetItems: ['装 (zhuāng)', '跑 (pǎo)'],
+    targetCount: 2,
+    assessmentThreshold: 0.8,
+    prerequisites: ['zh-sh-xlb-script-core-hanzi'],
+    tags: ['minimal-pairs', 'pronunciation', 'contrast'],
+  },
+];
+
+const LEVEL_2_OBJECTIVES: LearningObjective[] = [
+  {
+    id: 'zh-sh-xlb-vocab-menu-core',
+    levelNumber: 2,
+    category: 'vocabulary',
+    title: 'Use Shanghai dumpling-shop core vocabulary',
+    description: 'Apply food-stall vocabulary in ordering and recommendation exchanges.',
+    targetItems: ['方案', '愿意', '装', '不一样', '小笼包', '蟹壳黄', '阿姨', '犟', '本事', '接', '重要'],
+    targetCount: 11,
+    assessmentThreshold: 0.8,
+    prerequisites: ['zh-sh-xlb-pron-tone-pairs', 'zh-sh-xlb-pron-minimal-pair-zhuang-pao'],
+    tags: ['vocabulary', 'food', 'shanghai', 'dialogue'],
+  },
+];
+
+const LEVEL_3_OBJECTIVES: LearningObjective[] = [
+  {
+    id: 'zh-sh-xlb-gram-buhui-buyuanyi',
+    levelNumber: 3,
+    category: 'grammar',
+    title: 'Differentiate 不会 vs 不愿意',
+    description: 'Use inability vs unwillingness naturally in service and social interactions.',
+    targetItems: ['不会', '不愿意'],
+    targetCount: 2,
+    assessmentThreshold: 0.8,
+    prerequisites: ['zh-sh-xlb-vocab-menu-core'],
+    tags: ['grammar', 'modality'],
+  },
+  {
+    id: 'zh-sh-xlb-gram-formal-ni',
+    levelNumber: 3,
+    category: 'grammar',
+    title: 'Switch between 你 and 您',
+    description: 'Choose formal/informal second-person forms based on role and setting.',
+    targetItems: ['你', '您'],
+    targetCount: 2,
+    assessmentThreshold: 0.8,
+    prerequisites: ['zh-sh-xlb-vocab-menu-core'],
+    tags: ['grammar', 'register', 'politeness'],
+  },
+  {
+    id: 'zh-sh-xlb-gram-aspect-le',
+    levelNumber: 3,
+    category: 'grammar',
+    title: 'Use 了 for completed actions',
+    description: 'Use sentence-final and verb-complement 了 to express changes/completions.',
+    targetItems: ['了'],
+    targetCount: 1,
+    assessmentThreshold: 0.75,
+    prerequisites: ['zh-sh-xlb-vocab-menu-core'],
+    tags: ['grammar', 'aspect'],
+  },
+  {
+    id: 'zh-sh-xlb-gram-potential-bu-xia-qu',
+    levelNumber: 3,
+    category: 'grammar',
+    title: 'Use ~不下去 potential complement',
+    description: 'Express inability to continue with an action or state in context.',
+    targetItems: ['~不下去'],
+    targetCount: 1,
+    assessmentThreshold: 0.75,
+    prerequisites: ['zh-sh-xlb-vocab-menu-core'],
+    tags: ['grammar', 'complement', 'potential'],
+  },
+];
+
+const VOCABULARY_TARGETS: VocabularyTarget[] = [
+  { word: '方案', romanization: "fāng'àn", translation: 'plan', category: 'strategy', level: 2 },
+  { word: '愿意', romanization: 'yuànyì', translation: 'be willing to', category: 'attitude', level: 2 },
+  { word: '装', romanization: 'zhuāng', translation: 'to pretend; to pack', category: 'verb', level: 2 },
+  { word: '不一样', romanization: 'bù yíyàng', translation: 'different', category: 'adjective', level: 2 },
+  { word: '小笼包', romanization: 'xiǎolóngbāo', translation: 'soup dumpling', category: 'food', level: 2 },
+  { word: '蟹壳黄', romanization: 'xièkéhuáng', translation: 'sesame baked pastry', category: 'food', level: 2 },
+  { word: '阿姨', romanization: 'āyí', translation: 'auntie; polite address for middle-aged woman', category: 'person', level: 2 },
+  { word: '犟', romanization: 'jiàng', translation: 'stubborn', category: 'personality', level: 2 },
+  { word: '本事', romanization: 'běnshi', translation: 'ability; capability', category: 'ability', level: 2 },
+  { word: '接', romanization: 'jiē', translation: 'to receive; to pick up', category: 'verb', level: 2 },
+  { word: '重要', romanization: 'zhòngyào', translation: 'important', category: 'adjective', level: 2 },
+];
+
+const GRAMMAR_TARGETS: GrammarTarget[] = [
+  {
+    id: 'zh-gram-buhui-vs-buyuanyi',
+    pattern: '不会 vs 不愿意',
+    explanation: '不会 marks inability/lack of skill; 不愿意 marks unwillingness/choice.',
+    examples: [
+      { target: '我不会包小笼包。', translation: 'I cannot make xiaolongbao.' },
+      { target: '我不愿意装懂。', translation: "I'm not willing to pretend I understand." },
+    ],
+    level: 3,
+    locationId: 'xiaolongbao',
+  },
+  {
+    id: 'zh-gram-formality-ni-nin',
+    pattern: '你 / 您',
+    explanation: 'Use 您 for polite/formal address and 你 for neutral/informal conversation.',
+    examples: [
+      { target: '您要几笼小笼包？', translation: 'How many steamers would you like?' },
+      { target: '你愿意一起吃吗？', translation: 'Are you willing to eat together?' },
+    ],
+    level: 3,
+    locationId: 'xiaolongbao',
+  },
+  {
+    id: 'zh-gram-aspect-le',
+    pattern: '~了',
+    explanation: '了 indicates completed action or a change of state in context.',
+    examples: [
+      { target: '我点了蟹壳黄。', translation: 'I ordered sesame pastries.' },
+      { target: '人太多了。', translation: 'It has become too crowded.' },
+    ],
+    level: 3,
+    locationId: 'xiaolongbao',
+  },
+  {
+    id: 'zh-gram-potential-bu-xia-qu',
+    pattern: '~不下去',
+    explanation: 'Potential complement for not being able to continue an action.',
+    examples: [
+      { target: '太辣了，我吃不下去。', translation: "It's too spicy; I can't keep eating." },
+      { target: '太吵了，我听不下去。', translation: "It's too noisy; I can't keep listening." },
+    ],
+    level: 3,
+    locationId: 'xiaolongbao',
+  },
+];
+
+export const SHANGHAI_XIAOLONGBAO: Location = {
+  id: 'xiaolongbao',
+  cityId: 'shanghai',
+  name: { en: 'Xiaolongbao Shop', zh: '小笼包店' },
+  domain: 'restaurant',
+  order: 4,
+  backgroundImageUrl: runtimeAssetUrl('city.shanghai.location.dumpling-shop.backdrop.default'),
+  ambientDescription: 'A crowded Shanghai xiaolongbao shop with bamboo steamers, quick service, and lively table chatter.',
+  levels: [
+    {
+      level: 0,
+      name: 'SCRIPT',
+      description: 'Recognize core hanzi from the menu and dialogue cues.',
+      objectives: LEVEL_0_OBJECTIVES,
+      estimatedSessionMinutes: 12,
+      assessmentCriteria: { minAccuracy: 0.85, minItemsCompleted: 11, requiredObjectives: ['zh-sh-xlb-script-core-hanzi'] },
+    },
+    {
+      level: 1,
+      name: 'PRONUNCIATION',
+      description: 'Stabilize tones and minimal-pair contrasts for service dialogue.',
+      objectives: LEVEL_1_OBJECTIVES,
+      estimatedSessionMinutes: 14,
+      assessmentCriteria: {
+        minAccuracy: 0.8,
+        minItemsCompleted: 4,
+        requiredObjectives: ['zh-sh-xlb-pron-tone-pairs', 'zh-sh-xlb-pron-minimal-pair-zhuang-pao'],
+      },
+    },
+    {
+      level: 2,
+      name: 'VOCABULARY',
+      description: 'Deploy high-frequency dumpling-shop vocabulary in context.',
+      objectives: LEVEL_2_OBJECTIVES,
+      estimatedSessionMinutes: 18,
+      assessmentCriteria: { minAccuracy: 0.8, minItemsCompleted: 11, requiredObjectives: ['zh-sh-xlb-vocab-menu-core'] },
+    },
+    {
+      level: 3,
+      name: 'GRAMMAR',
+      description: 'Express ability, politeness, aspect, and continuation constraints accurately.',
+      objectives: LEVEL_3_OBJECTIVES,
+      estimatedSessionMinutes: 20,
+      assessmentCriteria: {
+        minAccuracy: 0.8,
+        minItemsCompleted: 4,
+        requiredObjectives: [
+          'zh-sh-xlb-gram-buhui-buyuanyi',
+          'zh-sh-xlb-gram-formal-ni',
+          'zh-sh-xlb-gram-aspect-le',
+          'zh-sh-xlb-gram-potential-bu-xia-qu',
+        ],
+      },
+    },
+  ],
+  vocabularyTargets: VOCABULARY_TARGETS,
+  grammarTargets: GRAMMAR_TARGETS,
+};

--- a/docs/shanghai/plan.md
+++ b/docs/shanghai/plan.md
@@ -1,0 +1,25 @@
+# Shanghai Content Plan
+
+## Issue 2.1 — Shanghai location + vocabulary
+
+Status: implemented in `apps/client/lib/content/shanghai/location.ts` and wired in the location + city registries.
+
+### Scope
+
+- Add Shanghai curriculum location `shanghai:xiaolongbao` (`小笼包店`) with full L0–L3 content.
+- Keep backward compatibility with existing `shanghai:dumpling_shop` references by aliasing both keys to the same location object.
+- Register Shanghai in a dedicated city registry.
+
+### Curriculum targets
+
+- **L0 (script):** 方, 案, 不, 一, 样, 愿, 意, 装, 小, 笼, 包
+- **L1 (pronunciation):** tone pairs (`方案 fāng'àn`, `愿意 yuànyì`) and `装/跑` minimal-pair drills
+- **L2 (vocabulary):** 方案, 愿意, 装, 不一样, 小笼包, 蟹壳黄, 阿姨, 犟, 本事, 接, 重要
+- **L3 (grammar):** 不会 vs 不愿意, formal/informal 你/您, 了 aspect, ~不下去 potential complement
+
+### Acceptance checks
+
+- `getLocationOrDefault('shanghai:xiaolongbao')` resolves to a populated location.
+- Shanghai is listed in `CITY_REGISTRY`.
+- L0–L3 objectives include stable IDs suitable for mastery tracking.
+- Backdrop asset path is populated via runtime asset key.


### PR DESCRIPTION
### Motivation
- Provide a first-pass, fully authored Shanghai curriculum location so the game can surface a populated `shanghai:xiaolongbao` (小笼包店) with L0–L3 objectives and vocabulary for Issue 2.1.
- Preserve backward compatibility for existing references by aliasing the prior `shanghai:dumpling_shop` key to the new location object.
- Ensure city-level registry presence so the world map and content generators can identify Shanghai as a target language pack.

### Description
- Added `apps/client/lib/content/shanghai/location.ts` which defines L0–L3 `LearningObjective` arrays, `vocabularyTargets`, and `grammarTargets`, and wires a runtime backdrop asset key via `runtimeAssetUrl`.
- Added `apps/client/lib/content/cities.ts` to expose a small `CITY_REGISTRY` and helpers so Shanghai is discoverable by city id and tooling.
- Updated `apps/client/lib/content/locations.ts` to import `SHANGHAI_XIAOLONGBAO`, alias both `shanghai:dumpling_shop` and `shanghai:xiaolongbao` to that object, and broadened `getLocation`/`getLocationOrDefault` to accept either composite keys or city+location args for compatibility.
- Added `docs/shanghai/plan.md` documenting Issue 2.1 scope, curriculum targets, and acceptance checks.

### Testing
- Functional QA: ran the repo QA flow for `erniesg/tong#190`: `validate-issue` reproduced the baseline gap and `validate-issue --verify-fix` verified static wiring but final acceptance is **blocked** because reviewer-visible temporal UI media could not be produced in this cloud run (see artifacts at `artifacts/qa-runs/functional-qa/erniesg-tong-190/`).
- Build checks: `npm --prefix apps/client run build` completed successfully, while `npm run demo:smoke` failed in this environment due to a missing runtime asset `'/assets/app/tong_opening.mp4'` (unrelated to the Shanghai curriculum data).
- Static verification: registry and curriculum greps passed (searches for `shanghai:xiaolongbao`, `shanghai:dumpling_shop`, objective IDs, and backdrop key); evidence saved to `artifacts/qa-runs/functional-qa/erniesg-tong-190/20260419T081836Z` and `.../20260419T082334Z`.
- How to test locally / follow-up steps: run `npm --prefix apps/client run build`, then start the app and exercise `/game?dev_intro=1&demo=...&qa_run_id=...&qa_trace=1` to capture reviewer-visible ordered frames (pre-action, input, stable post-action) showing Shanghai world map, opening `xiaolongbao` location, and L0–L3 objectives; attach the ordered frames or short GIF/video and the `window.__TONG_QA__` state export to this PR so the QA gates (temporal-capture, network-trace, console-state-trace) can be closed.

Note: This PR implements the static and registry work for `erniesg/tong#190` but does not close the issue because final reviewer-visible temporal UI evidence is still required before claiming full acceptance.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e48efb1020832aaddb334b862469b2)