### PR TITLE
[Issue #258] Panorama runtime drag overflow + cover-mode preservation (partial)

### DIFF
--- a/apps/client/app/backstage/panorama-runtime/page.tsx
+++ b/apps/client/app/backstage/panorama-runtime/page.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { UILangProvider } from '@/lib/i18n/UILangContext';
+import { SceneView } from '@/components/scene/SceneView';
+
+const DEMO_ACCESS_TOKEN = 'TONG-DEMO-ACCESS';
+const COVER_TEST_VIDEO = '/assets/cinematics/jin/intro_1.mp4';
+const PANORAMA_STANDIN = '/assets/webtoon/shanghai/h1/0.png';
+
+export default function BackstagePanoramaRuntimePage() {
+  const searchParams = useSearchParams();
+  const [mode, setMode] = useState<'panorama' | 'cover'>('panorama');
+  const [deltaX, setDeltaX] = useState(0);
+  const demoToken = searchParams.get('demo');
+
+  if (demoToken !== DEMO_ACCESS_TOKEN) {
+    return (
+      <main className="min-h-screen bg-[#0c1024] p-6 text-[#f3f5ff]">
+        <h1 className="text-xl font-semibold">Panorama Runtime Backstage</h1>
+        <p className="mt-3 max-w-2xl text-sm text-[#b8c2f0]">
+          Access restricted. Open this route with{' '}
+          <code className="rounded bg-black/30 px-1 py-0.5">?demo={DEMO_ACCESS_TOKEN}</code>.
+        </p>
+      </main>
+    );
+  }
+
+  return (
+    <UILangProvider value="en">
+      <main className="min-h-screen bg-[#060914] text-[#f3f5ff]">
+        <header className="mx-auto flex w-full max-w-5xl flex-wrap items-center gap-3 px-4 py-4">
+          <h1 className="text-lg font-semibold">Backstage · Panorama runtime</h1>
+          <button
+            type="button"
+            className={`rounded-full border px-3 py-1 text-xs font-semibold ${mode === 'panorama' ? 'border-[#91a8ff] bg-[#1a2758]' : 'border-white/20 bg-black/35'}`}
+            onClick={() => setMode('panorama')}
+          >
+            Panorama mode
+          </button>
+          <button
+            type="button"
+            className={`rounded-full border px-3 py-1 text-xs font-semibold ${mode === 'cover' ? 'border-[#91a8ff] bg-[#1a2758]' : 'border-white/20 bg-black/35'}`}
+            onClick={() => setMode('cover')}
+          >
+            Cover mode
+          </button>
+          <p className="ml-auto text-xs text-[#a7b5ea]">Drag delta: {deltaX.toFixed(2)}px</p>
+        </header>
+
+        <section className="mx-auto w-full max-w-5xl px-4 pb-6">
+          <div className="relative aspect-[9/16] overflow-hidden rounded-2xl border border-white/15 bg-black shadow-[0_24px_50px_rgba(0,0,0,0.45)]">
+            <SceneView
+              backgroundUrl={PANORAMA_STANDIN}
+              ambientDescription="Keep your head down. Listen before they notice you."
+              cinematic={{
+                videoUrl: mode === 'panorama' ? PANORAMA_STANDIN : COVER_TEST_VIDEO,
+                caption: mode === 'panorama'
+                  ? 'Panorama runtime drag test: move left/right and verify transform delta updates.'
+                  : 'Cover mode baseline: legacy cinematic behavior should remain unchanged.',
+                autoAdvance: false,
+                muted: true,
+              }}
+              cinematicMode={mode}
+              panoramaAuthoredWidth={mode === 'panorama' ? 3072 : undefined}
+              panoramaAuthoredHeight={mode === 'panorama' ? 1080 : undefined}
+              panoramaMinOverflowPx={mode === 'panorama' ? 220 : undefined}
+              onPanoramaTransformChange={setDeltaX}
+              onCinematicEnd={() => {}}
+            />
+          </div>
+        </section>
+      </main>
+    </UILangProvider>
+  );
+}

--- a/apps/client/components/scene/CinematicOverlay.tsx
+++ b/apps/client/components/scene/CinematicOverlay.tsx
@@ -15,18 +15,56 @@ interface CinematicOverlayProps {
   captionTranslation?: string;
   autoAdvance: boolean;
   muted?: boolean;
+  mode?: 'cover' | 'panorama';
+  panoramaAuthoredWidth?: number;
+  panoramaAuthoredHeight?: number;
+  panoramaMinOverflowPx?: number;
+  onPanoramaTransformChange?: (deltaX: number) => void;
   targetLang?: TargetLang;
   onEnd: () => void;
 }
 
-export function CinematicOverlay({ videoUrl, caption, captionTranslation, autoAdvance, muted = false, targetLang = 'ko', onEnd }: CinematicOverlayProps) {
+export function CinematicOverlay({
+  videoUrl,
+  caption,
+  captionTranslation,
+  autoAdvance,
+  muted = false,
+  mode = 'cover',
+  panoramaAuthoredWidth,
+  panoramaAuthoredHeight,
+  panoramaMinOverflowPx = 120,
+  onPanoramaTransformChange,
+  targetLang = 'ko',
+  onEnd,
+}: CinematicOverlayProps) {
   const lang = useUILang();
+  const rootRef = useRef<HTMLDivElement>(null);
   const videoRef = useRef<HTMLVideoElement>(null);
   const [fadingOut, setFadingOut] = useState(false);
   const [captionVisible, setCaptionVisible] = useState(false);
   const [candidateIndex, setCandidateIndex] = useState(0);
   const videoCandidates = useMemo(() => fallbackRuntimeAssetCandidates(videoUrl), [videoUrl]);
   const activeVideoUrl = videoCandidates[candidateIndex] ?? '';
+  const isPanoramaMode = mode === 'panorama';
+  const [viewportWidth, setViewportWidth] = useState(0);
+  const [naturalSize, setNaturalSize] = useState<{ width: number; height: number } | null>(null);
+  const [panX, setPanX] = useState(0);
+  const dragStateRef = useRef<{ startX: number; originPanX: number; movedPx: number } | null>(null);
+  const suppressTapRef = useRef(false);
+
+  const authoredAspect =
+    panoramaAuthoredWidth && panoramaAuthoredHeight && panoramaAuthoredWidth > 0 && panoramaAuthoredHeight > 0
+      ? panoramaAuthoredWidth / panoramaAuthoredHeight
+      : null;
+  const naturalAspect = naturalSize && naturalSize.width > 0 && naturalSize.height > 0
+    ? naturalSize.width / naturalSize.height
+    : null;
+  const panoramaAspect = authoredAspect ?? naturalAspect ?? (21 / 9);
+  const panoramaTrackWidth = viewportWidth > 0
+    ? Math.max(viewportWidth * panoramaAspect, viewportWidth + panoramaMinOverflowPx)
+    : 0;
+  const panoramaMinPanX = Math.min(0, viewportWidth - panoramaTrackWidth);
 
   // Typewriter state for caption
   const [captionChars, setCaptionChars] = useState(0);
@@ -51,8 +89,34 @@ export function CinematicOverlay({ videoUrl, caption, captionTranslation, autoAd
     setCandidateIndex(0);
   }, [videoUrl]);
 
+  useEffect(() => {
+    if (!isPanoramaMode) return;
+    const node = rootRef.current;
+    if (!node) return;
+    const resizeObserver = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) return;
+      setViewportWidth(entry.contentRect.width);
+    });
+    resizeObserver.observe(node);
+    return () => resizeObserver.disconnect();
+  }, [isPanoramaMode]);
+
+  useEffect(() => {
+    if (!isPanoramaMode) {
+      setPanX(0);
+      return;
+    }
+    setPanX((current) => Math.max(panoramaMinPanX, Math.min(0, current)));
+  }, [isPanoramaMode, panoramaMinPanX]);
+
+  useEffect(() => {
+    onPanoramaTransformChange?.(isPanoramaMode ? panX : 0);
+  }, [isPanoramaMode, onPanoramaTransformChange, panX]);
+
   // Autoplay with unmute fallback + audio fade-in
   useEffect(() => {
+    if (isPanoramaMode) return;
     const v = videoRef.current;
     if (!v) return;
     // Start at zero volume for fade-in
@@ -75,10 +139,11 @@ export function CinematicOverlay({ videoUrl, caption, captionTranslation, autoAd
       }, 40);
       return () => clearInterval(fadeIn);
     }
-  }, [activeVideoUrl, muted]);
+  }, [activeVideoUrl, isPanoramaMode, muted]);
 
   // Fade out audio before video ends
   useEffect(() => {
+    if (isPanoramaMode) return;
     const v = videoRef.current;
     if (!v || muted) return;
     const handleTimeUpdate = () => {
@@ -89,7 +154,7 @@ export function CinematicOverlay({ videoUrl, caption, captionTranslation, autoAd
     };
     v.addEventListener('timeupdate', handleTimeUpdate);
     return () => v.removeEventListener('timeupdate', handleTimeUpdate);
-  }, [activeVideoUrl, muted]);
+  }, [activeVideoUrl, isPanoramaMode, muted]);
 
   // Fade in caption shortly after video starts playing, then start typewriter
   useEffect(() => {
@@ -124,8 +189,17 @@ export function CinematicOverlay({ videoUrl, caption, captionTranslation, autoAd
 
   return (
     <div
+      ref={rootRef}
       className={`cinematic-overlay ${fadingOut ? 'cinematic-fade-out' : ''}`}
       onClick={(e) => {
+        if (suppressTapRef.current) {
+          suppressTapRef.current = false;
+          return;
+        }
+        if (isPanoramaMode) {
+          handleTap();
+          return;
+        }
         const v = videoRef.current;
         if (v && v.muted && !muted) {
           // First tap unmutes if autoplay was forced muted
@@ -136,25 +210,82 @@ export function CinematicOverlay({ videoUrl, caption, captionTranslation, autoAd
       }}
       role={autoAdvance ? undefined : 'button'}
       tabIndex={autoAdvance ? undefined : 0}
+      data-panorama-delta={isPanoramaMode ? panX.toFixed(2) : undefined}
     >
-      <video
-        ref={videoRef}
-        src={activeVideoUrl}
-        playsInline
-        muted={muted}
-        onEnded={handleEnded}
-        onError={() => {
-          if (candidateIndex + 1 < videoCandidates.length) {
-            setCandidateIndex(candidateIndex + 1);
-          } else {
-            triggerEnd();
-          }
-        }}
-        className="cinematic-video"
-        disablePictureInPicture
-        disableRemotePlayback
-        controlsList="nodownload noplaybackrate"
-      />
+      {isPanoramaMode ? (
+        <div
+          className="absolute inset-0 touch-none"
+          onPointerDown={(event) => {
+            if (panoramaTrackWidth <= viewportWidth) return;
+            dragStateRef.current = { startX: event.clientX, originPanX: panX, movedPx: 0 };
+            (event.currentTarget as HTMLDivElement).setPointerCapture(event.pointerId);
+          }}
+          onPointerMove={(event) => {
+            const dragState = dragStateRef.current;
+            if (!dragState) return;
+            const delta = event.clientX - dragState.startX;
+            dragState.movedPx = Math.max(dragState.movedPx, Math.abs(delta));
+            const nextPanX = Math.max(panoramaMinPanX, Math.min(0, dragState.originPanX + delta));
+            setPanX(nextPanX);
+          }}
+          onPointerUp={(event) => {
+            if (dragStateRef.current?.movedPx && dragStateRef.current.movedPx > 6) {
+              suppressTapRef.current = true;
+            }
+            dragStateRef.current = null;
+            (event.currentTarget as HTMLDivElement).releasePointerCapture(event.pointerId);
+          }}
+          onPointerCancel={(event) => {
+            dragStateRef.current = null;
+            (event.currentTarget as HTMLDivElement).releasePointerCapture(event.pointerId);
+          }}
+        >
+          <div
+            className="absolute inset-y-0 left-0 will-change-transform"
+            style={{ width: `${panoramaTrackWidth}px`, transform: `translate3d(${panX}px, 0, 0)` }}
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={activeVideoUrl}
+              alt=""
+              className="h-full w-full object-cover"
+              draggable={false}
+              onLoad={(event) => {
+                const media = event.currentTarget;
+                if (media.naturalWidth && media.naturalHeight) {
+                  setNaturalSize({ width: media.naturalWidth, height: media.naturalHeight });
+                }
+              }}
+              onError={() => {
+                if (candidateIndex + 1 < videoCandidates.length) {
+                  setCandidateIndex(candidateIndex + 1);
+                } else {
+                  triggerEnd();
+                }
+              }}
+            />
+          </div>
+        </div>
+      ) : (
+        <video
+          ref={videoRef}
+          src={activeVideoUrl}
+          playsInline
+          muted={muted}
+          onEnded={handleEnded}
+          onError={() => {
+            if (candidateIndex + 1 < videoCandidates.length) {
+              setCandidateIndex(candidateIndex + 1);
+            } else {
+              triggerEnd();
+            }
+          }}
+          className="cinematic-video"
+          disablePictureInPicture
+          disableRemotePlayback
+          controlsList="nodownload noplaybackrate"
+        />
+      )}
       {caption && (
         <div
           className={`cinematic-subtitle-bar ${captionVisible ? 'cinematic-subtitle-visible' : ''}`}

--- a/apps/client/components/scene/SceneView.tsx
+++ b/apps/client/components/scene/SceneView.tsx
@@ -18,6 +18,11 @@ interface SceneViewProps {
   backgroundTransition?: 'fade' | 'cut';
   ambientDescription?: string;
   cinematic?: { videoUrl: string; caption?: string; captionTranslation?: string; autoAdvance: boolean; muted?: boolean } | null;
+  cinematicMode?: 'cover' | 'panorama';
+  panoramaAuthoredWidth?: number;
+  panoramaAuthoredHeight?: number;
+  panoramaMinOverflowPx?: number;
+  onPanoramaTransformChange?: (deltaX: number) => void;
   onCinematicEnd?: () => void;
   npcName?: string;
   npcColor?: string;
@@ -63,6 +68,11 @@ export function SceneView({
   backgroundTransition,
   ambientDescription = '',
   cinematic = null,
+  cinematicMode = 'cover',
+  panoramaAuthoredWidth,
+  panoramaAuthoredHeight,
+  panoramaMinOverflowPx,
+  onPanoramaTransformChange,
   onCinematicEnd = () => {},
   npcName = '',
   npcColor = 'var(--color-primary)',
@@ -158,6 +168,11 @@ export function SceneView({
           captionTranslation={cinematic.captionTranslation}
           autoAdvance={cinematic.autoAdvance}
           muted={cinematic.muted ?? false}
+          mode={cinematicMode}
+          panoramaAuthoredWidth={panoramaAuthoredWidth}
+          panoramaAuthoredHeight={panoramaAuthoredHeight}
+          panoramaMinOverflowPx={panoramaMinOverflowPx}
+          onPanoramaTransformChange={onPanoramaTransformChange}
           targetLang={targetLang}
           onEnd={handleCinematicEnd}
         />


### PR DESCRIPTION
### Motivation
- Provide a true panorama cinematic mode that produces horizontal overflow and supports real pointer drag movement for the Shanghai onboarding experience.
- Preserve existing `cover` cinematic behavior so production onboarding remains unchanged.
- Expose a safe backstage runtime to validate panorama behavior without touching production onboarding fixtures or contracts.

### Description
- Add a `panorama` mode to `CinematicOverlay` with new props: `mode`, `panoramaAuthoredWidth`, `panoramaAuthoredHeight`, `panoramaMinOverflowPx`, and `onPanoramaTransformChange`, and implement a pointer-driven `translate3d(...)` track with clamped pan bounds and authored/media-dimension fallbacks (`apps/client/components/scene/CinematicOverlay.tsx`).
- Wire additive panorama props through `SceneView` (`cinematicMode`, authored dims, overflow minimum and transform callback) so existing callers keep default `cover` behavior (`apps/client/components/scene/SceneView.tsx`).
- Add a backstage-only runtime page at `/backstage/panorama-runtime` gated by `?demo=TONG-DEMO-ACCESS` that toggles Panorama vs Cover, uses a repo-visible stand-in asset, supplies authored-dimension fallbacks (3072×1080) and displays the live drag delta for validation (`apps/client/app/backstage/panorama-runtime/page.tsx`).
- Keep production onboarding page, Shanghai fixture, and contract files untouched as required.

### Testing
- Built the design system and launched the client dev server and confirmed the backstage route compiled and served on port 3004 (`npm --prefix apps/client run ds:build` then `npx next dev -p 3004`); this succeeded.
- Automated headless browser drag test using Playwright reproduced the expected behavior and returned a non-zero panorama transform delta after drag (example observed: `before=Drag delta: 0.00px`, `after=Drag delta: -206.08px`, `delta_attr=-206.08`) and cover mode returned to `0.00px` — test run succeeded against `http://127.0.0.1:3004/backstage/panorama-runtime?demo=TONG-DEMO-ACCESS`.
- Typecheck passed (`(cd apps/client && npx tsc --noEmit)`).
- How to reproduce locally: run the build/dev commands above, open `http://localhost:3004/backstage/panorama-runtime?demo=TONG-DEMO-ACCESS`, switch to Panorama mode and drag horizontally to observe a non-zero drag delta, then switch to Cover mode to confirm legacy behavior and delta reset.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7d2943d90832a94627146f7c02041)