### PR TITLE
[partial #256] Add Shanghai secret unlock contract and deterministic fixtures

### DIFF
--- a/docs/shanghai/ISSUE-256-reviewer-note.md
+++ b/docs/shanghai/ISSUE-256-reviewer-note.md
@@ -1,0 +1,12 @@
+# Issue #256 (partial) — Reviewer note
+
+This partial update only covers contract + fixture definitions for the Shanghai secret-location commerce flow.
+
+Included:
+- Secret location concept payload (`shanghai.secret.riverside_speakeasy`) with discovery/reveal states.
+- Invitation-token redemption shape using commerce-aligned terminology (`productKey`, `unlockKey`, `grantSource`, `entitlement`).
+- Deterministic unlock-flag snapshot payloads before and after redemption.
+
+Out of scope in this change:
+- UI wiring, onboarding scene behavior, or panorama runtime changes.
+- Stateful worker mutation logic beyond existing fixture-backed deterministic responses.

--- a/packages/contracts/api-contract.md
+++ b/packages/contracts/api-contract.md
@@ -334,9 +334,112 @@ Response:
 }
 ```
 
+## GET `/api/v1/commerce/shanghai-secret-status`
+Query:
+```json
+{ "userId": "demo-user-1", "city": "shanghai" }
+```
+
+Fixture:
+`packages/contracts/fixtures/commerce.shanghai-secret-status.sample.json`
+
+Response:
+```json
+{
+  "userId": "demo-user-1",
+  "city": "shanghai",
+  "asOfIso": "2026-04-21T09:12:00.000Z",
+  "secretLocation": {
+    "locationKey": "shanghai.secret.riverside_speakeasy",
+    "locationLabel": "Riverside Speakeasy",
+    "discoveryState": "teased",
+    "revealState": "alias_only",
+    "requiresInvitationToken": true
+  },
+  "invitationToken": {
+    "status": "eligible",
+    "tokenProductKey": "token.shanghai.secret.riverside_speakeasy.invite",
+    "tokenHint": "Found in advanced texting mission reward thread."
+  },
+  "unlockFlagsSnapshot": {
+    "snapshotId": "snap_unlock_flags_demo_user_1_20260421t091200z",
+    "generatedAtIso": "2026-04-21T09:12:00.000Z",
+    "flags": {
+      "unlock.shanghai.texting_mission": true,
+      "unlock.shanghai.secret.riverside_speakeasy": false,
+      "collectible.polaroid.shanghai_call": true
+    }
+  }
+}
+```
+
+## POST `/api/v1/commerce/shanghai-secret/redeem-invitation`
+Request:
+```json
+{
+  "userId": "demo-user-1",
+  "city": "shanghai",
+  "invitationTokenProductKey": "token.shanghai.secret.riverside_speakeasy.invite",
+  "invitationTokenCode": "INVITE-RIVER-0421",
+  "idempotencyKey": "redeem.shanghai.secret.riverside_speakeasy:demo-user-1:INVITE-RIVER-0421",
+  "metadata": {
+    "source": "mission_reward_message",
+    "threadId": "wechat_mission_thread_03"
+  }
+}
+```
+
+Fixture:
+`packages/contracts/fixtures/commerce.shanghai-secret-redeem.sample.json`
+
+Response:
+```json
+{
+  "redemptionId": "red_shanghai_secret_riverside_001",
+  "status": "redeemed",
+  "userId": "demo-user-1",
+  "city": "shanghai",
+  "idempotencyKey": "redeem.shanghai.secret.riverside_speakeasy:demo-user-1:INVITE-RIVER-0421",
+  "redeemedAtIso": "2026-04-21T09:14:00.000Z",
+  "invitationToken": {
+    "productKey": "token.shanghai.secret.riverside_speakeasy.invite",
+    "status": "consumed"
+  },
+  "grant": {
+    "grantId": "grant_unlock_shanghai_secret_riverside",
+    "unlockKey": "unlock.shanghai.secret.riverside_speakeasy",
+    "grantSource": "invitation_token_redemption"
+  },
+  "entitlement": {
+    "entitlementId": "ent_unlock_shanghai_secret_riverside",
+    "productKey": "unlock.shanghai.secret.riverside_speakeasy",
+    "type": "feature_access",
+    "status": "active",
+    "grantedAtIso": "2026-04-21T09:14:00.000Z",
+    "source": "invitation_token_redemption",
+    "purchaseEventId": null,
+    "metadata": {
+      "city": "shanghai",
+      "locationKey": "shanghai.secret.riverside_speakeasy",
+      "redeemTokenProductKey": "token.shanghai.secret.riverside_speakeasy.invite"
+    }
+  },
+  "unlockFlagsSnapshot": {
+    "snapshotId": "snap_unlock_flags_demo_user_1_20260421t091400z",
+    "generatedAtIso": "2026-04-21T09:14:00.000Z",
+    "flags": {
+      "unlock.shanghai.texting_mission": true,
+      "unlock.shanghai.secret.riverside_speakeasy": true,
+      "collectible.polaroid.shanghai_call": true
+    }
+  }
+}
+```
+
 Contract notes:
 - Demo worker responses are fixture-backed and deterministic; they are intentionally stateless mocks and do not mutate entitlement state across calls.
 - Real Stripe webhook signature verification, replay protection storage, refund/reversal handling, and restore flows are out of scope for this mock contract stage.
+- Secret Shanghai discovery uses commerce vocabulary: invitation token product keys, unlock keys, grant source, entitlement status, and unlock-flag snapshots.
 
 ## Canonical Media Events Fixture (Connector-Independent)
 Used by topic modeling/frequency workstreams so they can iterate without live Spotify/YouTube sync.

--- a/packages/contracts/fixtures/commerce.shanghai-secret-redeem.sample.json
+++ b/packages/contracts/fixtures/commerce.shanghai-secret-redeem.sample.json
@@ -1,0 +1,40 @@
+{
+  "redemptionId": "red_shanghai_secret_riverside_001",
+  "status": "redeemed",
+  "userId": "demo-user-1",
+  "city": "shanghai",
+  "idempotencyKey": "redeem.shanghai.secret.riverside_speakeasy:demo-user-1:INVITE-RIVER-0421",
+  "redeemedAtIso": "2026-04-21T09:14:00.000Z",
+  "invitationToken": {
+    "productKey": "token.shanghai.secret.riverside_speakeasy.invite",
+    "status": "consumed"
+  },
+  "grant": {
+    "grantId": "grant_unlock_shanghai_secret_riverside",
+    "unlockKey": "unlock.shanghai.secret.riverside_speakeasy",
+    "grantSource": "invitation_token_redemption"
+  },
+  "entitlement": {
+    "entitlementId": "ent_unlock_shanghai_secret_riverside",
+    "productKey": "unlock.shanghai.secret.riverside_speakeasy",
+    "type": "feature_access",
+    "status": "active",
+    "grantedAtIso": "2026-04-21T09:14:00.000Z",
+    "source": "invitation_token_redemption",
+    "purchaseEventId": null,
+    "metadata": {
+      "city": "shanghai",
+      "locationKey": "shanghai.secret.riverside_speakeasy",
+      "redeemTokenProductKey": "token.shanghai.secret.riverside_speakeasy.invite"
+    }
+  },
+  "unlockFlagsSnapshot": {
+    "snapshotId": "snap_unlock_flags_demo_user_1_20260421t091400z",
+    "generatedAtIso": "2026-04-21T09:14:00.000Z",
+    "flags": {
+      "unlock.shanghai.texting_mission": true,
+      "unlock.shanghai.secret.riverside_speakeasy": true,
+      "collectible.polaroid.shanghai_call": true
+    }
+  }
+}

--- a/packages/contracts/fixtures/commerce.shanghai-secret-status.sample.json
+++ b/packages/contracts/fixtures/commerce.shanghai-secret-status.sample.json
@@ -1,0 +1,26 @@
+{
+  "userId": "demo-user-1",
+  "city": "shanghai",
+  "asOfIso": "2026-04-21T09:12:00.000Z",
+  "secretLocation": {
+    "locationKey": "shanghai.secret.riverside_speakeasy",
+    "locationLabel": "Riverside Speakeasy",
+    "discoveryState": "teased",
+    "revealState": "alias_only",
+    "requiresInvitationToken": true
+  },
+  "invitationToken": {
+    "status": "eligible",
+    "tokenProductKey": "token.shanghai.secret.riverside_speakeasy.invite",
+    "tokenHint": "Found in advanced texting mission reward thread."
+  },
+  "unlockFlagsSnapshot": {
+    "snapshotId": "snap_unlock_flags_demo_user_1_20260421t091200z",
+    "generatedAtIso": "2026-04-21T09:12:00.000Z",
+    "flags": {
+      "unlock.shanghai.texting_mission": true,
+      "unlock.shanghai.secret.riverside_speakeasy": false,
+      "collectible.polaroid.shanghai_call": true
+    }
+  }
+}


### PR DESCRIPTION
### Motivation
- Introduce a secret Shanghai location discovery and invitation-token redemption flow so the commerce mock can express gated scene reveals and deterministic unlock snapshots.
- Provide deterministic fixture payloads for QA and downstream UI/workers to reference without adding stateful mutation logic.

### Description
- Added `GET /api/v1/commerce/shanghai-secret-status` and `POST /api/v1/commerce/shanghai-secret/redeem-invitation` to `packages/contracts/api-contract.md` with payloads for `secretLocation`, `invitationToken`, `grant`, `entitlement`, and `unlockFlagsSnapshot`.
- Added deterministic fixture files `packages/contracts/fixtures/commerce.shanghai-secret-status.sample.json` and `packages/contracts/fixtures/commerce.shanghai-secret-redeem.sample.json` containing before/after unlock-flag snapshots and idempotent redemption metadata.
- Added `docs/shanghai/ISSUE-256-reviewer-note.md` documenting scope (partial #256), what was included, and out-of-scope items.
- Aligned contract vocabulary to existing commerce/entitlement terms such as `productKey`, `unlockKey`, `grantSource`, `entitlement`, and `idempotencyKey`.

### Testing
- New fixtures were validated by parsing them with `node -e "const fs=require('fs');['packages/contracts/fixtures/commerce.shanghai-secret-status.sample.json','packages/contracts/fixtures/commerce.shanghai-secret-redeem.sample.json'].forEach(f=>JSON.parse(fs.readFileSync(f,'utf8'))); console.log('ok fixtures parse');"` which succeeded.
- `npm run test:graph-contracts` was executed and passed for the graph/fixture checks.
- `npm run test:api-flow` was attempted but failed in this environment because the local mock API server at `http://localhost:8787` was not running, so API-flow checks are optional and should be run locally or in CI with the worker running.
- How to test locally: run the fixture parse command above, then start the worker and run `npm run test:api-flow` to validate mock API endpoints against the new fixtures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7d2bee840832a82961dd8b557e222)