### PR TITLE
Add Shanghai panorama cold-open content/config pack

### DIFF
--- a/apps/client/lib/content/shanghai/panorama/cold-open.ts
+++ b/apps/client/lib/content/shanghai/panorama/cold-open.ts
@@ -1,0 +1,105 @@
+import { runtimeAssetUrl } from '@/lib/runtime-assets';
+import type { ShanghaiCharacterId } from '../characters';
+
+/**
+ * Shanghai onboarding panorama fixture (Phase P2).
+ *
+ * Coordinate system contract:
+ * - Rects are normalized to [0..1] against the authored media frame itself.
+ * - Runtime should map these rects after any letterbox/crop math from object-fit,
+ *   then apply hit-testing in viewport pixels.
+ */
+export interface PanoramaHotspotRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface PanoramaHotspotWindow {
+  id: string;
+  startMs: number;
+  endMs: number;
+  targetId: ShanghaiCharacterId;
+  rect: PanoramaHotspotRect;
+  label: string;
+}
+
+export interface TongEavesdropCallout {
+  id: string;
+  atMs: number;
+  text: string;
+}
+
+export interface ShanghaiPanoramaColdOpenConfig {
+  id: 'shanghai-panorama-cold-open-v1';
+  presentation: {
+    title: string;
+    subtitle: string;
+    mediaUrl: string;
+    posterUrl: string;
+    isTemporaryMedia: boolean;
+    mediaAssumptionNote: string;
+  };
+  hotspots: PanoramaHotspotWindow[];
+  tongCallouts: TongEavesdropCallout[];
+  handoff: {
+    ctaLabel: string;
+    ctaHint: string;
+    routeIntent: 'shanghai:onboarding:h1';
+  };
+}
+
+// Temporary media assumption (explicit): final Shanghai wide onboarding clip
+// is not checked into this repo yet, so we reuse a repo-visible 16:9 still.
+const TEMP_WIDE_MEDIA = runtimeAssetUrl('/assets/webtoon/shanghai/h1/0.png');
+
+export const SHANGHAI_PANORAMA_COLD_OPEN: ShanghaiPanoramaColdOpenConfig = {
+  id: 'shanghai-panorama-cold-open-v1',
+  presentation: {
+    title: 'Shanghai · Dumpling Street',
+    subtitle: 'Keep your head down. Listen before they notice you.',
+    mediaUrl: TEMP_WIDE_MEDIA,
+    posterUrl: TEMP_WIDE_MEDIA,
+    isTemporaryMedia: true,
+    mediaAssumptionNote:
+      'Using /assets/webtoon/shanghai/h1/0.png as a temporary stand-in until the final wide onboarding clip lands in-repo.',
+  },
+  hotspots: [
+    {
+      id: 'hs-shoucheng-open',
+      startMs: 2200,
+      endMs: 6100,
+      targetId: 'shoucheng',
+      // Right side seat, upper torso and face in the current stand-in frame.
+      rect: { x: 0.61, y: 0.19, width: 0.21, height: 0.5 },
+      label: '守成 · Opening line',
+    },
+    {
+      id: 'hs-dingman-retort',
+      startMs: 6400,
+      endMs: 9800,
+      targetId: 'dingman',
+      // Left side diner, tighter crop window for eat-then-retort beat.
+      rect: { x: 0.22, y: 0.2, width: 0.2, height: 0.54 },
+      label: '丁漫 · Dry response',
+    },
+  ],
+  tongCallouts: [
+    {
+      id: 'tong-eavesdrop-1',
+      atMs: 4700,
+      text: 'Tong: That clipped opener is 守成. He starts from terms, not feelings.',
+    },
+    {
+      id: 'tong-eavesdrop-2',
+      atMs: 8600,
+      text: 'Tong: 丁漫 answers with almost nothing. Watch who controls silence.',
+    },
+  ],
+  handoff: {
+    ctaLabel: 'Step into H1 negotiation',
+    ctaHint: 'You caught enough. Move closer and take the first scene.',
+    routeIntent: 'shanghai:onboarding:h1',
+  },
+};

--- a/apps/client/lib/content/shanghai/panorama/index.ts
+++ b/apps/client/lib/content/shanghai/panorama/index.ts
@@ -1,0 +1,7 @@
+export { SHANGHAI_PANORAMA_COLD_OPEN } from './cold-open';
+export type {
+  PanoramaHotspotRect,
+  PanoramaHotspotWindow,
+  ShanghaiPanoramaColdOpenConfig,
+  TongEavesdropCallout,
+} from './cold-open';

--- a/docs/shanghai/panorama-content-pack.md
+++ b/docs/shanghai/panorama-content-pack.md
@@ -1,0 +1,14 @@
+# Shanghai Panorama Content Pack (P2 support)
+
+This PR adds a fixture-style config for the Shanghai cold-open panorama so routing/runtime work can consume authored values without hardcoding.
+
+## Coordinate assumptions
+- Hotspot rectangles are normalized to `0..1` in media space.
+- Runtime should project normalized rects after applying object-fit crop/letterbox math.
+- Current windows are authored against the temporary stand-in media frame at `/assets/webtoon/shanghai/h1/0.png`.
+
+## Temporary media assumption
+The final wide onboarding clip is not in-repo yet. Until it lands, use the same stand-in key already wired in config:
+- `/assets/webtoon/shanghai/h1/0.png`
+
+When the final clip is available, replace `mediaUrl`/`posterUrl` and re-check hotspot rectangles against that true frame.


### PR DESCRIPTION
### Motivation
- Provide an authored, fixture-driven panorama cold-open for Shanghai so routing and runtime work can consume stable content values for onboarding without ad-hoc hardcoding, supporting follow-ups to #257/#259.

### Description
- Add a typed cold-open config at `apps/client/lib/content/shanghai/panorama/cold-open.ts` that includes presentation metadata, `isTemporaryMedia` flags and note, normalized hotspot windows with timestamp windows and rects, `targetId` values for `shoucheng` and `dingman`, two small Tong eavesdrop callouts, and an H1 handoff CTA with `routeIntent: 'shanghai:onboarding:h1'`.
- Add an export surface at `apps/client/lib/content/shanghai/panorama/index.ts` and a short authoring doc at `docs/shanghai/panorama-content-pack.md` that documents the normalized-rect contract and the temporary media assumption using `/assets/webtoon/shanghai/h1/0.png`.
- Key authored values to honor: normalized rects are in `0..1` media space and must be projected after any `object-fit` crop/letterbox math; hotspots are `hs-shoucheng-open` (2200–6100 ms) and `hs-dingman-retort` (6400–9800 ms); Tong callouts at 4700 ms and 8600 ms; `isTemporaryMedia: true` and `mediaAssumptionNote` must remain until final wide clip is replaced.
- How to test the content locally: confirm the file `apps/client/lib/content/shanghai/panorama/cold-open.ts` is exported and the doc note exists, and run the TypeScript check in the client as described below.

### Testing
- Ran `cd apps/client && npx tsc --noEmit` and the typecheck completed successfully (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7c3c0d088832ab95fe3832d25e4b0)