### PR TITLE
feat(contracts): add commerce contract fixtures and mock worker routes (partial #253)

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -6,6 +6,9 @@ import gameStartFixture from '../../../packages/contracts/fixtures/game.start-or
 import objectivesNextFixture from '../../../packages/contracts/fixtures/objectives.next.sample.json';
 import learnSessionsFixture from '../../../packages/contracts/fixtures/learn.sessions.sample.json';
 import mediaProfileFixture from '../../../packages/contracts/fixtures/player.media-profile.sample.json';
+import commerceEntitlementsFixture from '../../../packages/contracts/fixtures/commerce.entitlements.sample.json';
+import commerceUnlockGrantFixture from '../../../packages/contracts/fixtures/commerce.unlock-grant.sample.json';
+import commercePurchaseEventFixture from '../../../packages/contracts/fixtures/commerce.purchase-event.sample.json';
 import objectiveIdentityMap from '../../../packages/contracts/objective-identity-map.sample.json';
 import mockMediaWindow from '../../server/data/mock-media-window.json';
 
@@ -431,6 +434,9 @@ const FIXTURES = {
   objectivesNext: objectivesNextFixture,
   learnSessions: learnSessionsFixture,
   mediaProfile: mediaProfileFixture,
+  commerceEntitlements: commerceEntitlementsFixture,
+  commerceUnlockGrant: commerceUnlockGrantFixture,
+  commercePurchaseEvent: commercePurchaseEventFixture,
 };
 
 const objectiveIdentityByCanonical = new Map<string, (typeof objectiveIdentityMap.objectives)[number]>();
@@ -1799,6 +1805,69 @@ async function handleRequest(request: Request): Promise<Response> {
           spotify: result.mediaProfile.sourceBreakdown.spotify.itemsConsumed,
         },
         topTerms: result.frequency.items.slice(0, 10),
+      });
+    }
+
+    if (pathname === '/api/v1/commerce/entitlements' && request.method === 'GET') {
+      const userId = getUserIdFromSearch(url.searchParams);
+      const fixture = cloneJson(FIXTURES.commerceEntitlements as Record<string, unknown>);
+      return jsonResponse(200, { ...fixture, userId });
+    }
+
+    if (pathname === '/api/v1/commerce/unlocks/grant' && request.method === 'POST') {
+      const body = await readJsonBody(request);
+      const fixture = cloneJson(FIXTURES.commerceUnlockGrant as Record<string, unknown>);
+      const userId =
+        typeof body.userId === 'string' && body.userId.trim().length > 0 ? body.userId.trim() : DEFAULT_USER_ID;
+      return jsonResponse(200, {
+        ...fixture,
+        userId,
+        unlock:
+          body.unlock && typeof body.unlock === 'object'
+            ? body.unlock
+            : (fixture.unlock as Record<string, unknown> | undefined),
+        reason:
+          typeof body.reason === 'string' && body.reason.trim().length > 0
+            ? body.reason
+            : (fixture.reason as string | undefined),
+        idempotencyKey:
+          typeof body.idempotencyKey === 'string' && body.idempotencyKey.trim().length > 0
+            ? body.idempotencyKey
+            : (fixture.idempotencyKey as string | undefined),
+      });
+    }
+
+    if (pathname === '/api/v1/commerce/purchase-events' && request.method === 'POST') {
+      const body = await readJsonBody(request);
+      const fixture = cloneJson(FIXTURES.commercePurchaseEvent as Record<string, unknown>);
+      const providerEventId =
+        typeof body.providerEventId === 'string' && body.providerEventId.trim().length > 0
+          ? body.providerEventId.trim()
+          : (fixture.providerEventId as string);
+      return jsonResponse(200, {
+        ...fixture,
+        provider:
+          typeof body.provider === 'string' && body.provider.trim().length > 0
+            ? body.provider.trim()
+            : (fixture.provider as string),
+        providerEventId,
+        eventType:
+          typeof body.eventType === 'string' && body.eventType.trim().length > 0
+            ? body.eventType.trim()
+            : (fixture.eventType as string),
+        occurredAtIso:
+          typeof body.occurredAtIso === 'string' && body.occurredAtIso.trim().length > 0
+            ? body.occurredAtIso
+            : (fixture.occurredAtIso as string),
+        userId:
+          typeof body.userId === 'string' && body.userId.trim().length > 0
+            ? body.userId.trim()
+            : (fixture.userId as string),
+        purchase:
+          body.purchase && typeof body.purchase === 'object'
+            ? body.purchase
+            : (fixture.purchase as Record<string, unknown> | undefined),
+        idempotencyKey: `stripe:${providerEventId}`,
       });
     }
 

--- a/packages/contracts/api-contract.md
+++ b/packages/contracts/api-contract.md
@@ -842,3 +842,114 @@ Response:
   "openAiApiKeyConfigured": false
 }
 ```
+
+## GET `/api/v1/commerce/entitlements`
+Query:
+```json
+{ "userId": "demo-user-1" }
+```
+
+Response:
+```json
+{
+  "userId": "demo-user-1",
+  "snapshotAtIso": "2026-04-21T10:00:00.000Z",
+  "entitlements": {
+    "locations": [
+      {
+        "city": "shanghai",
+        "location": "practice_studio",
+        "tier": "advanced",
+        "source": "mission_unlock",
+        "grantedAtIso": "2026-04-20T12:30:00.000Z"
+      }
+    ],
+    "rewards": [
+      {
+        "rewardId": "polaroid_memory_shanghai_call_001",
+        "type": "polaroid_memory",
+        "source": "shanghai_advanced_texting_reward",
+        "grantedAtIso": "2026-04-20T12:35:00.000Z"
+      }
+    ]
+  }
+}
+```
+
+## POST `/api/v1/commerce/unlocks/grant`
+Request:
+```json
+{
+  "userId": "demo-user-1",
+  "unlock": {
+    "kind": "location_mode",
+    "city": "shanghai",
+    "location": "practice_studio",
+    "mode": "hangout",
+    "tier": "advanced"
+  },
+  "reason": "mission_assessment_passed",
+  "idempotencyKey": "demo-grant-shanghai-practice-studio-advanced"
+}
+```
+
+Response:
+```json
+{
+  "grantId": "grant_demo_001",
+  "userId": "demo-user-1",
+  "grantedAtIso": "2026-04-21T10:05:00.000Z",
+  "unlock": {
+    "kind": "location_mode",
+    "city": "shanghai",
+    "location": "practice_studio",
+    "mode": "hangout",
+    "tier": "advanced"
+  },
+  "reason": "mission_assessment_passed",
+  "idempotencyKey": "demo-grant-shanghai-practice-studio-advanced"
+}
+```
+
+## POST `/api/v1/commerce/purchase-events`
+Request:
+```json
+{
+  "provider": "stripe",
+  "providerEventId": "evt_demo_purchase_001",
+  "eventType": "checkout.session.completed",
+  "occurredAtIso": "2026-04-21T10:12:00.000Z",
+  "userId": "demo-user-1",
+  "purchase": {
+    "productId": "unlock_shanghai_auction_pass",
+    "quantity": 1,
+    "currency": "usd",
+    "amount": 1200
+  }
+}
+```
+
+Response:
+```json
+{
+  "recordId": "purchase_evt_demo_001",
+  "provider": "stripe",
+  "providerEventId": "evt_demo_purchase_001",
+  "eventType": "checkout.session.completed",
+  "occurredAtIso": "2026-04-21T10:12:00.000Z",
+  "receivedAtIso": "2026-04-21T10:12:01.000Z",
+  "userId": "demo-user-1",
+  "purchase": {
+    "productId": "unlock_shanghai_auction_pass",
+    "quantity": 1,
+    "currency": "usd",
+    "amount": 1200
+  },
+  "status": "persisted",
+  "idempotencyKey": "stripe:evt_demo_purchase_001"
+}
+```
+
+Contract notes:
+- These are deterministic mock contracts for local demo work and future client integration.
+- The unlock grant and purchase event payloads intentionally include `idempotencyKey` to support future replay-safe Stripe webhook handling.

--- a/packages/contracts/fixtures/commerce.entitlements.sample.json
+++ b/packages/contracts/fixtures/commerce.entitlements.sample.json
@@ -1,0 +1,23 @@
+{
+  "userId": "demo-user-1",
+  "snapshotAtIso": "2026-04-21T10:00:00.000Z",
+  "entitlements": {
+    "locations": [
+      {
+        "city": "shanghai",
+        "location": "practice_studio",
+        "tier": "advanced",
+        "source": "mission_unlock",
+        "grantedAtIso": "2026-04-20T12:30:00.000Z"
+      }
+    ],
+    "rewards": [
+      {
+        "rewardId": "polaroid_memory_shanghai_call_001",
+        "type": "polaroid_memory",
+        "source": "shanghai_advanced_texting_reward",
+        "grantedAtIso": "2026-04-20T12:35:00.000Z"
+      }
+    ]
+  }
+}

--- a/packages/contracts/fixtures/commerce.purchase-event.sample.json
+++ b/packages/contracts/fixtures/commerce.purchase-event.sample.json
@@ -1,0 +1,17 @@
+{
+  "recordId": "purchase_evt_demo_001",
+  "provider": "stripe",
+  "providerEventId": "evt_demo_purchase_001",
+  "eventType": "checkout.session.completed",
+  "occurredAtIso": "2026-04-21T10:12:00.000Z",
+  "receivedAtIso": "2026-04-21T10:12:01.000Z",
+  "userId": "demo-user-1",
+  "purchase": {
+    "productId": "unlock_shanghai_auction_pass",
+    "quantity": 1,
+    "currency": "usd",
+    "amount": 1200
+  },
+  "status": "persisted",
+  "idempotencyKey": "stripe:evt_demo_purchase_001"
+}

--- a/packages/contracts/fixtures/commerce.unlock-grant.sample.json
+++ b/packages/contracts/fixtures/commerce.unlock-grant.sample.json
@@ -1,0 +1,14 @@
+{
+  "grantId": "grant_demo_001",
+  "userId": "demo-user-1",
+  "grantedAtIso": "2026-04-21T10:05:00.000Z",
+  "unlock": {
+    "kind": "location_mode",
+    "city": "shanghai",
+    "location": "practice_studio",
+    "mode": "hangout",
+    "tier": "advanced"
+  },
+  "reason": "mission_assessment_passed",
+  "idempotencyKey": "demo-grant-shanghai-practice-studio-advanced"
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal, additive commerce contract and deterministic mock API so client work for Stripe + Shanghai auction can proceed against a stable local surface.
- Keep schema changes in `packages/contracts` first and ensure mock routes are demo-friendly and replay-safe via `idempotencyKey`.

### Description
- Added contract documentation for `GET /api/v1/commerce/entitlements`, `POST /api/v1/commerce/unlocks/grant`, and `POST /api/v1/commerce/purchase-events` in `packages/contracts/api-contract.md`.
- Added deterministic fixtures in `packages/contracts/fixtures/` for `commerce.entitlements.sample.json`, `commerce.unlock-grant.sample.json`, and `commerce.purchase-event.sample.json` that capture entitlement snapshots, unlock grants, and purchase-event records.
- Wired fixture-backed mock routes in `apps/worker/src/index.ts` that return the fixtures and accept request-field overrides for `userId`, `unlock`, `providerEventId`, and produce `idempotencyKey` values for replay-safety.
- Kept changes additive and local-demo only and marked this delivery partial for #253 (no real Stripe integration or durable persistence added).

### Testing
- Ran the repo queue planner with `python .agents/skills/_functional-qa/scripts/issue_router.py plan erniesg/tong#253` which produced a queued plan for `#253`.
- Installed worker deps and started the local worker with `npm --prefix apps/worker install` and `npm --prefix apps/worker run dev` which launched the mock server on `http://localhost:8788`.
- Ran the worker-local mock flow check `npm run test:api-flow:worker-local` which completed but failed the pre-existing unrelated `/api/v1/integrations/spotify/status` check (this failure is unrelated to new commerce routes).
- Exercised the new endpoints with curl + node assertions which passed: `GET /api/v1/commerce/entitlements?userId=demo-user-1` (output: "entitlements ok practice_studio"), `POST /api/v1/commerce/unlocks/grant` (output: "unlock grant ok grant_demo_001"), and `POST /api/v1/commerce/purchase-events` (output: "purchase event ok purchase_evt_demo_001").

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7c3cb3bc4832a9e330da3e3643d7e)