### PR TITLE
Add panorama-capable cinematic runtime base for Shanghai onboarding

### DIFF
--- a/apps/client/app/backstage/page.tsx
+++ b/apps/client/app/backstage/page.tsx
@@ -33,6 +33,12 @@ const SECTIONS = [
     description: 'Playtest session analysis — Gemini video understanding, issue extraction, auto-fix pipeline.',
     status: 'active',
   },
+  {
+    href: '/backstage/panorama-runtime',
+    title: 'Panorama Runtime',
+    description: 'Non-production harness for Shanghai cinematic pan + overlay anchoring validation.',
+    status: 'active',
+  },
 ];
 
 export default function BackstageOverview() {

--- a/apps/client/app/backstage/panorama-runtime/page.tsx
+++ b/apps/client/app/backstage/panorama-runtime/page.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { useState } from 'react';
+import { CinematicOverlay } from '@/components/scene/CinematicOverlay';
+
+const SHANGHAI_SAMPLE_ASSET = '/assets/locations/shanghai.mp4';
+
+export default function PanoramaRuntimeBackstagePage() {
+  const [playing, setPlaying] = useState(true);
+
+  return (
+    <main className="panorama-runtime-page">
+      <div className="panorama-runtime-note">
+        <h1>Panorama Runtime Harness (Non-production)</h1>
+        <p>
+          Isolated QA surface for onboarding cinematic pan behavior.
+          This route is intentionally separate from <code>/onboarding/shanghai</code>.
+        </p>
+        {!playing && (
+          <button type="button" className="panorama-runtime-replay" onClick={() => setPlaying(true)}>
+            Replay panorama sample
+          </button>
+        )}
+      </div>
+
+      {playing && (
+        <CinematicOverlay
+          videoUrl={SHANGHAI_SAMPLE_ASSET}
+          caption="上海的夜风有点甜。"
+          captionTranslation="The night breeze in Shanghai feels a little sweet."
+          autoAdvance={false}
+          muted
+          presentation={{
+            mode: 'panorama',
+            mediaWidth: 1920,
+            mediaHeight: 1080,
+            overlays: [
+              { id: 'street', anchor: 'world', x: 520, y: 700, label: 'Food Street' },
+              { id: 'cafe', anchor: 'world', x: 1290, y: 600, label: 'Cafe' },
+            ],
+          }}
+          onEnd={() => setPlaying(false)}
+        />
+      )}
+    </main>
+  );
+}

--- a/apps/client/app/globals.css
+++ b/apps/client/app/globals.css
@@ -2172,6 +2172,13 @@ button.nav-link:hover {
   animation: cinematicFadeOut 0.5s ease-in forwards;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .cinematic-overlay,
+  .cinematic-overlay.cinematic-fade-out {
+    animation-duration: 0.01ms;
+  }
+}
+
 @keyframes cinematicFadeIn {
   from { opacity: 0; }
   to   { opacity: 1; }
@@ -2180,6 +2187,25 @@ button.nav-link:hover {
 @keyframes cinematicFadeOut {
   from { opacity: 1; }
   to   { opacity: 0; }
+}
+
+.cinematic-viewport {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+}
+
+.cinematic-viewport--cover .cinematic-media-track {
+  width: 100%;
+  height: 100%;
+}
+
+.cinematic-viewport--panorama .cinematic-media-track {
+  position: absolute;
+  left: 0;
+  top: 0;
+  height: 100%;
+  min-width: 100%;
 }
 
 .cinematic-video {
@@ -2192,6 +2218,19 @@ button.nav-link:hover {
 }
 .cinematic-video::-webkit-media-controls-enclosure {
   display: none !important;
+}
+
+.cinematic-world-overlay-item {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  border: 1px solid rgba(255, 255, 255, 0.42);
+  background: rgba(12, 10, 20, 0.52);
+  color: rgba(255, 255, 255, 0.95);
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-size: 11px;
+  pointer-events: none;
+  white-space: nowrap;
 }
 
 .cinematic-tap-hint {
@@ -6762,6 +6801,45 @@ button.nav-link:hover {
   height: 100%;
   object-fit: cover;
   z-index: 0;
+}
+
+.panorama-runtime-page {
+  min-height: 100vh;
+  background: #050507;
+  color: #fff;
+}
+
+.panorama-runtime-note {
+  position: relative;
+  z-index: 120;
+  margin: 16px;
+  max-width: 520px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(8, 8, 12, 0.66);
+  padding: 12px 14px;
+}
+
+.panorama-runtime-note h1 {
+  margin: 0 0 6px;
+  font-size: 15px;
+  font-weight: 700;
+}
+
+.panorama-runtime-note p {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.panorama-runtime-replay {
+  margin-top: 10px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  background: rgba(255, 255, 255, 0.1);
+  color: #fff;
+  padding: 8px 10px;
+  font-size: 12px;
 }
 
 .summary-overlay {

--- a/apps/client/components/scene/CinematicOverlay.tsx
+++ b/apps/client/components/scene/CinematicOverlay.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { useRef, useCallback, useState, useEffect, useMemo } from 'react';
+import { useRef, useCallback, useState, useEffect, useMemo, type PointerEvent } from 'react';
 import { useUILang } from '@/lib/i18n/UILangContext';
 import { t } from '@/lib/i18n/ui-strings';
 import { KoreanText, type TargetLang } from '@/components/shared/KoreanText';
 import { fallbackRuntimeAssetCandidates } from '@/lib/runtime-assets';
+import type { CinematicPresentation, CinematicWorldOverlayItem } from '@/lib/types/hangout';
 
 const CAPTION_CHARS_PER_TICK = 2;
 const CAPTION_TICK_MS = 35;
@@ -15,18 +16,46 @@ interface CinematicOverlayProps {
   captionTranslation?: string;
   autoAdvance: boolean;
   muted?: boolean;
+  presentation?: CinematicPresentation;
   targetLang?: TargetLang;
   onEnd: () => void;
 }
 
-export function CinematicOverlay({ videoUrl, caption, captionTranslation, autoAdvance, muted = false, targetLang = 'ko', onEnd }: CinematicOverlayProps) {
+interface Bounds {
+  minX: number;
+  maxX: number;
+}
+
+export function CinematicOverlay({
+  videoUrl,
+  caption,
+  captionTranslation,
+  autoAdvance,
+  muted = false,
+  presentation,
+  targetLang = 'ko',
+  onEnd,
+}: CinematicOverlayProps) {
   const lang = useUILang();
+  const viewportRef = useRef<HTMLDivElement>(null);
   const videoRef = useRef<HTMLVideoElement>(null);
   const [fadingOut, setFadingOut] = useState(false);
   const [captionVisible, setCaptionVisible] = useState(false);
   const [candidateIndex, setCandidateIndex] = useState(0);
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+  const [viewportSize, setViewportSize] = useState({ width: 1, height: 1 });
+  const [mediaSize, setMediaSize] = useState({ width: presentation?.mediaWidth ?? 1, height: presentation?.mediaHeight ?? 1 });
+  const [panX, setPanX] = useState(0);
+  const panXRef = useRef(0);
+  const panDraggedRef = useRef(false);
+  const panDragRef = useRef<{ pointerId: number; startClientX: number; originPanX: number } | null>(null);
   const videoCandidates = useMemo(() => fallbackRuntimeAssetCandidates(videoUrl), [videoUrl]);
   const activeVideoUrl = videoCandidates[candidateIndex] ?? '';
+  const mode = presentation?.mode ?? 'cover';
+  const panoramaScale = useMemo(
+    () => Math.max(viewportSize.width / Math.max(1, mediaSize.width), viewportSize.height / Math.max(1, mediaSize.height)),
+    [mediaSize.height, mediaSize.width, viewportSize.height, viewportSize.width],
+  );
 
   // Typewriter state for caption
   const [captionChars, setCaptionChars] = useState(0);
@@ -50,6 +79,111 @@ export function CinematicOverlay({ videoUrl, caption, captionTranslation, autoAd
   useEffect(() => {
     setCandidateIndex(0);
   }, [videoUrl]);
+
+  useEffect(() => {
+    setMediaSize({
+      width: presentation?.mediaWidth ?? 1,
+      height: presentation?.mediaHeight ?? 1,
+    });
+  }, [presentation?.mediaHeight, presentation?.mediaWidth]);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    setPrefersReducedMotion(mediaQuery.matches);
+    const onChange = (event: MediaQueryListEvent) => setPrefersReducedMotion(event.matches);
+    mediaQuery.addEventListener('change', onChange);
+    return () => mediaQuery.removeEventListener('change', onChange);
+  }, []);
+
+  useEffect(() => {
+    const viewportEl = viewportRef.current;
+    if (!viewportEl) return;
+    const updateSize = () => {
+      setViewportSize({
+        width: viewportEl.clientWidth || 1,
+        height: viewportEl.clientHeight || 1,
+      });
+    };
+    updateSize();
+    const resizeObserver = new ResizeObserver(updateSize);
+    resizeObserver.observe(viewportEl);
+    return () => resizeObserver.disconnect();
+  }, []);
+
+  const getPanBounds = useCallback((): Bounds => {
+    if (mode !== 'panorama') return { minX: 0, maxX: 0 };
+    const renderedWidth = mediaSize.width * panoramaScale;
+    const overflowX = Math.max(0, renderedWidth - viewportSize.width);
+    return { minX: -overflowX, maxX: 0 };
+  }, [mediaSize.width, mode, panoramaScale, viewportSize.width]);
+
+  useEffect(() => {
+    if (mode !== 'panorama') {
+      panXRef.current = 0;
+      setPanX(0);
+      return;
+    }
+    const bounds = getPanBounds();
+    const clamped = Math.max(bounds.minX, Math.min(bounds.maxX, panXRef.current));
+    if (clamped !== panXRef.current) {
+      panXRef.current = clamped;
+      setPanX(clamped);
+    }
+  }, [getPanBounds, mode, viewportSize.height, viewportSize.width]);
+
+  const updatePan = useCallback((nextPan: number) => {
+    const bounds = getPanBounds();
+    const clamped = Math.max(bounds.minX, Math.min(bounds.maxX, nextPan));
+    panXRef.current = clamped;
+    setPanX(clamped);
+  }, [getPanBounds]);
+
+  const handlePanPointerDown = useCallback((event: PointerEvent<HTMLDivElement>) => {
+    if (mode !== 'panorama') return;
+    if (event.pointerType === 'mouse' && event.button !== 0) return;
+    event.currentTarget.setPointerCapture(event.pointerId);
+    panDraggedRef.current = false;
+    panDragRef.current = { pointerId: event.pointerId, startClientX: event.clientX, originPanX: panXRef.current };
+  }, [mode]);
+
+  const handlePanPointerMove = useCallback((event: PointerEvent<HTMLDivElement>) => {
+    const drag = panDragRef.current;
+    if (!drag || drag.pointerId !== event.pointerId) return;
+    if (Math.abs(event.clientX - drag.startClientX) > 4) panDraggedRef.current = true;
+    updatePan(drag.originPanX + (event.clientX - drag.startClientX));
+  }, [updatePan]);
+
+  const handlePanPointerUp = useCallback((event: PointerEvent<HTMLDivElement>) => {
+    const drag = panDragRef.current;
+    if (drag && drag.pointerId === event.pointerId) {
+      panDragRef.current = null;
+    }
+  }, []);
+
+  const mediaTransformStyle = mode === 'panorama'
+    ? {
+      transform: `translate3d(${panX}px, 0, 0) scale(${panoramaScale})`,
+      transformOrigin: 'top left',
+      transition: prefersReducedMotion ? 'none' : 'transform 180ms ease-out',
+      width: `${Math.max(1, mediaSize.width)}px`,
+      height: `${Math.max(1, mediaSize.height)}px`,
+    }
+    : undefined;
+
+  const renderWorldOverlay = (overlay: CinematicWorldOverlayItem) => {
+    const xPercent = Math.max(0, Math.min(100, (overlay.x / Math.max(1, mediaSize.width)) * 100));
+    const yPercent = Math.max(0, Math.min(100, (overlay.y / Math.max(1, mediaSize.height)) * 100));
+    return (
+      <button
+        key={overlay.id}
+        type="button"
+        className="cinematic-world-overlay-item"
+        style={{ left: `${xPercent}%`, top: `${yPercent}%` }}
+      >
+        {overlay.label}
+      </button>
+    );
+  };
 
   // Autoplay with unmute fallback + audio fade-in
   useEffect(() => {
@@ -126,6 +260,10 @@ export function CinematicOverlay({ videoUrl, caption, captionTranslation, autoAd
     <div
       className={`cinematic-overlay ${fadingOut ? 'cinematic-fade-out' : ''}`}
       onClick={(e) => {
+        if (mode === 'panorama' && panDraggedRef.current) {
+          panDraggedRef.current = false;
+          return;
+        }
         const v = videoRef.current;
         if (v && v.muted && !muted) {
           // First tap unmutes if autoplay was forced muted
@@ -137,27 +275,46 @@ export function CinematicOverlay({ videoUrl, caption, captionTranslation, autoAd
       role={autoAdvance ? undefined : 'button'}
       tabIndex={autoAdvance ? undefined : 0}
     >
-      <video
-        ref={videoRef}
-        src={activeVideoUrl}
-        playsInline
-        muted={muted}
-        onEnded={handleEnded}
-        onError={() => {
-          if (candidateIndex + 1 < videoCandidates.length) {
-            setCandidateIndex(candidateIndex + 1);
-          } else {
-            triggerEnd();
-          }
-        }}
-        className="cinematic-video"
-        disablePictureInPicture
-        disableRemotePlayback
-        controlsList="nodownload noplaybackrate"
-      />
+      <div
+        ref={viewportRef}
+        className={`cinematic-viewport cinematic-viewport--${mode}`}
+        onPointerDown={handlePanPointerDown}
+        onPointerMove={handlePanPointerMove}
+        onPointerUp={handlePanPointerUp}
+        onPointerCancel={handlePanPointerUp}
+      >
+        <div className="cinematic-media-track" style={mediaTransformStyle}>
+          <video
+            ref={videoRef}
+            src={activeVideoUrl}
+            playsInline
+            muted={muted}
+            onLoadedMetadata={() => {
+              const v = videoRef.current;
+              if (!v) return;
+              if (v.videoWidth && v.videoHeight) {
+                setMediaSize({ width: v.videoWidth, height: v.videoHeight });
+              }
+            }}
+            onEnded={handleEnded}
+            onError={() => {
+              if (candidateIndex + 1 < videoCandidates.length) {
+                setCandidateIndex(candidateIndex + 1);
+              } else {
+                triggerEnd();
+              }
+            }}
+            className="cinematic-video"
+            disablePictureInPicture
+            disableRemotePlayback
+            controlsList="nodownload noplaybackrate"
+          />
+          {presentation?.overlays?.filter((overlay) => overlay.anchor === 'world').map(renderWorldOverlay)}
+        </div>
+      </div>
       {caption && (
         <div
-          className={`cinematic-subtitle-bar ${captionVisible ? 'cinematic-subtitle-visible' : ''}`}
+          className={`cinematic-subtitle-bar cinematic-subtitle-bar--viewport ${captionVisible ? 'cinematic-subtitle-visible' : ''}`}
           style={captionTypewriterDone ? { pointerEvents: 'auto' } : undefined}
         >
           <p className="cinematic-subtitle-text">

--- a/apps/client/components/scene/SceneView.tsx
+++ b/apps/client/components/scene/SceneView.tsx
@@ -1,7 +1,13 @@
 'use client';
 
 import { useRef, useCallback, useState, useEffect } from 'react';
-import type { CreditGateState, ExerciseData, SessionMessage, WebtoonSequence } from '@/lib/types/hangout';
+import type {
+  CinematicPresentation,
+  CreditGateState,
+  ExerciseData,
+  SessionMessage,
+  WebtoonSequence,
+} from '@/lib/types/hangout';
 import type { TargetLang } from '@/components/shared/KoreanText';
 import { CHARACTER_MAP } from '@/lib/content/characters';
 import { Background } from './Background';
@@ -17,7 +23,14 @@ interface SceneViewProps {
   backgroundUrl: string;
   backgroundTransition?: 'fade' | 'cut';
   ambientDescription?: string;
-  cinematic?: { videoUrl: string; caption?: string; captionTranslation?: string; autoAdvance: boolean; muted?: boolean } | null;
+  cinematic?: {
+    videoUrl: string;
+    caption?: string;
+    captionTranslation?: string;
+    autoAdvance: boolean;
+    muted?: boolean;
+    presentation?: CinematicPresentation;
+  } | null;
   onCinematicEnd?: () => void;
   npcName?: string;
   npcColor?: string;
@@ -158,6 +171,7 @@ export function SceneView({
           captionTranslation={cinematic.captionTranslation}
           autoAdvance={cinematic.autoAdvance}
           muted={cinematic.muted ?? false}
+          presentation={cinematic.presentation}
           targetLang={targetLang}
           onEnd={handleCinematicEnd}
         />

--- a/apps/client/lib/types/hangout.ts
+++ b/apps/client/lib/types/hangout.ts
@@ -41,6 +41,29 @@ export interface CreditGateState {
   skipPayload: CreditGate['skipPayload'];
 }
 
+export type CinematicPresentationMode = 'cover' | 'panorama';
+
+export type CinematicOverlayAnchor = 'viewport' | 'world';
+
+export interface CinematicWorldOverlayItem {
+  id: string;
+  anchor: CinematicOverlayAnchor;
+  x: number;
+  y: number;
+  label: string;
+}
+
+export interface CinematicPresentation {
+  mode?: CinematicPresentationMode;
+  /**
+   * Authored media dimensions used to map world overlays and pan bounds.
+   * When omitted, runtime video metadata is used.
+   */
+  mediaWidth?: number;
+  mediaHeight?: number;
+  overlays?: CinematicWorldOverlayItem[];
+}
+
 export interface SceneSummary {
   summary: string;
   xpEarned: number;


### PR DESCRIPTION
### Motivation
- Add a panorama presentation mode for onboarding cinematics so Shanghai scenes can support wide/scrolling media with authored overlay anchors and mobile-first pan interactions.
- Preserve existing `cover` cinematic behavior and make overlay anchoring explicit so UI can distinguish viewport-fixed vs media-bound elements.
- Provide a clearly non-production QA harness so reviewers can exercise panorama behavior without touching onboarding routes.

### Description
- Introduced typed cinematic presentation contract in `apps/client/lib/types/hangout.ts` (`CinematicPresentation`, `CinematicWorldOverlayItem`, `mode`, authored `mediaWidth`/`mediaHeight`).
- Implemented panorama-capable runtime in `apps/client/components/scene/CinematicOverlay.tsx` with horizontal pointer/touch panning, clamped pan bounds (no blank gutters), world-overlay rendering (media coordinates → percent mapping), reduced-motion handling, and fallback to `cover` mode.
- Threaded the new `presentation` payload through `SceneView` (`apps/client/components/scene/SceneView.tsx`) without changing existing default behavior.
- Added CSS for viewport/media-track structure, world-overlay styling, and `prefers-reduced-motion` rules in `apps/client/app/globals.css`.
- Added an isolated non-production QA harness at `/backstage/panorama-runtime` and surfaced it in the backstage index (`apps/client/app/backstage/panorama-runtime/page.tsx`, `apps/client/app/backstage/page.tsx`), using the repo-visible placeholder asset `/assets/locations/shanghai.mp4`.

### Testing
- Started validation flow and local server: `npm --prefix apps/client run dev -- -p 3004` (server started successfully at `http://localhost:3004`). — succeeded.
- Confirmed harness route availability with `curl -I http://localhost:3004/backstage/panorama-runtime` and `curl -I http://localhost:3004/backstage` — both returned `200 OK`. — succeeded.
- Ran project typecheck: `cd apps/client && npx tsc --noEmit` — succeeded (no type errors reported).
- QA scripts: queued/initialized validation run via the repo QA tooling (`issue_router.py plan 258`, `qa_runtime.py init-run validate-issue`) and ran `npm run qa:suggest-recipe` for guidance. — succeeded.
- Playwright/device emulation not available in this environment (`ERROR: playwright not installed`), so automated desktop/mobile browser capture and final Safari/Android acceptance are pending. — blocked.

How to test locally
1. `npm --prefix apps/client run dev -- -p 3004`
2. Open `http://localhost:3004/backstage/panorama-runtime` and interact (drag/touch-pan) to verify clamped panning, viewport-fixed captions/tap hint, and world overlays moving with media.
3. Verify existing `cover` cinematics remain unchanged by running flows that show the default cinematic.

Blockers / follow-ups
- The harness uses a repo placeholder clip; final acceptance should be re-run with the production ultra-wide Shanghai asset when available.
- Full cross-device acceptance (Safari on macOS/iOS and Android) requires Playwright or device testing in a reviewer environment and remains pending.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7c3b81dbc832a95533e3aefcf6750)