### PR TITLE
feat(panorama): add draggable panorama cinematic + backstage runtime

### DIFF
--- a/apps/client/app/backstage/panorama-runtime/page.tsx
+++ b/apps/client/app/backstage/panorama-runtime/page.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { SceneView } from '@/components/scene/SceneView';
+
+const SHANGHAI_BACKDROP = '/assets/locations/shanghai-static.png';
+const PANORAMA_ASSET = '/assets/locations/shanghai-static.png';
+
+export default function PanoramaRuntimePage() {
+  const [mode, setMode] = useState<'panorama' | 'cover'>('panorama');
+  const [lastTransform, setLastTransform] = useState(0);
+  const [sessionKey, setSessionKey] = useState(0);
+
+  const cinematic = useMemo(() => ({
+    videoUrl: '/assets/tong_intro.webm',
+    caption: mode === 'panorama' ? 'Drag sideways to pan the Shanghai panorama.' : 'Cover mode control check.',
+    captionTranslation: mode === 'panorama' ? `Current transformX: ${Math.round(lastTransform)}px` : 'Existing cover video behavior should remain unchanged.',
+    autoAdvance: false,
+    muted: true,
+    mode,
+    panoramaImageUrl: PANORAMA_ASSET,
+    panoramaWidth: 3072,
+    panoramaHeight: 1024,
+    onPanoramaTransformChange: (transformX: number) => setLastTransform(transformX),
+  }), [lastTransform, mode]);
+
+  return (
+    <main className="relative min-h-[100dvh] bg-[#0a0f1b] text-white">
+      <div className="absolute left-3 right-3 top-3 z-40 rounded-xl border border-white/20 bg-black/55 p-3 text-xs backdrop-blur">
+        <p className="font-semibold">Panorama Runtime Backstage</p>
+        <p className="mt-1 opacity-80">Use this route to verify drag movement and transform output without touching onboarding production flow.</p>
+        <div className="mt-2 flex flex-wrap gap-2">
+          <button type="button" className="rounded border border-white/25 px-3 py-1" onClick={() => setMode('panorama')}>
+            Panorama mode
+          </button>
+          <button type="button" className="rounded border border-white/25 px-3 py-1" onClick={() => setMode('cover')}>
+            Cover mode
+          </button>
+          <button type="button" className="rounded border border-white/25 px-3 py-1" onClick={() => { setLastTransform(0); setSessionKey((prev) => prev + 1); }}>
+            Reset scene
+          </button>
+        </div>
+        <p className="mt-2">
+          Transform delta:
+          {' '}
+          <span data-testid="panorama-transform-delta" className="font-mono text-amber-300">
+            {Math.round(lastTransform)}px
+          </span>
+        </p>
+      </div>
+
+      <div className="absolute inset-0">
+        <SceneView
+          key={`${mode}-${sessionKey}`}
+          backgroundUrl={SHANGHAI_BACKDROP}
+          ambientDescription="Backstage panorama runtime check"
+          cinematic={cinematic}
+          npcName=""
+          sceneReady={true}
+        />
+      </div>
+    </main>
+  );
+}

--- a/apps/client/components/scene/CinematicOverlay.tsx
+++ b/apps/client/components/scene/CinematicOverlay.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, useCallback, useState, useEffect, useMemo } from 'react';
+import { useRef, useCallback, useState, useEffect, useMemo, type MouseEvent as ReactMouseEvent, type TouchEvent as ReactTouchEvent } from 'react';
 import { useUILang } from '@/lib/i18n/UILangContext';
 import { t } from '@/lib/i18n/ui-strings';
 import { KoreanText, type TargetLang } from '@/components/shared/KoreanText';
@@ -15,18 +15,55 @@ interface CinematicOverlayProps {
   captionTranslation?: string;
   autoAdvance: boolean;
   muted?: boolean;
+  mode?: 'cover' | 'panorama';
+  panoramaImageUrl?: string;
+  panoramaWidth?: number;
+  panoramaHeight?: number;
+  onPanoramaTransformChange?: (transformX: number) => void;
   targetLang?: TargetLang;
   onEnd: () => void;
 }
 
-export function CinematicOverlay({ videoUrl, caption, captionTranslation, autoAdvance, muted = false, targetLang = 'ko', onEnd }: CinematicOverlayProps) {
+const PANORAMA_DEFAULT_WIDTH = 2400;
+const PANORAMA_DEFAULT_HEIGHT = 1200;
+
+export function CinematicOverlay({
+  videoUrl,
+  caption,
+  captionTranslation,
+  autoAdvance,
+  muted = false,
+  mode = 'cover',
+  panoramaImageUrl,
+  panoramaWidth,
+  panoramaHeight,
+  onPanoramaTransformChange,
+  targetLang = 'ko',
+  onEnd,
+}: CinematicOverlayProps) {
   const lang = useUILang();
   const videoRef = useRef<HTMLVideoElement>(null);
+  const panoramaViewportRef = useRef<HTMLDivElement>(null);
+  const panoramaRef = useRef<HTMLDivElement>(null);
   const [fadingOut, setFadingOut] = useState(false);
   const [captionVisible, setCaptionVisible] = useState(false);
   const [candidateIndex, setCandidateIndex] = useState(0);
+  const [panoramaOffset, setPanoramaOffset] = useState(0);
+  const [draggingPanorama, setDraggingPanorama] = useState(false);
   const videoCandidates = useMemo(() => fallbackRuntimeAssetCandidates(videoUrl), [videoUrl]);
   const activeVideoUrl = videoCandidates[candidateIndex] ?? '';
+  const panoramaIsActive = mode === 'panorama';
+  const panoramaImageSrc = panoramaImageUrl || activeVideoUrl;
+  const [panoramaImageFailed, setPanoramaImageFailed] = useState(false);
+  const authoredPanoramaWidth = panoramaWidth ?? PANORAMA_DEFAULT_WIDTH;
+  const authoredPanoramaHeight = panoramaHeight ?? PANORAMA_DEFAULT_HEIGHT;
+  const [panoramaContentWidth, setPanoramaContentWidth] = useState(authoredPanoramaWidth);
+  const dragStateRef = useRef<{ startX: number; startOffset: number; moved: boolean } | null>(null);
+  const onPanoramaTransformChangeRef = useRef(onPanoramaTransformChange);
+
+  useEffect(() => {
+    onPanoramaTransformChangeRef.current = onPanoramaTransformChange;
+  }, [onPanoramaTransformChange]);
 
   // Typewriter state for caption
   const [captionChars, setCaptionChars] = useState(0);
@@ -51,8 +88,98 @@ export function CinematicOverlay({ videoUrl, caption, captionTranslation, autoAd
     setCandidateIndex(0);
   }, [videoUrl]);
 
+  useEffect(() => {
+    if (!panoramaIsActive) return;
+    setPanoramaOffset(0);
+    setPanoramaImageFailed(false);
+    onPanoramaTransformChangeRef.current?.(0);
+  }, [panoramaIsActive, panoramaImageSrc]);
+
+  useEffect(() => {
+    if (!panoramaIsActive) return;
+    const viewport = panoramaViewportRef.current;
+    if (!viewport) return;
+    const viewportWidth = viewport.clientWidth;
+    const computedByRatio = (viewportWidth * authoredPanoramaWidth) / authoredPanoramaHeight;
+    const nextWidth = Math.max(authoredPanoramaWidth, computedByRatio);
+    setPanoramaContentWidth(nextWidth);
+  }, [authoredPanoramaHeight, authoredPanoramaWidth, panoramaIsActive]);
+
+  const clampPanoramaOffset = useCallback((next: number) => {
+    const viewportWidth = panoramaViewportRef.current?.clientWidth ?? 0;
+    const maxOverflow = Math.max(0, panoramaContentWidth - viewportWidth);
+    return Math.min(0, Math.max(next, -maxOverflow));
+  }, [panoramaContentWidth]);
+
+  const applyPanoramaOffset = useCallback((next: number) => {
+    const clamped = clampPanoramaOffset(next);
+    setPanoramaOffset(clamped);
+    onPanoramaTransformChangeRef.current?.(clamped);
+  }, [clampPanoramaOffset]);
+
+  const handlePanoramaDragStart = useCallback((clientX: number) => {
+    if (!panoramaIsActive) return;
+    dragStateRef.current = {
+      startX: clientX,
+      startOffset: panoramaOffset,
+      moved: false,
+    };
+    setDraggingPanorama(true);
+  }, [panoramaIsActive, panoramaOffset]);
+
+  const handlePanoramaDragMove = useCallback((clientX: number) => {
+    const drag = dragStateRef.current;
+    if (!panoramaIsActive || !drag) return;
+    const deltaX = clientX - drag.startX;
+    if (Math.abs(deltaX) > 6) {
+      drag.moved = true;
+    }
+    applyPanoramaOffset(drag.startOffset + deltaX);
+  }, [applyPanoramaOffset, panoramaIsActive]);
+
+  const handlePanoramaDragEnd = useCallback(() => {
+    const drag = dragStateRef.current;
+    if (!drag) return;
+    dragStateRef.current = null;
+    setDraggingPanorama(false);
+    if (!drag.moved && !autoAdvance) {
+      triggerEnd();
+    }
+  }, [autoAdvance, triggerEnd]);
+
+  const handlePanoramaMouseDown = useCallback((event: ReactMouseEvent<HTMLDivElement>) => {
+    handlePanoramaDragStart(event.clientX);
+  }, [handlePanoramaDragStart]);
+
+  const handlePanoramaTouchStart = useCallback((event: ReactTouchEvent<HTMLDivElement>) => {
+    if (event.touches.length < 1) return;
+    handlePanoramaDragStart(event.touches[0].clientX);
+  }, [handlePanoramaDragStart]);
+
+  useEffect(() => {
+    if (!draggingPanorama) return;
+    const onMouseMove = (event: MouseEvent) => handlePanoramaDragMove(event.clientX);
+    const onMouseUp = () => handlePanoramaDragEnd();
+    const onTouchMove = (event: TouchEvent) => {
+      if (event.touches.length < 1) return;
+      handlePanoramaDragMove(event.touches[0].clientX);
+    };
+    const onTouchEnd = () => handlePanoramaDragEnd();
+    window.addEventListener('mousemove', onMouseMove);
+    window.addEventListener('mouseup', onMouseUp);
+    window.addEventListener('touchmove', onTouchMove, { passive: true });
+    window.addEventListener('touchend', onTouchEnd);
+    return () => {
+      window.removeEventListener('mousemove', onMouseMove);
+      window.removeEventListener('mouseup', onMouseUp);
+      window.removeEventListener('touchmove', onTouchMove);
+      window.removeEventListener('touchend', onTouchEnd);
+    };
+  }, [draggingPanorama, handlePanoramaDragEnd, handlePanoramaDragMove]);
+
   // Autoplay with unmute fallback + audio fade-in
   useEffect(() => {
+    if (panoramaIsActive) return;
     const v = videoRef.current;
     if (!v) return;
     // Start at zero volume for fade-in
@@ -75,10 +202,11 @@ export function CinematicOverlay({ videoUrl, caption, captionTranslation, autoAd
       }, 40);
       return () => clearInterval(fadeIn);
     }
-  }, [activeVideoUrl, muted]);
+  }, [activeVideoUrl, muted, panoramaIsActive]);
 
   // Fade out audio before video ends
   useEffect(() => {
+    if (panoramaIsActive) return;
     const v = videoRef.current;
     if (!v || muted) return;
     const handleTimeUpdate = () => {
@@ -89,7 +217,7 @@ export function CinematicOverlay({ videoUrl, caption, captionTranslation, autoAd
     };
     v.addEventListener('timeupdate', handleTimeUpdate);
     return () => v.removeEventListener('timeupdate', handleTimeUpdate);
-  }, [activeVideoUrl, muted]);
+  }, [activeVideoUrl, muted, panoramaIsActive]);
 
   // Fade in caption shortly after video starts playing, then start typewriter
   useEffect(() => {
@@ -126,6 +254,7 @@ export function CinematicOverlay({ videoUrl, caption, captionTranslation, autoAd
     <div
       className={`cinematic-overlay ${fadingOut ? 'cinematic-fade-out' : ''}`}
       onClick={(e) => {
+        if (panoramaIsActive) return;
         const v = videoRef.current;
         if (v && v.muted && !muted) {
           // First tap unmutes if autoplay was forced muted
@@ -137,24 +266,65 @@ export function CinematicOverlay({ videoUrl, caption, captionTranslation, autoAd
       role={autoAdvance ? undefined : 'button'}
       tabIndex={autoAdvance ? undefined : 0}
     >
-      <video
-        ref={videoRef}
-        src={activeVideoUrl}
-        playsInline
-        muted={muted}
-        onEnded={handleEnded}
-        onError={() => {
-          if (candidateIndex + 1 < videoCandidates.length) {
-            setCandidateIndex(candidateIndex + 1);
-          } else {
-            triggerEnd();
-          }
-        }}
-        className="cinematic-video"
-        disablePictureInPicture
-        disableRemotePlayback
-        controlsList="nodownload noplaybackrate"
-      />
+      {panoramaIsActive ? (
+        <div
+          ref={panoramaViewportRef}
+          className="absolute inset-0 overflow-hidden touch-none"
+          onMouseDown={handlePanoramaMouseDown}
+          onTouchStart={handlePanoramaTouchStart}
+          onDoubleClick={(event) => event.preventDefault()}
+          style={{ cursor: draggingPanorama ? 'grabbing' : 'grab' }}
+        >
+          <div
+            ref={panoramaRef}
+            className="absolute top-0 left-0 h-full"
+            style={{
+              width: `${panoramaContentWidth}px`,
+              transform: `translate3d(${panoramaOffset}px, 0px, 0px)`,
+              transition: draggingPanorama ? 'none' : 'transform 120ms ease-out',
+              willChange: 'transform',
+            }}
+          >
+            {!panoramaImageFailed ? (
+              <img
+                src={panoramaImageSrc}
+                alt="Panorama cinematic backdrop"
+                className="h-full w-full select-none"
+                draggable={false}
+                style={{ objectFit: 'fill' }}
+                onError={() => setPanoramaImageFailed(true)}
+              />
+            ) : (
+              <div
+                className="h-full w-full"
+                style={{
+                  background:
+                    'linear-gradient(90deg, #1a2242 0%, #2f4f87 18%, #8f5f8d 36%, #e58f5c 54%, #4b8b84 72%, #25253f 100%)',
+                }}
+              />
+            )}
+          </div>
+        </div>
+      ) : (
+        <video
+          ref={videoRef}
+          src={activeVideoUrl}
+          playsInline
+          muted={muted}
+          onEnded={handleEnded}
+          onError={() => {
+            if (candidateIndex + 1 < videoCandidates.length) {
+              setCandidateIndex(candidateIndex + 1);
+            } else {
+              triggerEnd();
+            }
+          }}
+          className="cinematic-video"
+          disablePictureInPicture
+          disableRemotePlayback
+          controlsList="nodownload noplaybackrate"
+        />
+      )}
       {caption && (
         <div
           className={`cinematic-subtitle-bar ${captionVisible ? 'cinematic-subtitle-visible' : ''}`}

--- a/apps/client/components/scene/SceneView.tsx
+++ b/apps/client/components/scene/SceneView.tsx
@@ -17,7 +17,18 @@ interface SceneViewProps {
   backgroundUrl: string;
   backgroundTransition?: 'fade' | 'cut';
   ambientDescription?: string;
-  cinematic?: { videoUrl: string; caption?: string; captionTranslation?: string; autoAdvance: boolean; muted?: boolean } | null;
+  cinematic?: {
+    videoUrl: string;
+    caption?: string;
+    captionTranslation?: string;
+    autoAdvance: boolean;
+    muted?: boolean;
+    mode?: 'cover' | 'panorama';
+    panoramaImageUrl?: string;
+    panoramaWidth?: number;
+    panoramaHeight?: number;
+    onPanoramaTransformChange?: (transformX: number) => void;
+  } | null;
   onCinematicEnd?: () => void;
   npcName?: string;
   npcColor?: string;
@@ -158,6 +169,11 @@ export function SceneView({
           captionTranslation={cinematic.captionTranslation}
           autoAdvance={cinematic.autoAdvance}
           muted={cinematic.muted ?? false}
+          mode={cinematic.mode ?? 'cover'}
+          panoramaImageUrl={cinematic.panoramaImageUrl}
+          panoramaWidth={cinematic.panoramaWidth}
+          panoramaHeight={cinematic.panoramaHeight}
+          onPanoramaTransformChange={cinematic.onPanoramaTransformChange}
           targetLang={targetLang}
           onEnd={handleCinematicEnd}
         />


### PR DESCRIPTION
### Motivation
- Provide a true panorama mode for cinematic backdrops that yields real horizontal overflow and direct drag-to-pan interaction instead of faking motion with CSS covers. 
- Keep existing cover/video cinematic behavior unchanged so production onboarding is not affected. 
- Expose a backstage-only route to validate interaction and metrics without touching production onboarding codepaths.

### Description
- Added a `mode: 'panorama' | 'cover'` option and panorama props to `CinematicOverlay` and implemented a draggable, authored-dimension panorama that produces real horizontal overflow, clamps panning, emits transform updates via `onPanoramaTransformChange`, and falls back to an authored gradient if the image fails. 
- Implemented robust input handling for mouse and touch (drag start/move/end) and computed content width by authored dimensions and viewport ratio for predictable overflow. 
- Extended `SceneView` cinematic typing and passthrough so callers can supply `mode`, `panoramaImageUrl`, `panoramaWidth`, `panoramaHeight`, and `onPanoramaTransformChange` without breaking existing callers. 
- Added a backstage validation route `/backstage/panorama-runtime` that toggles panorama/cover modes, shows a transform-delta readout, and is intentionally kept separate from production onboarding pages.

### Testing
- Start client and manual runtime validation: ran `npm --prefix apps/client run dev -- --port 3004` and verified the app served `http://localhost:3004/backstage/panorama-runtime?demo=TONG-DEMO-ACCESS`. (Succeeded.)
- Automated interaction check: ran browser automation against `/backstage/panorama-runtime?demo=TONG-DEMO-ACCESS` that performed a horizontal drag and observed a non-zero transform delta (example observed `0px -> -627px`) and then switched to Cover mode to confirm a `<video class="cinematic-video">` is rendered. (Succeeded.)
- Typecheck: ran `cd apps/client && npx tsc --noEmit` to validate types. (Succeeded.)

How to test locally
- Run the client dev server: `npm --prefix apps/client run dev -- --port 3004`.
- Open `http://localhost:3004/backstage/panorama-runtime?demo=TONG-DEMO-ACCESS`, ensure "Panorama mode" is active, drag horizontally across the cinematic and confirm the transform delta readout becomes non-zero, then switch to "Cover mode" and confirm the video element is present.
- Run typecheck: `cd apps/client && npx tsc --noEmit`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7d2943d90832a94627146f7c02041)