### PR TITLE
feat(contracts): add commerce mock contracts and worker routes (issue #253 partial)

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -6,6 +6,9 @@ import gameStartFixture from '../../../packages/contracts/fixtures/game.start-or
 import objectivesNextFixture from '../../../packages/contracts/fixtures/objectives.next.sample.json';
 import learnSessionsFixture from '../../../packages/contracts/fixtures/learn.sessions.sample.json';
 import mediaProfileFixture from '../../../packages/contracts/fixtures/player.media-profile.sample.json';
+import commerceEntitlementsFixture from '../../../packages/contracts/fixtures/commerce.entitlements.sample.json';
+import commerceUnlockGrantFixture from '../../../packages/contracts/fixtures/commerce.unlock-grant.sample.json';
+import commercePurchaseEventFixture from '../../../packages/contracts/fixtures/commerce.purchase-event.sample.json';
 import objectiveIdentityMap from '../../../packages/contracts/objective-identity-map.sample.json';
 import mockMediaWindow from '../../server/data/mock-media-window.json';
 
@@ -431,6 +434,9 @@ const FIXTURES = {
   objectivesNext: objectivesNextFixture,
   learnSessions: learnSessionsFixture,
   mediaProfile: mediaProfileFixture,
+  commerceEntitlements: commerceEntitlementsFixture,
+  commerceUnlockGrant: commerceUnlockGrantFixture,
+  commercePurchaseEvent: commercePurchaseEventFixture,
 };
 
 const objectiveIdentityByCanonical = new Map<string, (typeof objectiveIdentityMap.objectives)[number]>();
@@ -1830,6 +1836,42 @@ async function handleRequest(request: Request): Promise<Response> {
       const profile = upsertProfile(body.userId, body.profile ? { profile: body.profile } : body);
       const ingestion = ensureIngestionForUser(body.userId);
       return jsonResponse(200, { ok: true, profile, mediaProfile: ingestion.mediaProfile });
+    }
+
+
+    if (pathname === '/api/v1/commerce/entitlements' && request.method === 'GET') {
+      const userId = getUserIdFromSearch(url.searchParams);
+      return jsonResponse(200, {
+        ...(cloneJson(FIXTURES.commerceEntitlements) as Record<string, unknown>),
+        userId,
+      });
+    }
+
+    if (pathname === '/api/v1/commerce/unlocks/grant' && request.method === 'POST') {
+      const body = await readJsonBody(request);
+      const userId = body.userId || DEFAULT_USER_ID;
+      const fixture = cloneJson(FIXTURES.commerceUnlockGrant) as Record<string, unknown>;
+      return jsonResponse(200, {
+        ...fixture,
+        userId,
+        unlockType: body.unlockType || fixture.unlockType,
+        resourceId: body.resourceId || fixture.resourceId,
+        source: body.source || fixture.source,
+        referenceId: body.referenceId || fixture.referenceId,
+      });
+    }
+
+    if (pathname === '/api/v1/commerce/purchase-events' && request.method === 'POST') {
+      const body = await readJsonBody(request);
+      const fixture = cloneJson(FIXTURES.commercePurchaseEvent) as Record<string, unknown>;
+      return jsonResponse(200, {
+        ...fixture,
+        eventId: body.eventId || fixture.eventId,
+        provider: body.provider || fixture.provider,
+        eventType: body.eventType || fixture.eventType,
+        userId: body.userId || fixture.userId,
+        idempotencyKey: body.idempotencyKey || fixture.idempotencyKey,
+      });
     }
 
     if (pathname === '/api/v1/objectives/next' && request.method === 'GET') {

--- a/docs/handoff-notes.md
+++ b/docs/handoff-notes.md
@@ -276,3 +276,10 @@ Template:
   - Reuse the existing scripted messaging renderer from #124 for a new deterministic 9:16 mock capture route.
   - Extend `ScriptedMessagingPlayer` controls/additive API (no second renderer) so mock-ui can drive play/pause/restart/jump deterministically.
   - Keep global style churn minimal and document route/query fixtures in demo run-of-show.
+
+## 2026-04-21 (Issue 253 commerce contract + mock API intent)
+- Date: 2026-04-21
+- Branch/worktree: `work` (server-api lane crossing shared `packages/contracts/**`)
+- Intent:
+  - Add additive commerce contract shapes and fixtures for entitlement snapshot, unlock grant, and purchase-event persistence so Stripe and Shanghai auction work can consume stable request/response contracts.
+  - Wire deterministic fixture-backed worker routes for the new commerce endpoints without introducing hidden mutable state or real payment integration.

--- a/packages/contracts/api-contract.md
+++ b/packages/contracts/api-contract.md
@@ -200,6 +200,102 @@ Response:
 }
 ```
 
+
+## GET `/api/v1/commerce/entitlements`
+Query:
+```json
+{ "userId": "demo-user-1" }
+```
+
+Response:
+```json
+{
+  "userId": "demo-user-1",
+  "asOfIso": "2026-04-21T00:00:00.000Z",
+  "currencies": { "xp": 110, "sp": 45, "rp": 12 },
+  "entitlements": [
+    {
+      "entitlementId": "entl_shanghai_auction_house_access",
+      "kind": "location_access",
+      "resourceId": "shanghai:auction_house",
+      "status": "active",
+      "source": "unlock_grant",
+      "grantedAtIso": "2026-04-20T23:00:00.000Z",
+      "expiresAtIso": null,
+      "metadata": {
+        "cityId": "shanghai",
+        "locationId": "practice_studio",
+        "unlockReason": "mission_reward"
+      }
+    }
+  ],
+  "unlockables": {
+    "locationIds": ["practice_studio"],
+    "missionIds": ["shanghai_advanced_texting"],
+    "rewardIds": ["polaroid_memory_001"]
+  }
+}
+```
+
+## POST `/api/v1/commerce/unlocks/grant`
+Request:
+```json
+{
+  "userId": "demo-user-1",
+  "unlockType": "location_access",
+  "resourceId": "shanghai:auction_house",
+  "source": "mission_reward",
+  "referenceId": "mission_sh_texting_clear"
+}
+```
+
+Response:
+```json
+{
+  "grantId": "grant_demo_unlock_001",
+  "userId": "demo-user-1",
+  "unlockType": "location_access",
+  "resourceId": "shanghai:auction_house",
+  "status": "granted",
+  "source": "mission_reward",
+  "referenceId": "mission_sh_texting_clear",
+  "entitlementId": "entl_shanghai_auction_house_access",
+  "grantedAtIso": "2026-04-21T00:05:00.000Z",
+  "balanceDelta": { "xp": 0, "sp": -20, "rp": 3 }
+}
+```
+
+## POST `/api/v1/commerce/purchase-events`
+Request:
+```json
+{
+  "eventId": "evt_demo_checkout_001",
+  "provider": "stripe",
+  "eventType": "checkout.session.completed",
+  "userId": "demo-user-1",
+  "idempotencyKey": "stripe:evt_demo_checkout_001"
+}
+```
+
+Response:
+```json
+{
+  "recordId": "pevt_rec_demo_001",
+  "eventId": "evt_demo_checkout_001",
+  "provider": "stripe",
+  "eventType": "checkout.session.completed",
+  "userId": "demo-user-1",
+  "idempotencyKey": "stripe:evt_demo_checkout_001",
+  "status": "recorded",
+  "receivedAtIso": "2026-04-21T00:08:00.000Z",
+  "persistedAtIso": "2026-04-21T00:08:00.000Z",
+  "raw": {
+    "livemode": false,
+    "object": "event"
+  }
+}
+```
+
 ## POST `/api/v1/ingestion/run-mock`
 Request:
 ```json

--- a/packages/contracts/fixtures/commerce.entitlements.sample.json
+++ b/packages/contracts/fixtures/commerce.entitlements.sample.json
@@ -1,0 +1,36 @@
+{
+  "userId": "demo-user-1",
+  "asOfIso": "2026-04-21T00:00:00.000Z",
+  "currencies": {
+    "xp": 110,
+    "sp": 45,
+    "rp": 12
+  },
+  "entitlements": [
+    {
+      "entitlementId": "entl_shanghai_auction_house_access",
+      "kind": "location_access",
+      "resourceId": "shanghai:auction_house",
+      "status": "active",
+      "source": "unlock_grant",
+      "grantedAtIso": "2026-04-20T23:00:00.000Z",
+      "expiresAtIso": null,
+      "metadata": {
+        "cityId": "shanghai",
+        "locationId": "practice_studio",
+        "unlockReason": "mission_reward"
+      }
+    }
+  ],
+  "unlockables": {
+    "locationIds": [
+      "practice_studio"
+    ],
+    "missionIds": [
+      "shanghai_advanced_texting"
+    ],
+    "rewardIds": [
+      "polaroid_memory_001"
+    ]
+  }
+}

--- a/packages/contracts/fixtures/commerce.purchase-event.sample.json
+++ b/packages/contracts/fixtures/commerce.purchase-event.sample.json
@@ -1,0 +1,15 @@
+{
+  "recordId": "pevt_rec_demo_001",
+  "eventId": "evt_demo_checkout_001",
+  "provider": "stripe",
+  "eventType": "checkout.session.completed",
+  "userId": "demo-user-1",
+  "idempotencyKey": "stripe:evt_demo_checkout_001",
+  "status": "recorded",
+  "receivedAtIso": "2026-04-21T00:08:00.000Z",
+  "persistedAtIso": "2026-04-21T00:08:00.000Z",
+  "raw": {
+    "livemode": false,
+    "object": "event"
+  }
+}

--- a/packages/contracts/fixtures/commerce.unlock-grant.sample.json
+++ b/packages/contracts/fixtures/commerce.unlock-grant.sample.json
@@ -1,0 +1,16 @@
+{
+  "grantId": "grant_demo_unlock_001",
+  "userId": "demo-user-1",
+  "unlockType": "location_access",
+  "resourceId": "shanghai:auction_house",
+  "status": "granted",
+  "source": "mission_reward",
+  "referenceId": "mission_sh_texting_clear",
+  "entitlementId": "entl_shanghai_auction_house_access",
+  "grantedAtIso": "2026-04-21T00:05:00.000Z",
+  "balanceDelta": {
+    "xp": 0,
+    "sp": -20,
+    "rp": 3
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal, additive commerce contract and deterministic mock API so Stripe and Shanghai auction integration work can proceed with stable request/response shapes.
- Keep changes fixture-first in `packages/contracts` and demo-friendly without introducing real payment providers or hidden mutable state.

### Description
- Added contract docs for `GET /api/v1/commerce/entitlements`, `POST /api/v1/commerce/unlocks/grant`, and `POST /api/v1/commerce/purchase-events` in `packages/contracts/api-contract.md`.
- Added deterministic fixtures: `packages/contracts/fixtures/commerce.entitlements.sample.json`, `packages/contracts/fixtures/commerce.unlock-grant.sample.json`, and `packages/contracts/fixtures/commerce.purchase-event.sample.json` documenting the entitlement snapshot, unlock grant, and purchase-event record shapes respectively.
- Wired fixtures into the worker and implemented mock routes in `apps/worker/src/index.ts` that return fixture-backed responses and echo request overrides for `GET /api/v1/commerce/entitlements`, `POST /api/v1/commerce/unlocks/grant`, and `POST /api/v1/commerce/purchase-events` without DB persistence.
- Added a handoff note entry in `docs/handoff-notes.md` and kept all edits additive to follow the repo contract-first workflow.

### Testing
- Ran `python .agents/skills/_functional-qa/scripts/issue_router.py plan 253` and `python .agents/skills/_functional-qa/scripts/codex_cloud_queue.py plan 253` to validate the issue plan successfully.
- Installed worker deps with `npm --prefix apps/worker install` and exercised the new routes against the local worker; assertions passed for `GET /api/v1/commerce/entitlements?userId=demo-commerce-user`, `POST /api/v1/commerce/unlocks/grant`, and `POST /api/v1/commerce/purchase-events` returning the expected fixture-backed shapes.
- Ran `npm run test:api-flow:worker-local` which failed on a pre-existing `/integrations/spotify/status` 404 that is unrelated to the commerce changes.
- Remaining explicit gaps: real Stripe webhook signature verification and provider auth, durable DB-backed purchase-event persistence and replay-safe idempotency enforcement, entitlement restore/audit history and reconciliation, and auction redemption/settlement domain logic; this PR is therefore a partial fulfillment of #253 and does not close the issue.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7c3cb3bc4832a9e330da3e3643d7e)