### PR TITLE
Add panorama-capable cinematic runtime base for Shanghai onboarding

### DIFF
--- a/apps/client/app/backstage/panorama-runtime/page.tsx
+++ b/apps/client/app/backstage/panorama-runtime/page.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { useState } from 'react';
+import { CinematicOverlay } from '@/components/scene/CinematicOverlay';
+
+const SAMPLE_VIDEO = '/assets/locations/shanghai.mp4';
+
+export default function PanoramaRuntimeBackstagePage() {
+  const [mode, setMode] = useState<'cover' | 'panorama'>('panorama');
+  const [playing, setPlaying] = useState(true);
+
+  return (
+    <main style={{ minHeight: '100vh', background: '#111', color: '#fff', padding: 20 }}>
+      <h1 style={{ marginTop: 0 }}>Backstage: Panorama Runtime (Non-production)</h1>
+      <p style={{ maxWidth: 760, opacity: 0.8 }}>
+        Temporary QA harness for issue #258. This route is isolated from onboarding and game production flows.
+      </p>
+      <div style={{ display: 'flex', gap: 8, marginBottom: 12 }}>
+        <button type="button" onClick={() => setMode('cover')}>Cover mode</button>
+        <button type="button" onClick={() => setMode('panorama')}>Panorama mode</button>
+        <button type="button" onClick={() => setPlaying(true)}>Replay</button>
+      </div>
+
+      <div style={{ position: 'relative', width: 'min(960px, 100%)', aspectRatio: '9 / 16', border: '1px solid #333' }}>
+        {playing ? (
+          <CinematicOverlay
+            videoUrl={SAMPLE_VIDEO}
+            caption="외탄 강변을 걸어볼까?"
+            captionTranslation="Want to take a walk along the Bund?"
+            autoAdvance={false}
+            muted
+            presentationMode={mode}
+            worldOverlays={[
+              { id: 'left', x: 23, y: 40, content: 'WORLD • Food Street' },
+              { id: 'right', x: 73, y: 62, content: 'WORLD • Subway Hub' },
+            ]}
+            onEnd={() => setPlaying(false)}
+          />
+        ) : (
+          <div style={{ display: 'grid', placeItems: 'center', width: '100%', height: '100%' }}>
+            Tap replay to run again.
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/apps/client/app/globals.css
+++ b/apps/client/app/globals.css
@@ -2166,6 +2166,8 @@ button.nav-link:hover {
   align-items: center;
   justify-content: center;
   animation: cinematicFadeIn 0.5s ease-out;
+  touch-action: pan-y;
+  user-select: none;
 }
 
 .cinematic-overlay.cinematic-fade-out {
@@ -2186,6 +2188,37 @@ button.nav-link:hover {
   width: 100%;
   height: 100%;
   object-fit: cover;
+}
+
+.cinematic-world-stage {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.cinematic-world-stage--panorama {
+  left: 0;
+  right: auto;
+  overflow: hidden;
+}
+
+.cinematic-video--panorama {
+  object-fit: fill;
+}
+
+.cinematic-world-overlay {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  border-radius: 999px;
+  background: rgba(5, 8, 15, 0.62);
+  color: #fff;
+  padding: 4px 8px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  backdrop-filter: blur(3px);
+  pointer-events: none;
 }
 .cinematic-video::-webkit-media-controls {
   display: none !important;
@@ -2208,6 +2241,21 @@ button.nav-link:hover {
 @keyframes pulse {
   0%, 100% { opacity: 0.5; }
   50% { opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cinematic-overlay {
+    animation-duration: 1ms;
+  }
+  .cinematic-overlay.cinematic-fade-out {
+    animation-duration: 1ms;
+  }
+  .cinematic-subtitle-bar {
+    transition-duration: 1ms;
+  }
+  .cinematic-tap-hint {
+    animation: none;
+  }
 }
 
 /* ── Cinematic subtitles ──────────────────────────────────── */

--- a/apps/client/components/scene/CinematicOverlay.tsx
+++ b/apps/client/components/scene/CinematicOverlay.tsx
@@ -5,6 +5,7 @@ import { useUILang } from '@/lib/i18n/UILangContext';
 import { t } from '@/lib/i18n/ui-strings';
 import { KoreanText, type TargetLang } from '@/components/shared/KoreanText';
 import { fallbackRuntimeAssetCandidates } from '@/lib/runtime-assets';
+import type { CinematicPresentationMode, CinematicWorldOverlay } from '@/lib/types/hangout';
 
 const CAPTION_CHARS_PER_TICK = 2;
 const CAPTION_TICK_MS = 35;
@@ -15,18 +16,42 @@ interface CinematicOverlayProps {
   captionTranslation?: string;
   autoAdvance: boolean;
   muted?: boolean;
+  presentationMode?: CinematicPresentationMode;
+  worldOverlays?: CinematicWorldOverlay[];
   targetLang?: TargetLang;
   onEnd: () => void;
 }
 
-export function CinematicOverlay({ videoUrl, caption, captionTranslation, autoAdvance, muted = false, targetLang = 'ko', onEnd }: CinematicOverlayProps) {
+const DRAG_THRESHOLD_PX = 6;
+
+const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value));
+
+export function CinematicOverlay({
+  videoUrl,
+  caption,
+  captionTranslation,
+  autoAdvance,
+  muted = false,
+  presentationMode = 'cover',
+  worldOverlays = [],
+  targetLang = 'ko',
+  onEnd,
+}: CinematicOverlayProps) {
   const lang = useUILang();
   const videoRef = useRef<HTMLVideoElement>(null);
+  const viewportRef = useRef<HTMLDivElement>(null);
   const [fadingOut, setFadingOut] = useState(false);
   const [captionVisible, setCaptionVisible] = useState(false);
   const [candidateIndex, setCandidateIndex] = useState(0);
+  const [isDragging, setIsDragging] = useState(false);
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+  const suppressTapRef = useRef(false);
+  const dragStateRef = useRef<{ pointerId: number; startX: number; startOffset: number } | null>(null);
   const videoCandidates = useMemo(() => fallbackRuntimeAssetCandidates(videoUrl), [videoUrl]);
   const activeVideoUrl = videoCandidates[candidateIndex] ?? '';
+  const [videoAspectRatio, setVideoAspectRatio] = useState(16 / 9);
+  const [viewportSize, setViewportSize] = useState({ width: 0, height: 0 });
+  const [panOffset, setPanOffset] = useState(0);
 
   // Typewriter state for caption
   const [captionChars, setCaptionChars] = useState(0);
@@ -44,12 +69,76 @@ export function CinematicOverlay({ videoUrl, caption, captionTranslation, autoAd
   }, [autoAdvance, triggerEnd]);
 
   const handleTap = useCallback(() => {
+    if (suppressTapRef.current) {
+      suppressTapRef.current = false;
+      return;
+    }
     if (!autoAdvance) triggerEnd();
   }, [autoAdvance, triggerEnd]);
 
   useEffect(() => {
     setCandidateIndex(0);
   }, [videoUrl]);
+
+  useEffect(() => {
+    const media = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const onChange = () => setPrefersReducedMotion(media.matches);
+    onChange();
+    media.addEventListener('change', onChange);
+    return () => media.removeEventListener('change', onChange);
+  }, []);
+
+  useEffect(() => {
+    const target = viewportRef.current;
+    if (!target) return;
+    const observer = new ResizeObserver((entries) => {
+      const rect = entries[0]?.contentRect;
+      if (!rect) return;
+      setViewportSize({ width: rect.width, height: rect.height });
+    });
+    observer.observe(target);
+    return () => observer.disconnect();
+  }, []);
+
+  const mediaWidth = useMemo(() => {
+    if (!viewportSize.height) return 0;
+    return viewportSize.height * videoAspectRatio;
+  }, [viewportSize.height, videoAspectRatio]);
+  const minOffset = Math.min(0, viewportSize.width - mediaWidth);
+  const maxOffset = 0;
+  const panoramaActive = presentationMode === 'panorama' && mediaWidth > viewportSize.width + 0.5;
+
+  useEffect(() => {
+    if (!panoramaActive) {
+      setPanOffset(0);
+      return;
+    }
+    setPanOffset((prev) => clamp(prev || (viewportSize.width - mediaWidth) / 2, minOffset, maxOffset));
+  }, [panoramaActive, viewportSize.width, mediaWidth, minOffset, maxOffset]);
+
+  const handlePointerDown = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    if (!panoramaActive || event.pointerType === 'mouse' && event.button !== 0) return;
+    const target = event.currentTarget;
+    target.setPointerCapture(event.pointerId);
+    dragStateRef.current = { pointerId: event.pointerId, startX: event.clientX, startOffset: panOffset };
+    setIsDragging(true);
+  }, [panOffset, panoramaActive]);
+
+  const handlePointerMove = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    const drag = dragStateRef.current;
+    if (!drag || drag.pointerId !== event.pointerId) return;
+    const delta = event.clientX - drag.startX;
+    if (Math.abs(delta) > DRAG_THRESHOLD_PX) suppressTapRef.current = true;
+    setPanOffset(clamp(drag.startOffset + delta, minOffset, maxOffset));
+  }, [minOffset, maxOffset]);
+
+  const handlePointerUp = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    const drag = dragStateRef.current;
+    if (!drag || drag.pointerId !== event.pointerId) return;
+    dragStateRef.current = null;
+    setIsDragging(false);
+    event.currentTarget.releasePointerCapture(event.pointerId);
+  }, []);
 
   // Autoplay with unmute fallback + audio fade-in
   useEffect(() => {
@@ -125,6 +214,11 @@ export function CinematicOverlay({ videoUrl, caption, captionTranslation, autoAd
   return (
     <div
       className={`cinematic-overlay ${fadingOut ? 'cinematic-fade-out' : ''}`}
+      ref={viewportRef}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={handlePointerUp}
       onClick={(e) => {
         const v = videoRef.current;
         if (v && v.muted && !muted) {
@@ -137,11 +231,25 @@ export function CinematicOverlay({ videoUrl, caption, captionTranslation, autoAd
       role={autoAdvance ? undefined : 'button'}
       tabIndex={autoAdvance ? undefined : 0}
     >
+      <div
+        className={`cinematic-world-stage ${panoramaActive ? 'cinematic-world-stage--panorama' : ''}`}
+        style={panoramaActive ? {
+          width: `${mediaWidth}px`,
+          transform: `translate3d(${panOffset}px, 0, 0)`,
+          transition: isDragging || prefersReducedMotion ? 'none' : 'transform 220ms ease-out',
+        } : undefined}
+      >
       <video
         ref={videoRef}
         src={activeVideoUrl}
         playsInline
         muted={muted}
+        onLoadedMetadata={(event) => {
+          const { videoWidth, videoHeight } = event.currentTarget;
+          if (videoWidth > 0 && videoHeight > 0) {
+            setVideoAspectRatio(videoWidth / videoHeight);
+          }
+        }}
         onEnded={handleEnded}
         onError={() => {
           if (candidateIndex + 1 < videoCandidates.length) {
@@ -150,11 +258,21 @@ export function CinematicOverlay({ videoUrl, caption, captionTranslation, autoAd
             triggerEnd();
           }
         }}
-        className="cinematic-video"
+        className={`cinematic-video ${panoramaActive ? 'cinematic-video--panorama' : ''}`}
         disablePictureInPicture
         disableRemotePlayback
         controlsList="nodownload noplaybackrate"
       />
+        {worldOverlays.map((overlay) => (
+          <span
+            key={overlay.id}
+            className="cinematic-world-overlay"
+            style={{ left: `${overlay.x}%`, top: `${overlay.y}%` }}
+          >
+            {overlay.content}
+          </span>
+        ))}
+      </div>
       {caption && (
         <div
           className={`cinematic-subtitle-bar ${captionVisible ? 'cinematic-subtitle-visible' : ''}`}

--- a/apps/client/components/scene/SceneView.tsx
+++ b/apps/client/components/scene/SceneView.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRef, useCallback, useState, useEffect } from 'react';
-import type { CreditGateState, ExerciseData, SessionMessage, WebtoonSequence } from '@/lib/types/hangout';
+import type { CinematicPayload, CreditGateState, ExerciseData, SessionMessage, WebtoonSequence } from '@/lib/types/hangout';
 import type { TargetLang } from '@/components/shared/KoreanText';
 import { CHARACTER_MAP } from '@/lib/content/characters';
 import { Background } from './Background';
@@ -17,7 +17,7 @@ interface SceneViewProps {
   backgroundUrl: string;
   backgroundTransition?: 'fade' | 'cut';
   ambientDescription?: string;
-  cinematic?: { videoUrl: string; caption?: string; captionTranslation?: string; autoAdvance: boolean; muted?: boolean } | null;
+  cinematic?: CinematicPayload | null;
   onCinematicEnd?: () => void;
   npcName?: string;
   npcColor?: string;
@@ -158,6 +158,8 @@ export function SceneView({
           captionTranslation={cinematic.captionTranslation}
           autoAdvance={cinematic.autoAdvance}
           muted={cinematic.muted ?? false}
+          presentationMode={cinematic.presentationMode}
+          worldOverlays={cinematic.worldOverlays}
           targetLang={targetLang}
           onEnd={handleCinematicEnd}
         />

--- a/apps/client/lib/types/hangout.ts
+++ b/apps/client/lib/types/hangout.ts
@@ -35,6 +35,26 @@ export interface WebtoonSequence {
   autoAdvance: boolean;
 }
 
+export type CinematicPresentationMode = 'cover' | 'panorama';
+export type CinematicOverlayAnchor = 'viewport' | 'world';
+
+export interface CinematicWorldOverlay {
+  id: string;
+  x: number;
+  y: number;
+  content: string;
+}
+
+export interface CinematicPayload {
+  videoUrl: string;
+  caption?: string;
+  captionTranslation?: string;
+  autoAdvance: boolean;
+  muted?: boolean;
+  presentationMode?: CinematicPresentationMode;
+  worldOverlays?: CinematicWorldOverlay[];
+}
+
 export interface CreditGateState {
   cost: number;
   spendPayload: CreditGate['spendPayload'];


### PR DESCRIPTION
### Motivation

- Provide a panorama-capable cinematic presentation for Shanghai onboarding so wide media can be explored horizontally without blank gutters.
- Define clear overlay anchoring so `viewport` overlays remain fixed while authored `world` overlays move with media pan.
- Preserve the existing `cover` cinematic behavior and respect user `prefers-reduced-motion` settings.
- Offer an isolated non-production harness for QA that uses a repo-visible placeholder clip when the final wide asset is not yet available.

### Description

- Add runtime types and payload shape in `apps/client/lib/types/hangout.ts` (`CinematicPayload`, `CinematicWorldOverlay`, `CinematicPresentationMode`) and wire them through `SceneView` so cinematics accept `presentationMode` and `worldOverlays`.
- Extend `CinematicOverlay` (`apps/client/components/scene/CinematicOverlay.tsx`) to support `panorama` mode with pointer/touch horizontal drag, clamped pan bounds, drag-vs-tap suppression, dynamic aspect calculation, and reduced-motion-aware easing while keeping `cover` behavior unchanged.
- Add CSS rules in `apps/client/app/globals.css` for the panorama world stage, world overlay styling, and reduced-motion overrides to keep subtitle/tap-hint anchoring stable.
- Add a non-production QA harness at `apps/client/app/backstage/panorama-runtime/page.tsx` that uses the repo placeholder `/assets/locations/shanghai.mp4` and demonstrates mode switching and world markers for reviewer validation.
- Files changed: `apps/client/components/scene/CinematicOverlay.tsx`, `apps/client/components/scene/SceneView.tsx`, `apps/client/lib/types/hangout.ts`, `apps/client/app/globals.css`, and `apps/client/app/backstage/panorama-runtime/page.tsx`.

### Testing

- Ran typecheck with `cd apps/client && npx tsc --noEmit` and it succeeded.
- Built design system and launched the local dev server with `cd apps/client && npm run ds:build && npx next dev -p 3004` and verified the harness route responded at `http://localhost:3004/backstage/panorama-runtime` (HTTP 200).
- Verified runtime asset availability with `curl -I http://localhost:3004/assets/locations/shanghai.mp4` (HTTP 200) and confirmed the harness rendered the cinematic component in both desktop and mobile emulation during local testing.
- QA run scaffold created via the repo functional QA scripts (`validate-issue` flow), and finalization was marked `blocked` because required reviewer-facing evidence types (`contract-assertions`, `console-state-trace`) were not attached in this environment, and final Safari/Android device acceptance is still pending.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7c3b81dbc832a95533e3aefcf6750)