### PR TITLE
prep(#259): harden Shanghai onboarding resume + H1 asset fallback

### DIFF
--- a/apps/client/app/onboarding/shanghai/page.tsx
+++ b/apps/client/app/onboarding/shanghai/page.tsx
@@ -2,11 +2,11 @@
 
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { Suspense, useCallback, useMemo, useRef, useState } from 'react';
+import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { getWebtoonFixture } from '@/lib/content/shanghai/fixtures';
 import { WebtoonStrip, type WebtoonTheme } from '@/components/scene/WebtoonStrip';
 import { WebtoonPurchaseSheet } from '@/components/scene/WebtoonPurchaseSheet';
-import { dispatch } from '@/lib/store/game-store';
+import { dispatch, useGameState } from '@/lib/store/game-store';
 import { useWebtoonUnlocks } from '@/lib/hooks/useWebtoonUnlocks';
 
 const FIXTURE_ID = 'shanghai-h1';
@@ -14,6 +14,42 @@ const CITY_ID = 'shanghai';
 const LOCATION_ID = 'dumpling_shop';
 const AYI_ID = 'fangayi';
 const ONBOARDING_SCENE_ID = 'shanghai:h1';
+const SHANGHAI_ONBOARDING_STATE_KEY = 'tong:onboarding:shanghai:h1';
+
+type ShanghaiEntryIntent = 'cover' | 'panorama';
+
+type ShanghaiOnboardingState = {
+  completed?: boolean;
+  completedAt?: string;
+  lastEntryIntent?: ShanghaiEntryIntent;
+};
+
+function getEntryIntent(value: string | null): ShanghaiEntryIntent | null {
+  if (value === 'panorama' || value === 'cover') return value;
+  return null;
+}
+
+function loadShanghaiOnboardingState(): ShanghaiOnboardingState {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = localStorage.getItem(SHANGHAI_ONBOARDING_STATE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as ShanghaiOnboardingState;
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function persistShanghaiOnboardingState(patch: ShanghaiOnboardingState): void {
+  if (typeof window === 'undefined') return;
+  try {
+    const existing = loadShanghaiOnboardingState();
+    localStorage.setItem(SHANGHAI_ONBOARDING_STATE_KEY, JSON.stringify({ ...existing, ...patch }));
+  } catch {
+    // no-op when storage is unavailable
+  }
+}
 
 // Mastery items surfaced by the onboarding scene. Mirrors what the H1 fixture
 // resolution spec would apply in the dynamic path — replicated here so the
@@ -29,9 +65,12 @@ const MASTERY_ITEMS: { id: string; category: 'vocabulary' | 'grammar' }[] = [
 function ShanghaiOnboardingContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const gameState = useGameState();
   const entry = useMemo(() => getWebtoonFixture(FIXTURE_ID), []);
+  const isAlreadyCompleted = gameState.onboardingStatus[ONBOARDING_SCENE_ID] === 'completed';
+  const [entryIntent, setEntryIntent] = useState<ShanghaiEntryIntent>('cover');
   const completedRef = useRef(false);
-  const [completed, setCompleted] = useState(false);
+  const [completed, setCompleted] = useState(isAlreadyCompleted);
   const [theme, setTheme] = useState<WebtoonTheme>('warm');
   const [showHelp, setShowHelp] = useState(false);
   const {
@@ -44,6 +83,25 @@ function ShanghaiOnboardingContent() {
     spendSp,
     activateGamePass,
   } = useWebtoonUnlocks(FIXTURE_ID, searchParams);
+
+  useEffect(() => {
+    const parsedFromSearch = getEntryIntent(searchParams.get('entry'));
+    const persisted = loadShanghaiOnboardingState();
+    const resolvedIntent = parsedFromSearch ?? persisted.lastEntryIntent ?? 'cover';
+    setEntryIntent(resolvedIntent);
+    persistShanghaiOnboardingState({ lastEntryIntent: resolvedIntent });
+  }, [searchParams]);
+
+  useEffect(() => {
+    const persisted = loadShanghaiOnboardingState();
+    const persistedCompleted = persisted.completed === true;
+    const resolvedCompleted = isAlreadyCompleted || persistedCompleted;
+    completedRef.current = resolvedCompleted;
+    setCompleted(resolvedCompleted);
+    if (resolvedCompleted && !isAlreadyCompleted) {
+      dispatch({ type: 'SET_ONBOARDING_STATUS', sceneId: ONBOARDING_SCENE_ID, status: 'completed' });
+    }
+  }, [isAlreadyCompleted]);
 
   const onComplete = useCallback(() => {
     if (completedRef.current) return;
@@ -61,14 +119,16 @@ function ShanghaiOnboardingContent() {
     dispatch({ type: 'SET_ONBOARDING_STATUS', sceneId: ONBOARDING_SCENE_ID, status: 'completed' });
     // Small XP payout for completing onboarding.
     dispatch({ type: 'ADD_XP', amount: 40 });
-  }, []);
+    persistShanghaiOnboardingState({ completed: true, completedAt: new Date().toISOString(), lastEntryIntent: entryIntent });
+  }, [entryIntent]);
 
   const handleLeave = useCallback(() => {
     if (!completedRef.current) {
       dispatch({ type: 'SET_ONBOARDING_STATUS', sceneId: ONBOARDING_SCENE_ID, status: 'dismissed' });
     }
+    persistShanghaiOnboardingState({ lastEntryIntent: entryIntent });
     router.push('/game?phase=city_map');
-  }, [router]);
+  }, [entryIntent, router]);
 
   if (!entry) {
     return (

--- a/apps/client/lib/content/shanghai/fixtures/h1-webtoon.ts
+++ b/apps/client/lib/content/shanghai/fixtures/h1-webtoon.ts
@@ -1,6 +1,8 @@
 import type { WebtoonPanel, WebtoonSpec } from '@/lib/hangout/fixture-types';
 
-const ASSET = (n: number) => `/assets/webtoon/shanghai/h1/${n}.png`;
+const AVAILABLE_ASSET_PANELS = new Set([0, 1, 2, 3, 4, 5, 6]);
+const FALLBACK_ASSET_PANEL = 6;
+const ASSET = (n: number) => `/assets/webtoon/shanghai/h1/${AVAILABLE_ASSET_PANELS.has(n) ? n : FALLBACK_ASSET_PANEL}.png`;
 
 // Warm daytime palette (parchment surface).
 const PARCHMENT = '#ffffff';
@@ -31,7 +33,8 @@ const INK_BORDER_DARK = 'rgba(255, 248, 238, 0.9)';
 //   4: 1682x2193 (~3:4 portrait)     — deflection (food)
 //   5: 1440x2562 (9:16 portrait)     — pitch line (focus)
 //   6: 1682x2193 (~3:4 portrait)     — mic drop setup (dark-gradient lead)
-//   7+: placeholder paths — art pending. Layouts pre-baked so the strip reads end-to-end today.
+//   7+: art pending. Until placeholders land, these panels gracefully reuse panel 6's image
+//       so the strip remains readable without 404 asset requests.
 //   7:  concede + reframe
 //   8:  pitch v2 "不装的人"
 //   9:  retort "你觉得我不装？"


### PR DESCRIPTION
### Motivation
- Prevent 404s from missing H1 art panels (7+) so the Shanghai onboarding/webtoon flows read end-to-end.
- Persist onboarding completion and resume metadata so refresh/return does not re-award or lose progress.
- Accept and persist an `entry` intent (`panorama` | `cover`) from the onboarding querystring while preserving the default cover behavior.
- Keep navigation behavior unchanged to avoid introducing redirect loops in this prep slice.

### Description
- Add a graceful fallback for missing H1 images by introducing `AVAILABLE_ASSET_PANELS`, `FALLBACK_ASSET_PANEL`, and an `ASSET` helper that reuses panel 6 for unavailable indices in `apps/client/lib/content/shanghai/fixtures/h1-webtoon.ts`.
- Add a local onboarding state key and typed helpers (`loadShanghaiOnboardingState` / `persistShanghaiOnboardingState`) to `apps/client/app/onboarding/shanghai/page.tsx` for storing `{ completed, completedAt, lastEntryIntent }` in `localStorage`.
- Hydrate onboarding completion from both `game-store` (`useGameState().onboardingStatus`) and persisted local state, avoid duplicate completion dispatches by checking current store/persisted state, and persist state on `onComplete` and `handleLeave` (also persist `lastEntryIntent`).
- Parse `entry` from search params (`?entry=panorama`|`cover`) and persist the resolved intent while leaving navigation (`/game?phase=city_map`) and scene components unchanged.

### Testing
- Automated: `npx tsc -p apps/client/tsconfig.json --noEmit` was run and succeeded.
- Automated: `npm --prefix apps/client run typecheck` was attempted and failed because the `typecheck` script is not defined in `apps/client/package.json`.
- Automated: `npm --prefix apps/client exec tsc --noEmit` was attempted and failed due to `npm exec`/flag handling in this environment; use `npx tsc -p apps/client/tsconfig.json --noEmit` instead.
- How to test (manual): open `/onboarding/shanghai` and verify panels 7+ do not 404 and render with fallback; open `/webtoon/shanghai-h1` to confirm fixture rendering; complete onboarding once and refresh `/onboarding/shanghai` to confirm resume state and no duplicate rewards; visit `/onboarding/shanghai?entry=panorama`, reload, and verify the `entry` intent persisted.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7d2abefa8832ab8f8ffc63007b313)