### PR TITLE
[Partial #256] Add Shanghai secret-location contract and deterministic fixtures

### DIFF
--- a/docs/shanghai/REVIEWER-NOTE-256.md
+++ b/docs/shanghai/REVIEWER-NOTE-256.md
@@ -1,0 +1,16 @@
+# Issue #256 (partial) — Reviewer note
+
+Scope in this slice is contract + fixture only (no UI/runtime wiring).
+
+## What is defined
+- Secret Shanghai location concept: **Archive Alley** with deterministic reveal state progression (`hidden` → `teased` → `revealed` → `entered`).
+- Invitation-token redemption response aligned to commerce unlock vocabulary (`unlockKey`, `grantSource`, `idempotencyKey`, `entitlement`).
+- Unlock-flag snapshots in both status and redemption fixtures so reviewers can verify before/after state deterministically.
+
+## Deterministic fixtures
+- `packages/contracts/fixtures/shanghai.secret-location.status.sample.json`
+- `packages/contracts/fixtures/shanghai.secret-location.redeem.sample.json`
+
+## Out of scope in this partial
+- No scene, onboarding, or panorama runtime edits.
+- No mutation-persistent redemption flow in server runtime.

--- a/packages/contracts/api-contract.md
+++ b/packages/contracts/api-contract.md
@@ -934,6 +934,39 @@ Response:
 }
 ```
 
+## GET `/api/v1/shanghai/secret-location/status`
+Query:
+```json
+{ "userId": "demo-user-1", "locationId": "archive_alley" }
+```
+
+Response:
+Path: `packages/contracts/fixtures/shanghai.secret-location.status.sample.json`
+
+Contract notes:
+- `reveal.state` is the scene-facing state machine: `hidden` → `teased` → `revealed` → `entered`.
+- `concept.unlockKey`/`concept.productKey` use commerce naming so entitlement checks can be reused across mission and location unlocks.
+- `unlockFlagSnapshot` is a deterministic read-model snapshot for fixture-backed mocks; stateless demo workers must not mutate it between calls.
+
+## POST `/api/v1/shanghai/secret-location/redeem-invitation`
+Request:
+```json
+{
+  "userId": "demo-user-1",
+  "locationId": "archive_alley",
+  "invitationToken": "inv_shanghai_arc_1f6e9a",
+  "idempotencyKey": "unlock.shanghai.secret.archive_alley:demo-user-1:inv_archive_alley_001"
+}
+```
+
+Response:
+Path: `packages/contracts/fixtures/shanghai.secret-location.redeem.sample.json`
+
+Contract notes:
+- Redemption response mirrors commerce unlock grants (`unlockKey`, `grantSource`, `idempotencyKey`, and `entitlement`) for terminology alignment.
+- `grantSource` value for invitation claims is `invitation_token`.
+- `unlockFlagSnapshot.flags` must reflect post-redemption truth values without relying on mutable server state in this mock stage.
+
 ## GET `/api/v1/demo/secret-status`
 Notes:
 - Protected when `TONG_DEMO_PASSWORD` is configured.

--- a/packages/contracts/fixtures/shanghai.secret-location.redeem.sample.json
+++ b/packages/contracts/fixtures/shanghai.secret-location.redeem.sample.json
@@ -1,0 +1,39 @@
+{
+  "redemptionId": "redeem_inv_archive_alley_001",
+  "status": "granted",
+  "userId": "demo-user-1",
+  "city": "shanghai",
+  "locationId": "archive_alley",
+  "unlockKey": "unlock.shanghai.secret.archive_alley",
+  "grantSource": "invitation_token",
+  "grantedAtIso": "2026-04-21T10:03:00.000Z",
+  "idempotencyKey": "unlock.shanghai.secret.archive_alley:demo-user-1:inv_archive_alley_001",
+  "invitationToken": {
+    "tokenId": "inv_archive_alley_001",
+    "tokenHint": "inv_shanghai_arc_***",
+    "status": "redeemed",
+    "redeemedAtIso": "2026-04-21T10:03:00.000Z"
+  },
+  "entitlement": {
+    "entitlementId": "ent_unlock_shanghai_secret_archive_alley",
+    "productKey": "unlock.shanghai.secret.archive_alley",
+    "type": "location_unlock",
+    "status": "active",
+    "grantedAtIso": "2026-04-21T10:03:00.000Z",
+    "source": "invitation_token",
+    "purchaseEventId": null,
+    "metadata": {
+      "city": "shanghai",
+      "location": "archive_alley",
+      "revealStateAfterGrant": "revealed"
+    }
+  },
+  "unlockFlagSnapshot": {
+    "snapshotId": "ufs_demo_user_1_20260421T100300Z",
+    "flags": {
+      "unlock.shanghai.secret.archive_alley": true,
+      "unlock.shanghai.texting_mission": true,
+      "collectible.polaroid.shanghai_call": true
+    }
+  }
+}

--- a/packages/contracts/fixtures/shanghai.secret-location.status.sample.json
+++ b/packages/contracts/fixtures/shanghai.secret-location.status.sample.json
@@ -1,0 +1,42 @@
+{
+  "userId": "demo-user-1",
+  "city": "shanghai",
+  "locationId": "archive_alley",
+  "asOfIso": "2026-04-21T10:00:00.000Z",
+  "concept": {
+    "name": "Archive Alley",
+    "tagline": "Invitation-only lane behind the old print shop.",
+    "unlockKey": "unlock.shanghai.secret.archive_alley",
+    "productKey": "unlock.shanghai.secret.archive_alley"
+  },
+  "reveal": {
+    "state": "teased",
+    "stateHistory": [
+      {
+        "state": "hidden",
+        "atIso": "2026-04-20T18:00:00.000Z",
+        "source": "system_seed"
+      },
+      {
+        "state": "teased",
+        "atIso": "2026-04-21T09:45:00.000Z",
+        "source": "story_beat"
+      }
+    ],
+    "nextEligibleTransition": "revealed"
+  },
+  "invitationToken": {
+    "tokenHint": "inv_shanghai_arc_***",
+    "status": "redeemable",
+    "expiresAtIso": "2026-05-01T00:00:00.000Z"
+  },
+  "unlockFlagSnapshot": {
+    "snapshotId": "ufs_demo_user_1_20260421T100000Z",
+    "flags": {
+      "unlock.shanghai.secret.archive_alley": false,
+      "unlock.shanghai.texting_mission": true,
+      "collectible.polaroid.shanghai_call": true
+    }
+  },
+  "entitlement": null
+}


### PR DESCRIPTION
### Motivation
- Define the secret Shanghai location concept and its reveal lifecycle so downstream UI/runtime can consume a stable contract for gating and invites.
- Align redemption and unlock terminology with the existing commerce/entitlement vocabulary to enable reuse of entitlement checks and analytics.
- Provide deterministic, fixture-backed read-model snapshots so demo workers remain stateless and QA can validate before/after unlock states.

### Description
- Added API contract entries for `GET /api/v1/shanghai/secret-location/status` and `POST /api/v1/shanghai/secret-location/redeem-invitation` to `packages/contracts/api-contract.md` with notes on reveal-state semantics and redemption semantics. 
- Added two deterministic fixtures under `packages/contracts/fixtures/`: `shanghai.secret-location.status.sample.json` (status + pre-redemption unlock snapshot) and `shanghai.secret-location.redeem.sample.json` (redemption response + post-redemption unlock snapshot). 
- Added a short reviewer note `docs/shanghai/REVIEWER-NOTE-256.md` describing scope, deterministic fixture usage, and out-of-scope constraints for this partial work. 
- Kept terminology consistent with commerce fixtures by using `unlockKey`, `grantSource`, `idempotencyKey`, `entitlement`, and `unlockFlagSnapshot` fields.

### Testing
- Verified the new fixtures parse as JSON with `node -e "const fs=require('fs');['packages/contracts/fixtures/shanghai.secret-location.status.sample.json','packages/contracts/fixtures/shanghai.secret-location.redeem.sample.json'].forEach(p=>JSON.parse(fs.readFileSync(p,'utf8'))); console.log('ok fixtures');"` which returned `ok fixtures`.
- Ran the contract/schema smoke checks with `npm run test:graph-contracts` and observed the script pass for the checked fixtures. 
- Confirmed the added `api-contract.md` entries are present and reference the new fixture paths for reviewers to validate.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7d2bee840832a82961dd8b557e222)