### PR TITLE
feat: issue #157 Phase 1 — static export build + Worker route migrations

### DIFF
--- a/apps/client/next.config.mjs
+++ b/apps/client/next.config.mjs
@@ -25,9 +25,11 @@ const assetRemotePattern = buildAssetRemotePattern(
   process.env.NEXT_PUBLIC_TONG_ASSETS_BASE_URL || 'https://assets.tong.berlayar.ai',
 );
 
+const isStaticExportBuild = process.env.TONG_BUILD_MODE === 'static-export';
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  output: 'standalone',
+  output: isStaticExportBuild ? 'export' : 'standalone',
   reactStrictMode: true,
   experimental: {
     externalDir: true,
@@ -35,8 +37,11 @@ const nextConfig = {
   images: assetRemotePattern
     ? {
         remotePatterns: [assetRemotePattern],
+        unoptimized: isStaticExportBuild,
       }
-    : undefined,
+    : isStaticExportBuild
+      ? { unoptimized: true }
+      : undefined,
 };
 
 export default nextConfig;

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -11,7 +11,8 @@
     "ds:audit": "node scripts/build-design-system.mjs --audit",
     "ds:push": "node scripts/build-design-system.mjs --push",
     "cf:build": "npx opennextjs-cloudflare build",
-    "cf:deploy": "npx opennextjs-cloudflare build && node scripts/prune-open-next-assets.mjs && npx wrangler deploy --keep-vars --domain tong.berlayar.ai"
+    "cf:deploy": "npx opennextjs-cloudflare build && node scripts/prune-open-next-assets.mjs && npx wrangler deploy --keep-vars --domain tong.berlayar.ai",
+    "build:static": "node scripts/build-static.mjs"
   },
   "dependencies": {
     "@ai-sdk/openai": "^1.3.24",

--- a/apps/client/scripts/build-static.mjs
+++ b/apps/client/scripts/build-static.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const clientRoot = process.cwd();
+
+const staticBuildExclusions = [
+  {
+    source: path.join(clientRoot, 'app', 'api'),
+    parked: path.join(clientRoot, 'app', '__api_ssr_only__'),
+  },
+  {
+    source: path.join(clientRoot, 'app', 'playtest', '[id]'),
+    parked: path.join(clientRoot, 'app', 'playtest', '__id_ssr_only__'),
+  },
+];
+
+async function exists(target) {
+  try {
+    await fs.access(target);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function run(command, args, env) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: clientRoot,
+      stdio: 'inherit',
+      env,
+    });
+
+    child.on('exit', (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(new Error(`${command} ${args.join(' ')} exited with code ${code}`));
+    });
+    child.on('error', reject);
+  });
+}
+
+async function parkRouteForStaticBuild(entry) {
+  if (!(await exists(entry.source))) return false;
+  if (await exists(entry.parked)) {
+    throw new Error(`Static build staging path already exists: ${entry.parked}`);
+  }
+  await fs.rename(entry.source, entry.parked);
+  return true;
+}
+
+async function restoreRouteAfterBuild(entry, wasParked) {
+  if (!wasParked) return;
+  if (await exists(entry.source)) {
+    throw new Error(`Cannot restore staged path because destination already exists: ${entry.source}`);
+  }
+  await fs.rename(entry.parked, entry.source);
+}
+
+const env = {
+  ...process.env,
+  TONG_BUILD_MODE: 'static-export',
+};
+
+const parked = [];
+try {
+  for (const entry of staticBuildExclusions) {
+    const wasParked = await parkRouteForStaticBuild(entry);
+    parked.push({ entry, wasParked });
+  }
+
+  await run('npm', ['run', 'ds:build'], env);
+  await run('npx', ['next', 'build'], env);
+} finally {
+  for (const { entry, wasParked } of parked.reverse()) {
+    await restoreRouteAfterBuild(entry, wasParked);
+  }
+}

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -150,6 +150,29 @@ const CORS_HEADERS = {
   'Access-Control-Allow-Headers': 'Content-Type, x-demo-password',
 };
 
+const TRANSLATE_LANG_CODES: Record<string, string> = {
+  en: 'en',
+  zh: 'zh-CN',
+  ja: 'ja',
+  ko: 'ko',
+};
+
+async function translateViaGoogle(text: string, from: string, to: string): Promise<string> {
+  const sl = TRANSLATE_LANG_CODES[from] ?? from;
+  const tl = TRANSLATE_LANG_CODES[to] ?? to;
+  const url = `https://translate.googleapis.com/translate_a/single?client=gtx&sl=${sl}&tl=${tl}&dt=t&q=${encodeURIComponent(text)}`;
+
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Google Translate returned ${response.status}`);
+  }
+
+  const data = await response.json();
+  const segments = data?.[0] as Array<[string, ...unknown[]]> | undefined;
+  if (!segments) return text;
+  return segments.map((segment) => segment[0]).join('');
+}
+
 const DEFAULT_USER_ID = 'demo-user-1';
 const PROFICIENCY_RANK: Record<string, number> = {
   none: 0,
@@ -1742,6 +1765,35 @@ async function handleRequest(request: Request): Promise<Response> {
     if (pathname === '/health') {
       const env = (globalThis as any).__env;
       return jsonResponse(200, { ok: true, service: 'tong-api', hasResend: !!env?.RESEND_API_KEY, hasDB: !!env?.DB });
+    }
+
+    if (pathname === '/api/ai/translate' && request.method === 'POST') {
+      const body = await readJsonBody(request);
+      const words = Array.isArray(body.words) ? body.words : [];
+      const from = typeof body.from === 'string' ? body.from : '';
+      const to = typeof body.to === 'string' ? body.to : '';
+
+      if (!words.length || !from || !to) {
+        return jsonResponse(400, { error: 'Missing words, from, or to' });
+      }
+
+      const batch = words.slice(0, 30).map((word) => String(word));
+
+      try {
+        const joined = batch.join('\n');
+        const translated = await translateViaGoogle(joined, from, to);
+        const parts = translated.split('\n');
+
+        const translations: Record<string, string> = {};
+        for (let i = 0; i < batch.length; i++) {
+          translations[batch[i]] = (parts[i] ?? '').trim();
+        }
+
+        return jsonResponse(200, { translations });
+      } catch (error) {
+        console.error('[worker:translate] error', error);
+        return jsonResponse(200, { translations: {} });
+      }
     }
 
     if (pathname === '/api/v1/captions/enriched' && request.method === 'GET') {

--- a/docs/issue-157-phase1-static-export-audit.md
+++ b/docs/issue-157-phase1-static-export-audit.md
@@ -1,0 +1,41 @@
+# Issue #157 Phase 1 — static export API audit
+
+This document tracks the `apps/client/app/api/*` route decision for Phase 1.
+
+## Build-mode behavior
+
+- `npm --prefix apps/client run build` keeps the existing SSR path and includes all Next route handlers.
+- `npm --prefix apps/client run build:static` parks `apps/client/app/api` during the build so Next static export can complete without server route handlers.
+- `npm --prefix apps/client run build:static` also parks `apps/client/app/playtest/[id]` because the dynamic segment has no `generateStaticParams()` and remains SSR-only in Phase 1.
+
+## Route-by-route classification
+
+| Route | Decision | Phase 1 action |
+| --- | --- | --- |
+| `app/api/ai/hangout/route.ts` | Keep on SSR build only | Static build skips via API parking; no migration yet |
+| `app/api/ai/playtest-clarify/route.ts` | Keep on SSR build only | Intentionally untouched (conflict guard with PR #218) |
+| `app/api/ai/studio/route.ts` | Keep on SSR build only | Static build skips via API parking; no migration yet |
+| `app/api/ai/signal-keywords/route.ts` | Keep on SSR build only | Static build skips via API parking; no migration yet |
+| `app/api/ai/campaign/route.ts` | Keep on SSR build only | Static build skips via API parking; no migration yet |
+| `app/api/ai/lesson/route.ts` | Keep on SSR build only | Static build skips via API parking; no migration yet |
+| `app/api/ai/director/route.ts` | Keep on SSR build only | Static build skips via API parking; no migration yet |
+| `app/api/ai/translate/route.ts` | Move to Worker | Added `POST /api/ai/translate` in `apps/worker/src/index.ts` |
+| `app/api/local/videos/[videoId]/route.ts` | Keep on SSR build only | Static build skips via API parking; no migration yet |
+
+## Static-export client audit (`'use client'` constraints)
+
+Static export compile was used as the check for client components and found no blockers requiring edits in:
+
+- `apps/client/app/game/page.tsx` (forbidden path)
+- `apps/client/app/globals.css` (forbidden path)
+
+No `cookies()`, `headers()`, or server actions were introduced as part of this Phase 1 change.
+
+## Current blockers to a successful static export
+
+`build:static` still fails without touching forbidden or out-of-scope files.
+
+1. `apps/client/app/game/layout.tsx` sets `dynamic = 'force-dynamic'`, which blocks export for `/game`, `/game/hangout`, `/game/map`, and `/game/block-crush`.
+2. `apps/client/app/mock/messaging-promo/page.tsx` uses `searchParams` in a way that triggers static generation bailout/timeouts under `output: 'export'`.
+
+Per the task constraints, no changes were made to `apps/client/app/game/page.tsx` or `apps/client/app/globals.css`.


### PR DESCRIPTION
### Motivation
- Add an env-gated static-export build mode so a Capacitor-friendly static artifact can be produced without changing the existing SSR build path. 
- Provide a dual pipeline where `npm --prefix apps/client run build` remains SSR and `npm --prefix apps/client run build:static` runs a gated static export flow. 
- Move any safe-to-run-in-Workers route(s) out of Next SSR so the static build is practical while keeping SSR-only routes untouched under this Phase 1 scope.
- Phase 1 of #157. Phases 2–5 remain. Do not close #157.

### Description
- Toggle Next `output` via `TONG_BUILD_MODE=static-export` by adding `isStaticExportBuild` in `apps/client/next.config.mjs` so `output` becomes `'export'` only for the static build and image handling sets `unoptimized` in that mode. 
- Add `apps/client/scripts/build-static.mjs` and a `build:static` npm script which temporarily parks SSR-only route folders (currently `app/api` and `app/playtest/[id]`) during `next build` to allow static export, then restores them after the build. 
- Migrate `app/api/ai/translate` behavior into the Worker runtime by adding a `POST /api/ai/translate` handler in `apps/worker/src/index.ts` that preserves the Google-batch translation behavior and response shape (`{ translations: { ... } }`). 
- Add `docs/issue-157-phase1-static-export-audit.md` documenting per-route Phase 1 decisions and listing remaining blockers for a full static export.

### Testing
- Ran the SSR build: `npm --prefix apps/client run build` and the SSR build completed successfully. 
- Type-check: `npx tsc -p apps/client/tsconfig.json --noEmit` passed with no type errors. 
- Ran the static export flow: `npm --prefix apps/client run build:static` which prepares the static build but currently fails due to out-of-scope dynamic/SSR-only pages; these failures are documented as blockers rather than regressions. 
- Worker parity check: invoked the migrated translate route with curl and confirmed the response shape is preserved; example:

```
curl -sS -X POST 'http://localhost:8787/api/ai/translate' \
  -H 'content-type: application/json' \
  -d '{"words":["안녕하세요","감사합니다"],"from":"ko","to":"en"}'
```
Expected shape: `{ "translations": { "안녕하세요": "...", "감사합니다": "..." } }`.

Notes on blockers observed during `build:static`: 
- `apps/client/app/game/layout.tsx` sets `dynamic = 'force-dynamic'`, which prevents static-export rendering for `/game` and related routes. 
- `apps/client/app/mock/messaging-promo/page.tsx` uses `searchParams` in a pattern that triggers static-generation bailouts/timeouts under `output: 'export'`.

How to test locally
- Run `npm --prefix apps/client run build` (should succeed). 
- Run `npx tsc -p apps/client/tsconfig.json --noEmit` (should be green). 
- Run `npm --prefix apps/client run build:static` to exercise the gated static export and observe documented blockers. 
- (Optional) Start the Worker server and run the curl example above to validate the `ai/translate` Worker endpoint returns the expected JSON shape.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6143ec6d4832a8bb3b4f563987a2e)