### PR TITLE
feat(client): panorama cinematic mode with anchored overlays and non-production lab (#258)

### DIFF
--- a/apps/client/app/backstage/page.tsx
+++ b/apps/client/app/backstage/page.tsx
@@ -16,6 +16,12 @@ const SECTIONS = [
     status: 'active',
   },
   {
+    href: '/backstage/panorama-lab',
+    title: 'Panorama Lab',
+    description: 'Non-production cinematic harness for panorama panning and overlay anchor behavior.',
+    status: 'active',
+  },
+  {
     href: '/backstage/signals',
     title: 'Signals',
     description: 'Social media intelligence — trending formats, sounds, aesthetics from TikTok/IG/XHS.',

--- a/apps/client/app/backstage/panorama-lab/page.tsx
+++ b/apps/client/app/backstage/panorama-lab/page.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useMemo } from 'react';
+import { CinematicOverlay } from '@/components/scene/CinematicOverlay';
+
+const SAMPLE_VIDEO_URL = '/assets/locations/shanghai.mp4';
+
+export default function PanoramaLabPage() {
+  const sampleOverlays = useMemo(() => ([
+    { id: 'viewport-title', anchor: 'viewport' as const, label: 'Viewport overlay (fixed)', x: 0.5, y: 0.1 },
+    { id: 'world-food', anchor: 'world' as const, label: 'World marker: Food Street', x: 0.24, y: 0.42 },
+    { id: 'world-subway', anchor: 'world' as const, label: 'World marker: Subway Hub', x: 0.74, y: 0.5 },
+  ]), []);
+
+  return (
+    <section style={{ display: 'grid', gap: 12 }}>
+      <header>
+        <p className="kicker">Backstage • Non-production harness</p>
+        <h2 style={{ margin: '4px 0 8px' }}>Panorama Cinematic Lab</h2>
+        <p className="page-copy">
+          Drag horizontally (mouse or touch) to pan. World overlays move with the media while viewport overlays stay fixed.
+        </p>
+      </header>
+
+      <div
+        style={{
+          position: 'relative',
+          borderRadius: 18,
+          overflow: 'hidden',
+          border: '1px solid var(--line)',
+          width: '100%',
+          aspectRatio: '9 / 16',
+          maxHeight: 'min(72svh, 760px)',
+          background: '#000',
+        }}
+      >
+        <CinematicOverlay
+          videoUrl={SAMPLE_VIDEO_URL}
+          caption="외탄 야경부터 지하철 허브까지 — 시선을 움직여 보세요."
+          captionTranslation="From Bund night lights to the subway hub — drag to explore the panorama."
+          autoAdvance={false}
+          muted
+          mode="panorama"
+          initialPan={0.5}
+          overlays={sampleOverlays}
+          onEnd={() => {}}
+        />
+      </div>
+    </section>
+  );
+}

--- a/apps/client/app/globals.css
+++ b/apps/client/app/globals.css
@@ -2187,6 +2187,48 @@ button.nav-link:hover {
   height: 100%;
   object-fit: cover;
 }
+.cinematic-frame {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+}
+
+.cinematic-world-layer {
+  position: absolute;
+  inset: 0;
+}
+
+.cinematic-video--panorama {
+  width: auto;
+  min-width: 100%;
+  height: 100%;
+  max-width: none;
+  object-fit: contain;
+  object-position: left center;
+}
+
+.cinematic-hotspot {
+  position: absolute;
+  z-index: 1;
+  transform: translate(-50%, -50%);
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.34);
+  padding: 6px 10px;
+  font-size: 11px;
+  letter-spacing: 0.01em;
+  color: rgba(255, 255, 255, 0.96);
+  background: rgba(10, 10, 10, 0.68);
+  backdrop-filter: blur(5px);
+  white-space: nowrap;
+}
+
+.cinematic-hotspot--viewport {
+  z-index: 3;
+}
+
+.cinematic-hotspot--world {
+  z-index: 1;
+}
 .cinematic-video::-webkit-media-controls {
   display: none !important;
 }
@@ -2245,6 +2287,16 @@ button.nav-link:hover {
   color: rgba(255,255,255,0.75);
   line-height: 1.35;
   text-shadow: 0 1px 3px rgba(0,0,0,0.7);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cinematic-overlay,
+  .cinematic-overlay.cinematic-fade-out,
+  .cinematic-subtitle-bar,
+  .cinematic-tap-hint {
+    animation: none !important;
+    transition: none !important;
+  }
 }
 
 .webtoon-overlay {

--- a/apps/client/components/scene/CinematicOverlay.tsx
+++ b/apps/client/components/scene/CinematicOverlay.tsx
@@ -5,6 +5,7 @@ import { useUILang } from '@/lib/i18n/UILangContext';
 import { t } from '@/lib/i18n/ui-strings';
 import { KoreanText, type TargetLang } from '@/components/shared/KoreanText';
 import { fallbackRuntimeAssetCandidates } from '@/lib/runtime-assets';
+import type { CinematicOverlayHotspot, CinematicPresentationMode } from '@/lib/types/hangout';
 
 const CAPTION_CHARS_PER_TICK = 2;
 const CAPTION_TICK_MS = 35;
@@ -15,18 +16,45 @@ interface CinematicOverlayProps {
   captionTranslation?: string;
   autoAdvance: boolean;
   muted?: boolean;
+  mode?: CinematicPresentationMode;
+  initialPan?: number;
+  overlays?: CinematicOverlayHotspot[];
   targetLang?: TargetLang;
   onEnd: () => void;
 }
 
-export function CinematicOverlay({ videoUrl, caption, captionTranslation, autoAdvance, muted = false, targetLang = 'ko', onEnd }: CinematicOverlayProps) {
+const clamp01 = (value: number): number => Math.min(1, Math.max(0, value));
+
+export function CinematicOverlay({
+  videoUrl,
+  caption,
+  captionTranslation,
+  autoAdvance,
+  muted = false,
+  mode = 'cover',
+  initialPan = 0.5,
+  overlays = [],
+  targetLang = 'ko',
+  onEnd,
+}: CinematicOverlayProps) {
   const lang = useUILang();
+  const isPanorama = mode === 'panorama';
   const videoRef = useRef<HTMLVideoElement>(null);
+  const frameRef = useRef<HTMLDivElement>(null);
   const [fadingOut, setFadingOut] = useState(false);
   const [captionVisible, setCaptionVisible] = useState(false);
   const [candidateIndex, setCandidateIndex] = useState(0);
   const videoCandidates = useMemo(() => fallbackRuntimeAssetCandidates(videoUrl), [videoUrl]);
   const activeVideoUrl = videoCandidates[candidateIndex] ?? '';
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+  const [panPixels, setPanPixels] = useState(0);
+  const [panBounds, setPanBounds] = useState(0);
+  const dragStateRef = useRef<{ active: boolean; moved: boolean; startX: number; startPan: number }>({
+    active: false,
+    moved: false,
+    startX: 0,
+    startPan: 0,
+  });
 
   // Typewriter state for caption
   const [captionChars, setCaptionChars] = useState(0);
@@ -50,6 +78,77 @@ export function CinematicOverlay({ videoUrl, caption, captionTranslation, autoAd
   useEffect(() => {
     setCandidateIndex(0);
   }, [videoUrl]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const media = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const syncPreference = () => setPrefersReducedMotion(media.matches);
+    syncPreference();
+    media.addEventListener('change', syncPreference);
+    return () => media.removeEventListener('change', syncPreference);
+  }, []);
+
+  useEffect(() => {
+    setPanPixels(0);
+    setPanBounds(0);
+  }, [activeVideoUrl, mode]);
+
+  useEffect(() => {
+    if (!isPanorama) return;
+    const frameEl = frameRef.current;
+    const videoEl = videoRef.current;
+    if (!frameEl || !videoEl) return;
+
+    const updatePanGeometry = () => {
+      const viewportWidth = frameEl.clientWidth;
+      const viewportHeight = frameEl.clientHeight;
+      const intrinsicWidth = videoEl.videoWidth;
+      const intrinsicHeight = videoEl.videoHeight;
+      if (!viewportWidth || !viewportHeight || !intrinsicWidth || !intrinsicHeight) return;
+
+      const renderWidth = (viewportHeight * intrinsicWidth) / intrinsicHeight;
+      const nextBounds = Math.max(0, Math.round(renderWidth - viewportWidth));
+      setPanBounds(nextBounds);
+      setPanPixels(clamp01(initialPan) * nextBounds);
+    };
+
+    videoEl.addEventListener('loadedmetadata', updatePanGeometry);
+    window.addEventListener('resize', updatePanGeometry);
+    updatePanGeometry();
+    return () => {
+      videoEl.removeEventListener('loadedmetadata', updatePanGeometry);
+      window.removeEventListener('resize', updatePanGeometry);
+    };
+  }, [activeVideoUrl, initialPan, isPanorama]);
+
+  const handlePointerDown = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    if (!isPanorama || panBounds <= 0) return;
+    dragStateRef.current = { active: true, moved: false, startX: event.clientX, startPan: panPixels };
+    event.currentTarget.setPointerCapture(event.pointerId);
+  }, [isPanorama, panBounds, panPixels]);
+
+  const handlePointerMove = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    if (!dragStateRef.current.active || panBounds <= 0) return;
+    const deltaX = event.clientX - dragStateRef.current.startX;
+    if (Math.abs(deltaX) > 4) {
+      dragStateRef.current.moved = true;
+    }
+    const nextPan = dragStateRef.current.startPan - deltaX;
+    setPanPixels(Math.min(panBounds, Math.max(0, nextPan)));
+  }, [panBounds]);
+
+  const handlePointerUp = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    if (!dragStateRef.current.active) return false;
+    const moved = dragStateRef.current.moved;
+    dragStateRef.current = { active: false, moved: false, startX: 0, startPan: panPixels };
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    return moved;
+  }, [panPixels]);
+
+  const worldOverlays = overlays.filter((overlay) => overlay.anchor === 'world');
+  const viewportOverlays = overlays.filter((overlay) => overlay.anchor === 'viewport');
 
   // Autoplay with unmute fallback + audio fade-in
   useEffect(() => {
@@ -126,6 +225,7 @@ export function CinematicOverlay({ videoUrl, caption, captionTranslation, autoAd
     <div
       className={`cinematic-overlay ${fadingOut ? 'cinematic-fade-out' : ''}`}
       onClick={(e) => {
+        if (dragStateRef.current.moved) return;
         const v = videoRef.current;
         if (v && v.muted && !muted) {
           // First tap unmutes if autoplay was forced muted
@@ -134,27 +234,53 @@ export function CinematicOverlay({ videoUrl, caption, captionTranslation, autoAd
         }
         handleTap();
       }}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={handlePointerUp}
       role={autoAdvance ? undefined : 'button'}
       tabIndex={autoAdvance ? undefined : 0}
     >
-      <video
-        ref={videoRef}
-        src={activeVideoUrl}
-        playsInline
-        muted={muted}
-        onEnded={handleEnded}
-        onError={() => {
-          if (candidateIndex + 1 < videoCandidates.length) {
-            setCandidateIndex(candidateIndex + 1);
-          } else {
-            triggerEnd();
-          }
-        }}
-        className="cinematic-video"
-        disablePictureInPicture
-        disableRemotePlayback
-        controlsList="nodownload noplaybackrate"
-      />
+      <div ref={frameRef} className={`cinematic-frame cinematic-frame--${mode}`}>
+        <div
+          className="cinematic-world-layer"
+          style={isPanorama ? {
+            transform: `translate3d(${-panPixels}px, 0, 0)`,
+            transition: prefersReducedMotion ? 'none' : 'transform 220ms ease-out',
+          } : undefined}
+        >
+          <video
+            ref={videoRef}
+            src={activeVideoUrl}
+            playsInline
+            muted={muted}
+            onEnded={handleEnded}
+            onError={() => {
+              if (candidateIndex + 1 < videoCandidates.length) {
+                setCandidateIndex(candidateIndex + 1);
+              } else {
+                triggerEnd();
+              }
+            }}
+            className={`cinematic-video cinematic-video--${mode}`}
+            disablePictureInPicture
+            disableRemotePlayback
+            controlsList="nodownload noplaybackrate"
+          />
+          {worldOverlays.map((overlay) => (
+            <div
+              key={overlay.id}
+              className="cinematic-hotspot cinematic-hotspot--world"
+              style={{
+                left: `${clamp01(overlay.x) * 100}%`,
+                top: `${clamp01(overlay.y) * 100}%`,
+              }}
+            >
+              {overlay.label}
+            </div>
+          ))}
+        </div>
+      </div>
       {caption && (
         <div
           className={`cinematic-subtitle-bar ${captionVisible ? 'cinematic-subtitle-visible' : ''}`}
@@ -175,6 +301,18 @@ export function CinematicOverlay({ videoUrl, caption, captionTranslation, autoAd
           )}
         </div>
       )}
+      {viewportOverlays.map((overlay) => (
+        <div
+          key={overlay.id}
+          className="cinematic-hotspot cinematic-hotspot--viewport"
+          style={{
+            left: `${clamp01(overlay.x) * 100}%`,
+            top: `${clamp01(overlay.y) * 100}%`,
+          }}
+        >
+          {overlay.label}
+        </div>
+      ))}
       {!autoAdvance && !fadingOut && (
         <div className="cinematic-tap-hint">{t('tap_to_skip', lang)}</div>
       )}

--- a/apps/client/components/scene/SceneView.tsx
+++ b/apps/client/components/scene/SceneView.tsx
@@ -1,7 +1,13 @@
 'use client';
 
 import { useRef, useCallback, useState, useEffect } from 'react';
-import type { CreditGateState, ExerciseData, SessionMessage, WebtoonSequence } from '@/lib/types/hangout';
+import type {
+  CinematicPresentation,
+  CreditGateState,
+  ExerciseData,
+  SessionMessage,
+  WebtoonSequence,
+} from '@/lib/types/hangout';
 import type { TargetLang } from '@/components/shared/KoreanText';
 import { CHARACTER_MAP } from '@/lib/content/characters';
 import { Background } from './Background';
@@ -17,7 +23,7 @@ interface SceneViewProps {
   backgroundUrl: string;
   backgroundTransition?: 'fade' | 'cut';
   ambientDescription?: string;
-  cinematic?: { videoUrl: string; caption?: string; captionTranslation?: string; autoAdvance: boolean; muted?: boolean } | null;
+  cinematic?: CinematicPresentation | null;
   onCinematicEnd?: () => void;
   npcName?: string;
   npcColor?: string;
@@ -158,6 +164,9 @@ export function SceneView({
           captionTranslation={cinematic.captionTranslation}
           autoAdvance={cinematic.autoAdvance}
           muted={cinematic.muted ?? false}
+          mode={cinematic.mode ?? 'cover'}
+          initialPan={cinematic.initialPan}
+          overlays={cinematic.overlays}
           targetLang={targetLang}
           onEnd={handleCinematicEnd}
         />

--- a/apps/client/lib/types/hangout.ts
+++ b/apps/client/lib/types/hangout.ts
@@ -16,6 +16,28 @@ export interface SessionMessage {
   exercise?: ExerciseData;
 }
 
+export type CinematicPresentationMode = 'cover' | 'panorama';
+export type CinematicOverlayAnchor = 'viewport' | 'world';
+
+export interface CinematicOverlayHotspot {
+  id: string;
+  anchor: CinematicOverlayAnchor;
+  label: string;
+  x: number;
+  y: number;
+}
+
+export interface CinematicPresentation {
+  videoUrl: string;
+  caption?: string;
+  captionTranslation?: string;
+  autoAdvance: boolean;
+  muted?: boolean;
+  mode?: CinematicPresentationMode;
+  initialPan?: number;
+  overlays?: CinematicOverlayHotspot[];
+}
+
 export interface DialogueChoice {
   id: string;
   text: string;


### PR DESCRIPTION
### Motivation
- Provide a panorama-capable cinematic presentation for Shanghai onboarding that supports horizontal pan without blank gutters and an explicit overlay anchoring model.
- Preserve existing `cover` cinematic behavior while enabling authored in-world annotations that move with the media and viewport-fixed overlays.
- Offer a clearly non-production local harness so reviewers can validate pan/overlay behavior without touching production routes.

### Description
- Add new shared types in `apps/client/lib/types/hangout.ts` for `CinematicPresentation`, `CinematicOverlayHotspot`, `CinematicPresentationMode`, and anchor semantics (`viewport` | `world`).
- Extend `CinematicOverlay` (`apps/client/components/scene/CinematicOverlay.tsx`) to implement `panorama` mode with pointer/touch drag, clamped pan bounds derived from video metadata, drag/click disambiguation, reduced-motion respect, and rendering of `world` vs `viewport` overlays.
- Wire `SceneView` (`apps/client/components/scene/SceneView.tsx`) to accept the new `CinematicPresentation` contract and forward `mode`, `initialPan`, and `overlays` while remaining backward-compatible.
- Add CSS rules (`apps/client/app/globals.css`) for panorama rendering, hotspot styles, and reduced-motion fallbacks.
- Add a non-production verification harness at `/backstage/panorama-lab` (`apps/client/app/backstage/panorama-lab/page.tsx`) and expose it in the Backstage index for reviewer access.

### Testing
- Initialized a functional QA run scaffold for `erniesg/tong#258` using `python .agents/skills/_functional-qa/scripts/qa_runtime.py init-run validate-issue` which produced an artifacts run directory (run scaffolded before edits).
- Type-checked the client app with `npx --prefix apps/client tsc --noEmit -p apps/client/tsconfig.json` and the check passed.
- Started the client locally with `cd apps/client && npm run ds:build && npx next dev -p 3004` and confirmed the app compiled and served.
- Validated the panorama harness route returned HTTP 200 for desktop and mobile UA using `curl` (requests to `http://127.0.0.1:3004/backstage/panorama-lab` returned `200`).

How to test locally
1. `cd apps/client && npm run ds:build && npx next dev -p 3004`.
2. Open `http://localhost:3004/backstage`, unlock Backstage with the demo password, then open `http://localhost:3004/backstage/panorama-lab`.
3. Drag horizontally with mouse or touch and verify panning is clamped (no black gutters), viewport overlays remain fixed, and world overlays move with the media.
4. Toggle `prefers-reduced-motion` in OS/browser and confirm easing/transitions are reduced.

Notes / blockers
- A clearly temporary sample asset is used: `/assets/locations/shanghai.mp4` (repo-visible placeholder); final wide Shanghai clip may still be missing and is an explicit blocker for final acceptance on real devices.
- I attempted `npm --prefix apps/client run typecheck` but no `typecheck` script exists in `apps/client/package.json`; this step was skipped in favor of `npx tsc`.
- Final local Safari/Android acceptance testing remains pending and should be performed on real devices or device-specific browsers before closing issue #258.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7c3b81dbc832a95533e3aefcf6750)