### PR TITLE
feat(shanghai): add panorama cold-open authored content pack

### DIFF
--- a/apps/client/lib/content/shanghai/panorama-cold-open.ts
+++ b/apps/client/lib/content/shanghai/panorama-cold-open.ts
@@ -1,0 +1,118 @@
+/**
+ * Shanghai Panorama Content Pack (issue #257 support slice).
+ *
+ * This pack is intentionally fixture-driven and persistence-agnostic:
+ * it only describes authored media timing, hotspot geometry, and handoff copy.
+ */
+
+export type NormalizedRect = {
+  /** 0..1 fraction from the video's left edge. */
+  x: number;
+  /** 0..1 fraction from the video's top edge. */
+  y: number;
+  /** 0..1 fraction of the full frame width. */
+  width: number;
+  /** 0..1 fraction of the full frame height. */
+  height: number;
+};
+
+export interface ShanghaiPanoramaHotspotWindow {
+  id: string;
+  targetId: 'shoucheng' | 'dingman';
+  /** Milliseconds from clip start. */
+  startMs: number;
+  /** Milliseconds from clip start. */
+  endMs: number;
+  rect: NormalizedRect;
+  note?: string;
+}
+
+export interface ShanghaiPanoramaCallout {
+  id: string;
+  startMs: number;
+  endMs: number;
+  text: string;
+}
+
+export interface ShanghaiPanoramaHandoffCta {
+  title: string;
+  body: string;
+  primaryLabel: string;
+  routeHint: 'H1';
+}
+
+export interface ShanghaiPanoramaPresentation {
+  clipId: string;
+  clipSrc: string;
+  posterSrc: string;
+  autoplayMuted: boolean;
+  expectedAspectRatio: '21:9';
+  durationMs: number;
+}
+
+export interface ShanghaiPanoramaColdOpenConfig {
+  id: 'shanghai-panorama-cold-open-v1';
+  cityId: 'shanghai';
+  locationId: 'dumpling_shop';
+  presentation: ShanghaiPanoramaPresentation;
+  hotspotWindows: ShanghaiPanoramaHotspotWindow[];
+  tongCallouts: ShanghaiPanoramaCallout[];
+  handoffCta: ShanghaiPanoramaHandoffCta;
+}
+
+export const SHANGHAI_PANORAMA_COLD_OPEN_V1: ShanghaiPanoramaColdOpenConfig = {
+  id: 'shanghai-panorama-cold-open-v1',
+  cityId: 'shanghai',
+  locationId: 'dumpling_shop',
+  presentation: {
+    clipId: 'shanghai-panorama-temp-tong-intro',
+    // TEMP: use repo-visible placeholder until final Shanghai wide onboarding clip lands.
+    // Replace with the final authored panorama media key/URL once available.
+    clipSrc: '/assets/tong_intro.webm',
+    posterSrc: '/assets/locations/shanghai-static.png',
+    autoplayMuted: true,
+    expectedAspectRatio: '21:9',
+    durationMs: 13000,
+  },
+  // Coordinate convention:
+  // - rect values are normalized against the source frame (x/y/width/height in 0..1)
+  // - runtime should convert to px using the rendered video box AFTER letterboxing/cropping policy
+  hotspotWindows: [
+    {
+      id: 'hs-shoucheng-open',
+      targetId: 'shoucheng',
+      startMs: 1800,
+      endMs: 5600,
+      rect: { x: 0.58, y: 0.22, width: 0.14, height: 0.58 },
+      note: '守成 enters frame right and pauses at the table edge.',
+    },
+    {
+      id: 'hs-dingman-open',
+      targetId: 'dingman',
+      startMs: 3300,
+      endMs: 8100,
+      rect: { x: 0.31, y: 0.24, width: 0.16, height: 0.56 },
+      note: '丁漫 remains seated near the steam basket; quieter visual anchor.',
+    },
+  ],
+  tongCallouts: [
+    {
+      id: 'tong-eavesdrop-1',
+      startMs: 3900,
+      endMs: 5800,
+      text: 'Tong: Keep your voice low — this is 守成 and 丁漫 before they notice us.',
+    },
+    {
+      id: 'tong-eavesdrop-2',
+      startMs: 8600,
+      endMs: 11100,
+      text: 'Tong: Hear the tension? Let\'s step into H1 and catch the key lines.',
+    },
+  ],
+  handoffCta: {
+    title: 'Conversation is heating up.',
+    body: 'Enter H1 at the dumpling shop and track how 守成 and 丁漫 frame willingness versus ability.',
+    primaryLabel: 'Start H1 eavesdrop',
+    routeHint: 'H1',
+  },
+};

--- a/docs/shanghai/panorama-content-pack.md
+++ b/docs/shanghai/panorama-content-pack.md
@@ -1,0 +1,18 @@
+# Shanghai Panorama Cold-Open Content Pack (V1)
+
+This document records the authored content assumptions for the temporary panorama onboarding slice that supports issue #257 route/runtime wiring.
+
+## Source of truth
+- `apps/client/lib/content/shanghai/panorama-cold-open.ts`
+
+## Coordinate assumptions
+- Hotspot rectangles are normalized to the source frame as `{ x, y, width, height }` in the `0..1` range.
+- Runtime should project normalized coordinates into the rendered video viewport _after_ applying whatever letterbox/crop policy the player uses.
+- Timing windows are clip-relative milliseconds.
+
+## Temporary media assumption
+- The final Shanghai wide onboarding clip is not yet committed in this repo slice.
+- V1 uses repo-visible placeholders:
+  - clip: `/assets/tong_intro.webm`
+  - poster: `/assets/locations/shanghai-static.png`
+- Future route/runtime work should treat this as a swap-only media reference change, not a schema change.


### PR DESCRIPTION
### Motivation
- Provide a minimal, fixture-driven Shanghai panorama cold-open so the onboarding route/runtime can consume authored timing and hotspot data without ad-hoc content work. 
- Keep the content/config slice strictly additive and persistence-agnostic so parallel work (route wiring and final media swap) can proceed without schema changes. 
- Surface clear, repo-visible temporary media placeholders and coordinate assumptions so future swaps are swap-only and well-documented.

### Description
- Add authored config `apps/client/lib/content/shanghai/panorama-cold-open.ts` that defines the `ShanghaiPanoramaColdOpenConfig` schema and a `SHANGHAI_PANORAMA_COLD_OPEN_V1` fixture with presentation metadata, hotspot windows, Tong callouts, and a handoff CTA. 
- Presentation uses a temporary repo-visible placeholder clip and poster (`/assets/tong_intro.webm` and `/assets/locations/shanghai-static.png`) and includes `clipId`, `autoplayMuted`, `expectedAspectRatio`, and `durationMs`. 
- Hotspot data includes normalized `0..1` rects and timing windows for two targets: `hs-shoucheng-open` → `shoucheng` (1800–5600 ms) and `hs-dingman-open` → `dingman` (3300–8100 ms). 
- Include two short Tong eavesdrop callouts and an H1 handoff CTA, and add `docs/shanghai/panorama-content-pack.md` documenting coordinate conventions and the temporary media assumption; no global persistence or schema changes were introduced.

### Testing
- Run TypeScript typecheck with `npm --prefix apps/client exec -- tsc -p apps/client/tsconfig.json --noEmit`, which completed successfully in this environment. 
- Verify the new files are present at `apps/client/lib/content/shanghai/panorama-cold-open.ts` and `docs/shanghai/panorama-content-pack.md`. 
- How to test locally: run `npm --prefix apps/client exec -- tsc -p apps/client/tsconfig.json --noEmit` and inspect the fixture values in the two added files to confirm timestamps, hotspot targets, Tong lines, and temporary media placeholders.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7c3c0d088832ab95fe3832d25e4b0)