### PR TITLE
prep(#259): stabilize Shanghai H1 onboarding resume and panel fallbacks

### DIFF
--- a/apps/client/app/onboarding/shanghai/page.tsx
+++ b/apps/client/app/onboarding/shanghai/page.tsx
@@ -84,10 +84,8 @@ function ShanghaiOnboardingContent() {
       localStorage.setItem(ONBOARDING_ENTRY_KEY, queryEntry);
       return;
     }
-    const saved = localStorage.getItem(ONBOARDING_ENTRY_KEY);
-    if (saved === 'panorama' || saved === 'cover') {
-      setEntryIntent(saved);
-    }
+    setEntryIntent('cover');
+    localStorage.removeItem(ONBOARDING_ENTRY_KEY);
   }, [queryEntry]);
 
   const handleLeave = useCallback(() => {

--- a/apps/client/app/onboarding/shanghai/page.tsx
+++ b/apps/client/app/onboarding/shanghai/page.tsx
@@ -2,11 +2,11 @@
 
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { Suspense, useCallback, useMemo, useRef, useState } from 'react';
+import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { getWebtoonFixture } from '@/lib/content/shanghai/fixtures';
 import { WebtoonStrip, type WebtoonTheme } from '@/components/scene/WebtoonStrip';
 import { WebtoonPurchaseSheet } from '@/components/scene/WebtoonPurchaseSheet';
-import { dispatch } from '@/lib/store/game-store';
+import { dispatch, useGameState } from '@/lib/store/game-store';
 import { useWebtoonUnlocks } from '@/lib/hooks/useWebtoonUnlocks';
 
 const FIXTURE_ID = 'shanghai-h1';
@@ -14,6 +14,7 @@ const CITY_ID = 'shanghai';
 const LOCATION_ID = 'dumpling_shop';
 const AYI_ID = 'fangayi';
 const ONBOARDING_SCENE_ID = 'shanghai:h1';
+const ONBOARDING_ENTRY_KEY = 'tong:shanghai:onboarding-entry';
 
 // Mastery items surfaced by the onboarding scene. Mirrors what the H1 fixture
 // resolution spec would apply in the dynamic path — replicated here so the
@@ -29,11 +30,18 @@ const MASTERY_ITEMS: { id: string; category: 'vocabulary' | 'grammar' }[] = [
 function ShanghaiOnboardingContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const gameState = useGameState();
+  const persistedStatus = gameState.onboardingStatus[ONBOARDING_SCENE_ID];
   const entry = useMemo(() => getWebtoonFixture(FIXTURE_ID), []);
-  const completedRef = useRef(false);
-  const [completed, setCompleted] = useState(false);
+  const completedRef = useRef(persistedStatus === 'completed');
+  const [completed, setCompleted] = useState(persistedStatus === 'completed');
   const [theme, setTheme] = useState<WebtoonTheme>('warm');
   const [showHelp, setShowHelp] = useState(false);
+  const queryEntry = searchParams.get('entry');
+  const [entryIntent, setEntryIntent] = useState<'cover' | 'panorama'>('cover');
+  const mapReturnHref = entryIntent === 'panorama'
+    ? '/game?phase=city_map&entry=panorama'
+    : '/game?phase=city_map';
   const {
     entitlement,
     pendingUnlock,
@@ -63,12 +71,31 @@ function ShanghaiOnboardingContent() {
     dispatch({ type: 'ADD_XP', amount: 40 });
   }, []);
 
+  useEffect(() => {
+    if (persistedStatus === 'completed') {
+      completedRef.current = true;
+      setCompleted(true);
+    }
+  }, [persistedStatus]);
+
+  useEffect(() => {
+    if (queryEntry === 'panorama' || queryEntry === 'cover') {
+      setEntryIntent(queryEntry);
+      localStorage.setItem(ONBOARDING_ENTRY_KEY, queryEntry);
+      return;
+    }
+    const saved = localStorage.getItem(ONBOARDING_ENTRY_KEY);
+    if (saved === 'panorama' || saved === 'cover') {
+      setEntryIntent(saved);
+    }
+  }, [queryEntry]);
+
   const handleLeave = useCallback(() => {
     if (!completedRef.current) {
       dispatch({ type: 'SET_ONBOARDING_STATUS', sceneId: ONBOARDING_SCENE_ID, status: 'dismissed' });
     }
-    router.push('/game?phase=city_map');
-  }, [router]);
+    router.push(mapReturnHref);
+  }, [mapReturnHref, router]);
 
   if (!entry) {
     return (
@@ -201,7 +228,7 @@ function ShanghaiOnboardingContent() {
           <span style={{ opacity: 0.75 }}>+40 XP · 方阿姨 +3 · 5 vocab first-contact.</span>
           <button
             type="button"
-            onClick={() => router.push('/game?phase=city_map')}
+            onClick={() => router.push(mapReturnHref)}
             style={{
               background: '#f4d2ac',
               color: '#0d0d1a',

--- a/apps/client/lib/content/shanghai/fixtures/h1-webtoon.ts
+++ b/apps/client/lib/content/shanghai/fixtures/h1-webtoon.ts
@@ -1,6 +1,11 @@
 import type { WebtoonPanel, WebtoonSpec } from '@/lib/hangout/fixture-types';
 
-const ASSET = (n: number) => `/assets/webtoon/shanghai/h1/${n}.png`;
+const PLACEHOLDER_ASSET = '/assets/webtoon/shanghai/h1/placeholder.svg';
+const ASSET = (n: number) => (
+  n <= 6
+    ? `/assets/webtoon/shanghai/h1/${n}.png`
+    : PLACEHOLDER_ASSET
+);
 
 // Warm daytime palette (parchment surface).
 const PARCHMENT = '#ffffff';
@@ -31,7 +36,7 @@ const INK_BORDER_DARK = 'rgba(255, 248, 238, 0.9)';
 //   4: 1682x2193 (~3:4 portrait)     — deflection (food)
 //   5: 1440x2562 (9:16 portrait)     — pitch line (focus)
 //   6: 1682x2193 (~3:4 portrait)     — mic drop setup (dark-gradient lead)
-//   7+: placeholder paths — art pending. Layouts pre-baked so the strip reads end-to-end today.
+//   7+: use a non-404 placeholder plate while final art is pending.
 //   7:  concede + reframe
 //   8:  pitch v2 "不装的人"
 //   9:  retort "你觉得我不装？"

--- a/apps/client/public/assets/webtoon/shanghai/h1/placeholder.svg
+++ b/apps/client/public/assets/webtoon/shanghai/h1/placeholder.svg
@@ -1,0 +1,18 @@
+<svg width="1440" height="2560" viewBox="0 0 1440 2560" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="720" y1="0" x2="720" y2="2560" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#18131E"/>
+      <stop offset="1" stop-color="#30231B"/>
+    </linearGradient>
+  </defs>
+  <rect width="1440" height="2560" fill="url(#bg)"/>
+  <rect x="104" y="160" width="1232" height="2240" rx="44" stroke="#F4D2AC" stroke-opacity="0.38" stroke-width="8"/>
+  <circle cx="720" cy="1060" r="164" fill="#F4D2AC" fill-opacity="0.12"/>
+  <path d="M640 1060H800M720 980V1140" stroke="#F4D2AC" stroke-opacity="0.58" stroke-width="24" stroke-linecap="round"/>
+  <text x="720" y="1360" text-anchor="middle" fill="#FFF2E0" fill-opacity="0.92" font-size="72" font-family="system-ui, -apple-system, Segoe UI, Roboto, sans-serif" font-weight="700">
+    ART IN PROGRESS
+  </text>
+  <text x="720" y="1456" text-anchor="middle" fill="#F4D2AC" fill-opacity="0.78" font-size="44" font-family="system-ui, -apple-system, Segoe UI, Roboto, sans-serif">
+    Shanghai H1 placeholder panel
+  </text>
+</svg>


### PR DESCRIPTION
### Motivation
- Prevent runtime 404s for missing H1 art while final panels are pending and ensure the onboarding strip renders end-to-end.
- Make onboarding completion/resume idempotent so rewards and side-effects are not re-applied on refresh or revisit.
- Preserve `entry=panorama` intent when leaving/completing onboarding so return routing matches the caller intent and avoids redirect loops.

### Description
- Read persisted onboarding state from the singleton store via `useGameState` and initialize `completed`/`completedRef` from `onboardingStatus` to avoid re-granting completion side-effects in `onComplete` (`apps/client/app/onboarding/shanghai/page.tsx`).
- Parse and persist `entry` query param (`cover` | `panorama`) to `localStorage` and compute a single `mapReturnHref` used by both the Leave and Return buttons so the return URL preserves the caller intent (`apps/client/app/onboarding/shanghai/page.tsx`).
- Add a durable placeholder SVG asset and update the H1 fixture asset resolver so panel indices > 6 return the placeholder instead of 404ing while art is pending (`apps/client/lib/content/shanghai/fixtures/h1-webtoon.ts` and `apps/client/public/assets/webtoon/shanghai/h1/placeholder.svg`).
- Small UX wiring: use `mapReturnHref` for all navigation out of the onboarding scene to centralize return logic and prevent accidental redirect loops (`apps/client/app/onboarding/shanghai/page.tsx`).

How to test (manual):
- Open `/onboarding/shanghai` and confirm panels 7+ render without 404s and show the placeholder art.
- Complete the scene, refresh the page, and confirm the completion UI does not re-apply rewards (no duplicate XP/affinity increments) and the scene remains marked completed.
- Visit `/onboarding/shanghai?entry=panorama`, then Leave or Return and confirm the app returns to `/game?phase=city_map&entry=panorama`.
- Open `/webtoon/shanghai-h1` and verify the strip renders end-to-end without missing image requests for post-panel-6 content.

### Testing
- Ran client TypeScript check in the client workspace: `npx tsc --noEmit` (executed in `apps/client`) — passed.
- Attempts to run `npm --prefix apps/client exec tsc --noEmit` and `npm --prefix apps/client exec -- tsc --noEmit` printed npm/tsc help in this environment and were not useful; validated with `npx tsc --noEmit` instead — those npm-invocations failed due to CLI invocation behavior in this environment.
- No other automated tests were added or run in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7d2abefa8832ab8f8ffc63007b313)