### PR TITLE
Add commerce contract types, fixtures, and mock worker endpoints for entitlements/unlocks/purchase-events

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -6,6 +6,9 @@ import gameStartFixture from '../../../packages/contracts/fixtures/game.start-or
 import objectivesNextFixture from '../../../packages/contracts/fixtures/objectives.next.sample.json';
 import learnSessionsFixture from '../../../packages/contracts/fixtures/learn.sessions.sample.json';
 import mediaProfileFixture from '../../../packages/contracts/fixtures/player.media-profile.sample.json';
+import commerceEntitlementsFixture from '../../../packages/contracts/fixtures/commerce.entitlements.sample.json';
+import commerceUnlockGrantFixture from '../../../packages/contracts/fixtures/commerce.unlock-grant.sample.json';
+import commercePurchaseEventFixture from '../../../packages/contracts/fixtures/commerce.purchase-event.sample.json';
 import objectiveIdentityMap from '../../../packages/contracts/objective-identity-map.sample.json';
 import mockMediaWindow from '../../server/data/mock-media-window.json';
 
@@ -431,6 +434,9 @@ const FIXTURES = {
   objectivesNext: objectivesNextFixture,
   learnSessions: learnSessionsFixture,
   mediaProfile: mediaProfileFixture,
+  commerceEntitlements: commerceEntitlementsFixture,
+  commerceUnlockGrant: commerceUnlockGrantFixture,
+  commercePurchaseEvent: commercePurchaseEventFixture,
 };
 
 const objectiveIdentityByCanonical = new Map<string, (typeof objectiveIdentityMap.objectives)[number]>();
@@ -676,6 +682,79 @@ function getLocationId(search: URLSearchParams): LocationId {
 
 function getUserIdFromSearch(searchParams: URLSearchParams): string {
   return searchParams.get('userId') || DEFAULT_USER_ID;
+}
+
+function getCommerceEntitlements(userId: string): Record<string, unknown> {
+  const fixture = cloneJson(FIXTURES.commerceEntitlements) as Record<string, unknown>;
+  fixture.userId = userId;
+  return fixture;
+}
+
+function buildCommerceUnlockGrant(body: Record<string, any>): Record<string, unknown> {
+  const fixture = cloneJson(FIXTURES.commerceUnlockGrant) as Record<string, any>;
+  const userId = typeof body.userId === 'string' && body.userId.trim().length > 0 ? body.userId.trim() : fixture.userId;
+  const unlockKey =
+    typeof body.unlockKey === 'string' && body.unlockKey.trim().length > 0 ? body.unlockKey.trim() : fixture.unlockKey;
+  const grantSource =
+    typeof body.grantSource === 'string' && body.grantSource.trim().length > 0 ? body.grantSource.trim() : fixture.grantSource;
+  const purchaseEventId =
+    typeof body.purchaseEventId === 'string' && body.purchaseEventId.trim().length > 0
+      ? body.purchaseEventId.trim()
+      : fixture.purchaseEventId;
+  const idempotencyKey =
+    typeof body.idempotencyKey === 'string' && body.idempotencyKey.trim().length > 0
+      ? body.idempotencyKey.trim()
+      : `${unlockKey}:${userId}`;
+
+  fixture.userId = userId;
+  fixture.unlockKey = unlockKey;
+  fixture.grantSource = grantSource;
+  fixture.purchaseEventId = purchaseEventId || null;
+  fixture.idempotencyKey = idempotencyKey;
+  fixture.entitlement = {
+    ...(fixture.entitlement || {}),
+    productKey: unlockKey,
+    source: grantSource,
+    purchaseEventId: purchaseEventId || null,
+    ...(body.metadata ? { metadata: body.metadata } : {}),
+  };
+
+  return fixture;
+}
+
+function buildCommercePurchaseEvent(body: Record<string, any>): Record<string, unknown> {
+  const fixture = cloneJson(FIXTURES.commercePurchaseEvent) as Record<string, any>;
+  const providerEventId =
+    typeof body.providerEventId === 'string' && body.providerEventId.trim().length > 0
+      ? body.providerEventId.trim()
+      : fixture.providerEventId;
+  const userId = typeof body.userId === 'string' && body.userId.trim().length > 0 ? body.userId.trim() : fixture.userId;
+  const provider = typeof body.provider === 'string' && body.provider.trim().length > 0 ? body.provider.trim() : fixture.provider;
+  const eventType =
+    typeof body.eventType === 'string' && body.eventType.trim().length > 0 ? body.eventType.trim() : fixture.eventType;
+
+  fixture.provider = provider;
+  fixture.providerEventId = providerEventId;
+  fixture.userId = userId;
+  fixture.eventType = eventType;
+  fixture.occurredAtIso = typeof body.occurredAtIso === 'string' && body.occurredAtIso.trim().length > 0
+    ? body.occurredAtIso.trim()
+    : fixture.occurredAtIso;
+  fixture.dedupeKey = `${provider}:${providerEventId}`;
+  fixture.payloadHash = typeof body.payloadHash === 'string' && body.payloadHash.trim().length > 0
+    ? body.payloadHash.trim()
+    : fixture.payloadHash;
+  if (body.amount && typeof body.amount === 'object') {
+    fixture.amount = {
+      ...(fixture.amount || {}),
+      ...body.amount,
+    };
+  }
+  if (body.metadata && typeof body.metadata === 'object') {
+    fixture.metadata = body.metadata;
+  }
+
+  return fixture;
 }
 
 function getCaptionsForVideo(videoId = 'karina-variety-demo') {
@@ -1775,6 +1854,21 @@ async function handleRequest(request: Request): Promise<Response> {
       const userId = getUserIdFromSearch(url.searchParams);
       const ingestion = ensureIngestionForUser(userId);
       return jsonResponse(200, ingestion.mediaProfile || { ...(FIXTURES.mediaProfile as any), userId });
+    }
+
+    if (pathname === '/api/v1/commerce/entitlements' && request.method === 'GET') {
+      const userId = getUserIdFromSearch(url.searchParams);
+      return jsonResponse(200, getCommerceEntitlements(userId));
+    }
+
+    if (pathname === '/api/v1/commerce/unlocks/grant' && request.method === 'POST') {
+      const body = await readJsonBody(request);
+      return jsonResponse(200, buildCommerceUnlockGrant(body));
+    }
+
+    if (pathname === '/api/v1/commerce/purchase-events' && request.method === 'POST') {
+      const body = await readJsonBody(request);
+      return jsonResponse(200, buildCommercePurchaseEvent(body));
     }
 
     if (pathname === '/api/v1/ingestion/run-mock' && request.method === 'POST') {

--- a/packages/contracts/api-contract.md
+++ b/packages/contracts/api-contract.md
@@ -231,6 +231,113 @@ Response:
 }
 ```
 
+## GET `/api/v1/commerce/entitlements`
+Query:
+```json
+{ "userId": "demo-user-1" }
+```
+
+Response:
+```json
+{
+  "userId": "demo-user-1",
+  "asOfIso": "2026-04-21T09:00:00.000Z",
+  "balances": { "xp": 420, "sp": 160, "rp": 90 },
+  "entitlements": [
+    {
+      "entitlementId": "ent_shanghai_texting_pack",
+      "productKey": "unlock.shanghai.texting_mission",
+      "type": "mission_unlock",
+      "status": "active",
+      "grantedAtIso": "2026-04-18T02:00:00.000Z",
+      "source": "mission_reward",
+      "purchaseEventId": null
+    }
+  ]
+}
+```
+
+## POST `/api/v1/commerce/unlocks/grant`
+Request:
+```json
+{
+  "userId": "demo-user-1",
+  "unlockKey": "unlock.shanghai.auction.preview",
+  "grantSource": "purchase_event",
+  "idempotencyKey": "unlock.shanghai.auction.preview:demo-user-1",
+  "purchaseEventId": "pevt_demo_checkout_001",
+  "metadata": {
+    "priceId": "price_demo_auction_preview"
+  }
+}
+```
+
+Response:
+```json
+{
+  "grantId": "grant_unlock_shanghai_auction_pass",
+  "status": "granted",
+  "userId": "demo-user-1",
+  "unlockKey": "unlock.shanghai.auction.preview",
+  "grantSource": "purchase_event",
+  "grantedAtIso": "2026-04-21T09:10:00.000Z",
+  "idempotencyKey": "unlock.shanghai.auction.preview:demo-user-1",
+  "purchaseEventId": "pevt_demo_checkout_001",
+  "entitlement": {
+    "entitlementId": "ent_unlock_shanghai_auction_pass",
+    "productKey": "unlock.shanghai.auction.preview",
+    "type": "feature_access",
+    "status": "active",
+    "grantedAtIso": "2026-04-21T09:10:00.000Z",
+    "source": "purchase_event",
+    "purchaseEventId": "pevt_demo_checkout_001"
+  }
+}
+```
+
+## POST `/api/v1/commerce/purchase-events`
+Request:
+```json
+{
+  "provider": "stripe",
+  "providerEventId": "evt_demo_checkout_001",
+  "eventType": "checkout.session.completed",
+  "userId": "demo-user-1",
+  "occurredAtIso": "2026-04-21T09:08:00.000Z",
+  "amount": { "currency": "usd", "subtotal": 1299, "total": 1299 },
+  "metadata": {
+    "unlockKey": "unlock.shanghai.auction.preview",
+    "priceId": "price_demo_auction_preview"
+  },
+  "payloadHash": "sha256:demo_checkout_payload_hash"
+}
+```
+
+Response:
+```json
+{
+  "recordId": "pevt_demo_checkout_001",
+  "status": "recorded",
+  "provider": "stripe",
+  "providerEventId": "evt_demo_checkout_001",
+  "eventType": "checkout.session.completed",
+  "userId": "demo-user-1",
+  "occurredAtIso": "2026-04-21T09:08:00.000Z",
+  "recordedAtIso": "2026-04-21T09:08:05.000Z",
+  "dedupeKey": "stripe:evt_demo_checkout_001",
+  "amount": { "currency": "usd", "subtotal": 1299, "total": 1299 },
+  "metadata": {
+    "unlockKey": "unlock.shanghai.auction.preview",
+    "priceId": "price_demo_auction_preview"
+  },
+  "payloadHash": "sha256:demo_checkout_payload_hash"
+}
+```
+
+Contract notes:
+- Demo worker responses are fixture-backed and deterministic; they are intentionally stateless mocks and do not mutate entitlement state across calls.
+- Real Stripe webhook signature verification, replay protection storage, refund/reversal handling, and restore flows are out of scope for this mock contract stage.
+
 ## Canonical Media Events Fixture (Connector-Independent)
 Used by topic modeling/frequency workstreams so they can iterate without live Spotify/YouTube sync.
 

--- a/packages/contracts/fixtures/commerce.entitlements.sample.json
+++ b/packages/contracts/fixtures/commerce.entitlements.sample.json
@@ -1,0 +1,36 @@
+{
+  "userId": "demo-user-1",
+  "asOfIso": "2026-04-21T09:00:00.000Z",
+  "balances": {
+    "xp": 420,
+    "sp": 160,
+    "rp": 90
+  },
+  "entitlements": [
+    {
+      "entitlementId": "ent_shanghai_texting_pack",
+      "productKey": "unlock.shanghai.texting_mission",
+      "type": "mission_unlock",
+      "status": "active",
+      "grantedAtIso": "2026-04-18T02:00:00.000Z",
+      "source": "mission_reward",
+      "purchaseEventId": null,
+      "metadata": {
+        "city": "shanghai",
+        "location": "practice_studio"
+      }
+    },
+    {
+      "entitlementId": "ent_polaroid_shanghai_call",
+      "productKey": "collectible.polaroid.shanghai_call",
+      "type": "collectible",
+      "status": "active",
+      "grantedAtIso": "2026-04-19T03:15:00.000Z",
+      "source": "purchase_event",
+      "purchaseEventId": "pevt_demo_checkout_001",
+      "metadata": {
+        "reward": "video_call"
+      }
+    }
+  ]
+}

--- a/packages/contracts/fixtures/commerce.purchase-event.sample.json
+++ b/packages/contracts/fixtures/commerce.purchase-event.sample.json
@@ -1,0 +1,21 @@
+{
+  "recordId": "pevt_demo_checkout_001",
+  "status": "recorded",
+  "provider": "stripe",
+  "providerEventId": "evt_demo_checkout_001",
+  "eventType": "checkout.session.completed",
+  "userId": "demo-user-1",
+  "occurredAtIso": "2026-04-21T09:08:00.000Z",
+  "recordedAtIso": "2026-04-21T09:08:05.000Z",
+  "dedupeKey": "stripe:evt_demo_checkout_001",
+  "amount": {
+    "currency": "usd",
+    "subtotal": 1299,
+    "total": 1299
+  },
+  "metadata": {
+    "unlockKey": "unlock.shanghai.auction.preview",
+    "priceId": "price_demo_auction_preview"
+  },
+  "payloadHash": "sha256:demo_checkout_payload_hash"
+}

--- a/packages/contracts/fixtures/commerce.unlock-grant.sample.json
+++ b/packages/contracts/fixtures/commerce.unlock-grant.sample.json
@@ -1,0 +1,23 @@
+{
+  "grantId": "grant_unlock_shanghai_auction_pass",
+  "status": "granted",
+  "userId": "demo-user-1",
+  "unlockKey": "unlock.shanghai.auction.preview",
+  "grantSource": "purchase_event",
+  "grantedAtIso": "2026-04-21T09:10:00.000Z",
+  "idempotencyKey": "unlock.shanghai.auction.preview:demo-user-1",
+  "purchaseEventId": "pevt_demo_checkout_001",
+  "entitlement": {
+    "entitlementId": "ent_unlock_shanghai_auction_pass",
+    "productKey": "unlock.shanghai.auction.preview",
+    "type": "feature_access",
+    "status": "active",
+    "grantedAtIso": "2026-04-21T09:10:00.000Z",
+    "source": "purchase_event",
+    "purchaseEventId": "pevt_demo_checkout_001",
+    "metadata": {
+      "preview": true,
+      "city": "shanghai"
+    }
+  }
+}

--- a/packages/contracts/types.ts
+++ b/packages/contracts/types.ts
@@ -163,6 +163,85 @@ export interface PlayerLanguageProfile {
   proficiency: Record<TargetLanguage, 'none' | 'beginner' | 'intermediate' | 'advanced'>;
 }
 
+export type CommerceEntitlementType = 'feature_access' | 'location_unlock' | 'mission_unlock' | 'collectible';
+export type CommerceEntitlementStatus = 'active' | 'revoked' | 'expired';
+export type CommerceGrantSource = 'purchase_event' | 'mission_reward' | 'admin_manual';
+
+export interface CommerceEntitlement {
+  entitlementId: string;
+  productKey: string;
+  type: CommerceEntitlementType;
+  status: CommerceEntitlementStatus;
+  grantedAtIso: string;
+  source: CommerceGrantSource;
+  purchaseEventId?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+export interface CommerceEntitlementsResponse {
+  userId: string;
+  asOfIso: string;
+  balances: {
+    xp: number;
+    sp: number;
+    rp: number;
+  };
+  entitlements: CommerceEntitlement[];
+}
+
+export interface CommerceUnlockGrantRequest {
+  userId: string;
+  unlockKey: string;
+  grantSource: CommerceGrantSource;
+  idempotencyKey?: string;
+  purchaseEventId?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface CommerceUnlockGrantResponse {
+  grantId: string;
+  status: 'granted' | 'already_granted';
+  userId: string;
+  unlockKey: string;
+  grantSource: CommerceGrantSource;
+  grantedAtIso: string;
+  idempotencyKey: string;
+  purchaseEventId?: string | null;
+  entitlement: CommerceEntitlement;
+}
+
+export interface CommercePurchaseMoney {
+  currency: string;
+  subtotal: number;
+  total: number;
+}
+
+export interface CommercePurchaseEventRequest {
+  provider: 'stripe';
+  providerEventId: string;
+  eventType: string;
+  userId: string;
+  occurredAtIso: string;
+  amount: CommercePurchaseMoney;
+  metadata?: Record<string, unknown>;
+  payloadHash: string;
+}
+
+export interface CommercePurchaseEventResponse {
+  recordId: string;
+  status: 'recorded' | 'duplicate';
+  provider: 'stripe';
+  providerEventId: string;
+  eventType: string;
+  userId: string;
+  occurredAtIso: string;
+  recordedAtIso: string;
+  dedupeKey: string;
+  amount: CommercePurchaseMoney;
+  metadata?: Record<string, unknown>;
+  payloadHash: string;
+}
+
 export interface HangoutScore {
   xp: number;
   sp: number;


### PR DESCRIPTION
### Motivation

- Provide a minimal, additive commerce contract and deterministic mock API so client work for Stripe integration and the Shanghai auction can iterate against stable shapes without building real Stripe.  
- Keep schema changes in `packages/contracts` first and supply fixture-backed worker routes for local-demo and integration smoke tests.

### Description

- Add commerce types to `packages/contracts/types.ts` for entitlement snapshots, unlock grants, and purchase-event request/response shapes.  
- Document new mock API endpoints and sample payloads in `packages/contracts/api-contract.md` for `GET /api/v1/commerce/entitlements`, `POST /api/v1/commerce/unlocks/grant`, and `POST /api/v1/commerce/purchase-events`.  
- Add deterministic fixtures under `packages/contracts/fixtures/` (`commerce.entitlements.sample.json`, `commerce.unlock-grant.sample.json`, `commerce.purchase-event.sample.json`).  
- Wire fixture-backed mock handlers and lightweight builders into the demo worker (`apps/worker/src/index.ts`) and expose the three routes; handlers override request fields but remain stateless and non-persistent by design.

### Testing

- Generated the issue queue plans with `python .agents/skills/_functional-qa/scripts/issue_router.py plan 253` and `python .agents/skills/_functional-qa/scripts/codex_cloud_queue.py plan 253` (both succeeded).  
- Installed worker deps and started the local worker with `npm --prefix apps/worker install` and `npm --prefix apps/worker run dev`, and verified the new routes were served.  
- Exercised the routes with smoke assertions: `GET /api/v1/commerce/entitlements?userId=test-user` (asserted `userId === "test-user"` and `entitlements.length > 0`), `POST /api/v1/commerce/unlocks/grant` (asserted `idempotencyKey === "test-key-1"` and returned `entitlement.productKey === unlockKey`), and `POST /api/v1/commerce/purchase-events` (asserted `dedupeKey === "stripe:evt_custom_abc"` and `amount.total === 2500`), and all assertions passed.  
- Ran the repository mock-flow smoke via `npm run test:api-flow:worker-local`, which exercised many endpoints and passed all commerce checks but failed an existing unrelated check: `/api/v1/integrations/spotify/status` returned `404` (this is pre-existing and out of scope for this PR).  

How to exercise locally: 1) run `npm --prefix apps/worker install`; 2) run `npm --prefix apps/worker run dev`; 3) hit the routes with `curl` as shown in the PR body or use `npm run test:api-flow:worker-local` for a broader smoke run.

Remaining gaps / risks (out of scope for this patch):  
- No Stripe webhook signature verification or authenticity checks are implemented.  
- No durable event ledger, replay/idempotency storage, or persistent dedupe enforcement is present.  
- No entitlement restore/reconciliation or cross-device sync semantics are implemented.  
- No extended audit trail, refund/reversal handling, or Shanghai auction redemption fulfillment is implemented; client/UI integration for auction redemption remains to be added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7c3cb3bc4832a9e330da3e3643d7e)