### PR TITLE
feat(contracts): add Shanghai secret-location reveal + invitation fixtures (partial #256)

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -9,6 +9,9 @@ import mediaProfileFixture from '../../../packages/contracts/fixtures/player.med
 import commerceEntitlementsFixture from '../../../packages/contracts/fixtures/commerce.entitlements.sample.json';
 import commerceUnlockGrantFixture from '../../../packages/contracts/fixtures/commerce.unlock-grant.sample.json';
 import commercePurchaseEventFixture from '../../../packages/contracts/fixtures/commerce.purchase-event.sample.json';
+import commerceShanghaiInvitationRedeemFixture from '../../../packages/contracts/fixtures/commerce.shanghai-invitation-redeem.sample.json';
+import commerceShanghaiSecretLocationStatusFixture from '../../../packages/contracts/fixtures/commerce.shanghai-secret-location-status.sample.json';
+import commerceUnlockFlagsSnapshotFixture from '../../../packages/contracts/fixtures/commerce.unlock-flags.snapshot.sample.json';
 import objectiveIdentityMap from '../../../packages/contracts/objective-identity-map.sample.json';
 import mockMediaWindow from '../../server/data/mock-media-window.json';
 
@@ -437,6 +440,9 @@ const FIXTURES = {
   commerceEntitlements: commerceEntitlementsFixture,
   commerceUnlockGrant: commerceUnlockGrantFixture,
   commercePurchaseEvent: commercePurchaseEventFixture,
+  commerceShanghaiInvitationRedeem: commerceShanghaiInvitationRedeemFixture,
+  commerceShanghaiSecretLocationStatus: commerceShanghaiSecretLocationStatusFixture,
+  commerceUnlockFlagsSnapshot: commerceUnlockFlagsSnapshotFixture,
 };
 
 const objectiveIdentityByCanonical = new Map<string, (typeof objectiveIdentityMap.objectives)[number]>();
@@ -1916,6 +1922,18 @@ async function handleRequest(request: Request): Promise<Response> {
     if (pathname === '/api/v1/commerce/purchase-events' && request.method === 'POST') {
       const body = await readJsonBody(request);
       return jsonResponse(200, buildCommercePurchaseEvent(body));
+    }
+
+    if (pathname === '/api/v1/commerce/invitations/redeem' && request.method === 'POST') {
+      return jsonResponse(200, FIXTURES.commerceShanghaiInvitationRedeem);
+    }
+
+    if (pathname === '/api/v1/commerce/locations/secret-status' && request.method === 'GET') {
+      return jsonResponse(200, FIXTURES.commerceShanghaiSecretLocationStatus);
+    }
+
+    if (pathname === '/api/v1/commerce/unlock-flags/snapshot' && request.method === 'GET') {
+      return jsonResponse(200, FIXTURES.commerceUnlockFlagsSnapshot);
     }
 
     if (pathname === '/api/v1/ingestion/run-mock' && request.method === 'POST') {

--- a/docs/shanghai/ISSUE-256-reviewer-note.md
+++ b/docs/shanghai/ISSUE-256-reviewer-note.md
@@ -1,0 +1,13 @@
+# Issue #256 (partial) reviewer note
+
+Scope in this patch is contract + deterministic fixtures only (no UI/runtime scene changes).
+
+## What was added
+- Secret Shanghai location contract shape for `night_market_rooftop` with reveal-state progression and entitlement-backed unlock flags.
+- Invitation-token redemption response fixture aligned to commerce unlock vocabulary (`unlockKey`, `productKey`, `entitlementId`, `source`).
+- Unlock-flag snapshot fixture for deterministic reviewer assertions.
+
+## Intentional non-goals
+- No client scene/onboarding updates.
+- No panorama runtime edits.
+- No live persistence behavior; fixture-backed API contracts remain deterministic.

--- a/packages/contracts/api-contract.md
+++ b/packages/contracts/api-contract.md
@@ -338,6 +338,49 @@ Contract notes:
 - Demo worker responses are fixture-backed and deterministic; they are intentionally stateless mocks and do not mutate entitlement state across calls.
 - Real Stripe webhook signature verification, replay protection storage, refund/reversal handling, and restore flows are out of scope for this mock contract stage.
 
+## POST `/api/v1/commerce/invitations/redeem`
+Request:
+```json
+{
+  "userId": "demo-user-1",
+  "city": "shanghai",
+  "invitationToken": "INVITE-ROOFTOP-9F2K",
+  "idempotencyKey": "invite_tok_sh_rooftop_001:demo-user-1"
+}
+```
+
+Response:
+Path: `packages/contracts/fixtures/commerce.shanghai-invitation-redeem.sample.json`
+
+## GET `/api/v1/commerce/locations/secret-status`
+Query:
+```json
+{
+  "userId": "demo-user-1",
+  "city": "shanghai",
+  "locationId": "night_market_rooftop"
+}
+```
+
+Response:
+Path: `packages/contracts/fixtures/commerce.shanghai-secret-location-status.sample.json`
+
+Contract note:
+- `revealState` is deterministic and monotonic for fixture scenarios: `hidden` -> `teased` -> `token_required` -> `token_redeemed`.
+- `unlockFlags` mirror entitlement-backed access gates and must stay aligned with `unlockKey`/`productKey` naming used by commerce unlocks.
+
+## GET `/api/v1/commerce/unlock-flags/snapshot`
+Query:
+```json
+{ "userId": "demo-user-1" }
+```
+
+Response:
+Path: `packages/contracts/fixtures/commerce.unlock-flags.snapshot.sample.json`
+
+Contract note:
+- Snapshot payloads are immutable point-in-time reads meant for reviewer verification and deterministic QA assertions.
+
 ## Canonical Media Events Fixture (Connector-Independent)
 Used by topic modeling/frequency workstreams so they can iterate without live Spotify/YouTube sync.
 

--- a/packages/contracts/fixtures/commerce.shanghai-invitation-redeem.sample.json
+++ b/packages/contracts/fixtures/commerce.shanghai-invitation-redeem.sample.json
@@ -1,0 +1,26 @@
+{
+  "redeemEventId": "redeem_evt_shanghai_rooftop_001",
+  "status": "redeemed",
+  "userId": "demo-user-1",
+  "city": "shanghai",
+  "unlockKey": "unlock.shanghai.secret.night_market_rooftop",
+  "tokenId": "invite_tok_sh_rooftop_001",
+  "tokenFingerprint": "sha256:invite_tok_sh_rooftop_001",
+  "redeemedAtIso": "2026-04-21T09:18:00.000Z",
+  "idempotencyKey": "invite_tok_sh_rooftop_001:demo-user-1",
+  "entitlement": {
+    "entitlementId": "ent_unlock_shanghai_secret_night_market_rooftop",
+    "productKey": "unlock.shanghai.secret.night_market_rooftop",
+    "type": "feature_access",
+    "status": "active",
+    "grantedAtIso": "2026-04-21T09:18:00.000Z",
+    "source": "invitation_token",
+    "purchaseEventId": null,
+    "metadata": {
+      "city": "shanghai",
+      "locationId": "night_market_rooftop",
+      "unlockTier": "secret_location",
+      "redeemChannel": "npc_dm"
+    }
+  }
+}

--- a/packages/contracts/fixtures/commerce.shanghai-secret-location-status.sample.json
+++ b/packages/contracts/fixtures/commerce.shanghai-secret-location-status.sample.json
@@ -1,0 +1,34 @@
+{
+  "userId": "demo-user-1",
+  "city": "shanghai",
+  "locationId": "night_market_rooftop",
+  "unlockKey": "unlock.shanghai.secret.night_market_rooftop",
+  "revealState": "token_redeemed",
+  "invitationToken": {
+    "tokenHint": "INVITE-ROOFTOP-***",
+    "status": "redeemed",
+    "redeemedAtIso": "2026-04-21T09:18:00.000Z",
+    "redeemEventId": "redeem_evt_shanghai_rooftop_001"
+  },
+  "unlockFlags": {
+    "isDiscoverable": true,
+    "isVisibleOnMap": true,
+    "isEnterable": true,
+    "isMissionEligible": true
+  },
+  "entitlement": {
+    "entitlementId": "ent_unlock_shanghai_secret_night_market_rooftop",
+    "productKey": "unlock.shanghai.secret.night_market_rooftop",
+    "type": "feature_access",
+    "status": "active",
+    "grantedAtIso": "2026-04-21T09:18:00.000Z",
+    "source": "invitation_token",
+    "purchaseEventId": null,
+    "metadata": {
+      "city": "shanghai",
+      "locationId": "night_market_rooftop",
+      "unlockTier": "secret_location"
+    }
+  },
+  "asOfIso": "2026-04-21T09:20:00.000Z"
+}

--- a/packages/contracts/fixtures/commerce.unlock-flags.snapshot.sample.json
+++ b/packages/contracts/fixtures/commerce.unlock-flags.snapshot.sample.json
@@ -1,0 +1,27 @@
+{
+  "userId": "demo-user-1",
+  "snapshotAtIso": "2026-04-21T09:20:00.000Z",
+  "flags": [
+    {
+      "unlockKey": "unlock.shanghai.texting_mission",
+      "productKey": "unlock.shanghai.texting_mission",
+      "status": "active",
+      "source": "mission_reward",
+      "entitlementId": "ent_shanghai_texting_pack",
+      "updatedAtIso": "2026-04-18T02:00:00.000Z"
+    },
+    {
+      "unlockKey": "unlock.shanghai.secret.night_market_rooftop",
+      "productKey": "unlock.shanghai.secret.night_market_rooftop",
+      "status": "active",
+      "source": "invitation_token",
+      "entitlementId": "ent_unlock_shanghai_secret_night_market_rooftop",
+      "updatedAtIso": "2026-04-21T09:18:00.000Z",
+      "state": {
+        "revealState": "token_redeemed",
+        "mapVisibility": "visible",
+        "entryAccess": "allowed"
+      }
+    }
+  ]
+}

--- a/packages/contracts/types.ts
+++ b/packages/contracts/types.ts
@@ -165,7 +165,7 @@ export interface PlayerLanguageProfile {
 
 export type CommerceEntitlementType = 'feature_access' | 'location_unlock' | 'mission_unlock' | 'collectible';
 export type CommerceEntitlementStatus = 'active' | 'revoked' | 'expired';
-export type CommerceGrantSource = 'purchase_event' | 'mission_reward' | 'admin_manual';
+export type CommerceGrantSource = 'purchase_event' | 'mission_reward' | 'admin_manual' | 'invitation_token';
 
 export interface CommerceEntitlement {
   entitlementId: string;


### PR DESCRIPTION
### Motivation
- Define the secret Shanghai location concept and deterministic reveal progression for QA and reviewers.
- Add invitation-token redemption and unlock-flag snapshot shapes to align commerce/entitlement vocabulary with existing unlock flows.
- Provide deterministic fixtures so mock worker routes can return stable, reviewable payloads without changing UI or runtime scenes.

### Description
- Added contract docs for three new commerce shapes: `POST /api/v1/commerce/invitations/redeem`, `GET /api/v1/commerce/locations/secret-status`, and `GET /api/v1/commerce/unlock-flags/snapshot` in `packages/contracts/api-contract.md`.
- Added deterministic fixtures: `packages/contracts/fixtures/commerce.shanghai-invitation-redeem.sample.json`, `packages/contracts/fixtures/commerce.shanghai-secret-location-status.sample.json`, and `packages/contracts/fixtures/commerce.unlock-flags.snapshot.sample.json` capturing token redemption, reveal state, entitlement metadata, and snapshot flags.
- Exposed fixture-backed mock routes in the worker by wiring the new fixtures into `apps/worker/src/index.ts` so reviewers can hit the new shapes without stateful persistence.
- Added a short reviewer note at `docs/shanghai/ISSUE-256-reviewer-note.md` and kept the change scoped to partial #256 with no UI or panorama edits.

### Testing
- Ran `npm run test:graph-contracts` which passed successfully.
- Executed deterministic fixture & shape checks with a small Node script parsing the three new fixtures and asserting expected fields (timestamps, `revealState`, `productKey`/`unlockKey` alignment), which passed (`PASS fixture determinism + shape assertions`).
- Manual verification guidance: run the worker (`npm --prefix apps/worker run dev`) and confirm these endpoints return fixtures: `POST /api/v1/commerce/invitations/redeem`, `GET /api/v1/commerce/locations/secret-status`, and `GET /api/v1/commerce/unlock-flags/snapshot`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7d2bee840832a82961dd8b557e222)