### PR TITLE
[Issue #258][partial] Add draggable panorama runtime fallback

### DIFF
--- a/apps/client/app/backstage/panorama-runtime/page.tsx
+++ b/apps/client/app/backstage/panorama-runtime/page.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
+import { useMemo, useState } from 'react';
+import { SceneView } from '@/components/scene/SceneView';
+
+const DEMO_ACCESS_TOKEN = 'TONG-DEMO-ACCESS';
+
+export default function PanoramaRuntimePage() {
+  const searchParams = useSearchParams();
+  const hasAccess = searchParams.get('demo') === DEMO_ACCESS_TOKEN;
+  const [panoramaDeltaX, setPanoramaDeltaX] = useState(0);
+  const [mode, setMode] = useState<'cover' | 'panorama'>('panorama');
+
+  const cinematic = useMemo(() => ({
+    // Repo-visible stand-in media keeps this route independent from production onboarding wiring.
+    videoUrl: '/assets/webtoon/shanghai/h1/0.png',
+    caption: 'Keep your head down. Listen before they notice you.',
+    captionTranslation: 'Panorama runtime sandbox — drag sideways to inspect framing.',
+    autoAdvance: true,
+    muted: true,
+  }), []);
+
+  if (!hasAccess) {
+    return (
+      <main style={{ minHeight: '100dvh', display: 'grid', placeItems: 'center', background: '#05050a', color: '#f5f5f5', padding: 24 }}>
+        <div style={{ maxWidth: 620 }}>
+          <h1 style={{ marginTop: 0 }}>Panorama runtime sandbox</h1>
+          <p>Use <code>?demo={DEMO_ACCESS_TOKEN}</code> to open this backstage-only route.</p>
+          <p>This page is intentionally separate from production onboarding.</p>
+          <Link href="/" style={{ color: '#f0c040' }}>Back home</Link>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main style={{ minHeight: '100dvh', background: '#000' }}>
+      <SceneView
+        backgroundUrl=""
+        ambientDescription="Backstage panorama runtime test"
+        cinematic={cinematic}
+        cinematicMediaFit={mode}
+        cinematicAuthoredDimensions={{ width: 4096, height: 1536 }}
+        onCinematicPanoramaDeltaChange={setPanoramaDeltaX}
+      />
+
+      <section
+        style={{
+          position: 'fixed',
+          top: 12,
+          left: 12,
+          right: 12,
+          zIndex: 300,
+          display: 'flex',
+          gap: 8,
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          flexWrap: 'wrap',
+          pointerEvents: 'none',
+        }}
+      >
+        <div
+          style={{
+            pointerEvents: 'auto',
+            background: 'rgba(5,5,10,0.75)',
+            border: '1px solid rgba(255,255,255,0.15)',
+            borderRadius: 14,
+            padding: '8px 12px',
+            color: '#f5f5f5',
+            fontSize: 13,
+            fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+          }}
+        >
+          <div>mode: {mode}</div>
+          <div data-testid="panorama-transform-delta">transformX: {panoramaDeltaX.toFixed(2)}px</div>
+        </div>
+
+        <div style={{ display: 'flex', gap: 8, pointerEvents: 'auto' }}>
+          <button
+            type="button"
+            onClick={() => setMode('panorama')}
+            style={{
+              borderRadius: 999,
+              border: '1px solid rgba(255,255,255,0.2)',
+              background: mode === 'panorama' ? '#f0c040' : 'rgba(5,5,10,0.8)',
+              color: mode === 'panorama' ? '#111' : '#f5f5f5',
+              padding: '8px 12px',
+              fontWeight: 700,
+            }}
+          >
+            Panorama mode
+          </button>
+          <button
+            type="button"
+            onClick={() => setMode('cover')}
+            style={{
+              borderRadius: 999,
+              border: '1px solid rgba(255,255,255,0.2)',
+              background: mode === 'cover' ? '#f0c040' : 'rgba(5,5,10,0.8)',
+              color: mode === 'cover' ? '#111' : '#f5f5f5',
+              padding: '8px 12px',
+              fontWeight: 700,
+            }}
+          >
+            Cover mode
+          </button>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/client/components/scene/CinematicOverlay.tsx
+++ b/apps/client/components/scene/CinematicOverlay.tsx
@@ -15,18 +15,56 @@ interface CinematicOverlayProps {
   captionTranslation?: string;
   autoAdvance: boolean;
   muted?: boolean;
+  mediaFit?: 'cover' | 'panorama';
+  authoredDimensions?: { width: number; height: number };
+  onPanoramaDeltaChange?: (deltaX: number) => void;
   targetLang?: TargetLang;
   onEnd: () => void;
 }
 
-export function CinematicOverlay({ videoUrl, caption, captionTranslation, autoAdvance, muted = false, targetLang = 'ko', onEnd }: CinematicOverlayProps) {
+export function CinematicOverlay({
+  videoUrl,
+  caption,
+  captionTranslation,
+  autoAdvance,
+  muted = false,
+  mediaFit = 'cover',
+  authoredDimensions,
+  onPanoramaDeltaChange,
+  targetLang = 'ko',
+  onEnd,
+}: CinematicOverlayProps) {
   const lang = useUILang();
   const videoRef = useRef<HTMLVideoElement>(null);
+  const viewportRef = useRef<HTMLDivElement>(null);
   const [fadingOut, setFadingOut] = useState(false);
   const [captionVisible, setCaptionVisible] = useState(false);
   const [candidateIndex, setCandidateIndex] = useState(0);
+  const [intrinsicAspectRatio, setIntrinsicAspectRatio] = useState<number | null>(null);
+  const [viewportSize, setViewportSize] = useState({ width: 0, height: 0 });
+  const [dragOffsetX, setDragOffsetX] = useState(0);
+  const draggingRef = useRef(false);
+  const draggedDistanceRef = useRef(0);
+  const dragStartXRef = useRef(0);
+  const dragStartOffsetRef = useRef(0);
+  const hasInitializedPanRef = useRef(false);
   const videoCandidates = useMemo(() => fallbackRuntimeAssetCandidates(videoUrl), [videoUrl]);
   const activeVideoUrl = videoCandidates[candidateIndex] ?? '';
+  const useImageElement = /\.(png|jpe?g|webp|gif|avif)(\?.*)?$/i.test(activeVideoUrl);
+  const panoramaEnabled = mediaFit === 'panorama';
+  const mediaAspectRatio = useMemo(() => {
+    if (authoredDimensions && authoredDimensions.width > 0 && authoredDimensions.height > 0) {
+      return authoredDimensions.width / authoredDimensions.height;
+    }
+    if (intrinsicAspectRatio && intrinsicAspectRatio > 0) return intrinsicAspectRatio;
+    // Wide fallback gives deterministic horizontal overflow even when temporary media is 16:9.
+    return 21 / 9;
+  }, [authoredDimensions, intrinsicAspectRatio]);
+  const panoramaRenderWidth = useMemo(() => {
+    if (!panoramaEnabled || viewportSize.width <= 0 || viewportSize.height <= 0) return viewportSize.width;
+    return Math.max(viewportSize.width, viewportSize.height * mediaAspectRatio);
+  }, [mediaAspectRatio, panoramaEnabled, viewportSize.height, viewportSize.width]);
+  const panoramaOverflow = Math.max(0, panoramaRenderWidth - viewportSize.width);
 
   // Typewriter state for caption
   const [captionChars, setCaptionChars] = useState(0);
@@ -44,15 +82,53 @@ export function CinematicOverlay({ videoUrl, caption, captionTranslation, autoAd
   }, [autoAdvance, triggerEnd]);
 
   const handleTap = useCallback(() => {
+    if (panoramaEnabled) return;
     if (!autoAdvance) triggerEnd();
-  }, [autoAdvance, triggerEnd]);
+  }, [autoAdvance, panoramaEnabled, triggerEnd]);
 
   useEffect(() => {
     setCandidateIndex(0);
   }, [videoUrl]);
 
+  useEffect(() => {
+    setDragOffsetX(0);
+    hasInitializedPanRef.current = false;
+  }, [activeVideoUrl, panoramaEnabled]);
+
+  useEffect(() => {
+    const viewport = viewportRef.current;
+    if (!viewport || !panoramaEnabled) return;
+    const updateSize = () => {
+      setViewportSize({ width: viewport.clientWidth, height: viewport.clientHeight });
+    };
+    updateSize();
+    const observer = new ResizeObserver(updateSize);
+    observer.observe(viewport);
+    return () => observer.disconnect();
+  }, [panoramaEnabled]);
+
+  useEffect(() => {
+    if (!panoramaEnabled) {
+      onPanoramaDeltaChange?.(0);
+      return;
+    }
+    setDragOffsetX((current) => {
+      if (panoramaOverflow <= 0) return 0;
+      if (!hasInitializedPanRef.current) {
+        hasInitializedPanRef.current = true;
+        return -panoramaOverflow / 2;
+      }
+      return Math.min(0, Math.max(-panoramaOverflow, current));
+    });
+  }, [onPanoramaDeltaChange, panoramaEnabled, panoramaOverflow]);
+
+  useEffect(() => {
+    onPanoramaDeltaChange?.(dragOffsetX);
+  }, [dragOffsetX, onPanoramaDeltaChange]);
+
   // Autoplay with unmute fallback + audio fade-in
   useEffect(() => {
+    if (useImageElement) return;
     const v = videoRef.current;
     if (!v) return;
     // Start at zero volume for fade-in
@@ -75,10 +151,11 @@ export function CinematicOverlay({ videoUrl, caption, captionTranslation, autoAd
       }, 40);
       return () => clearInterval(fadeIn);
     }
-  }, [activeVideoUrl, muted]);
+  }, [activeVideoUrl, muted, useImageElement]);
 
   // Fade out audio before video ends
   useEffect(() => {
+    if (useImageElement) return;
     const v = videoRef.current;
     if (!v || muted) return;
     const handleTimeUpdate = () => {
@@ -89,7 +166,7 @@ export function CinematicOverlay({ videoUrl, caption, captionTranslation, autoAd
     };
     v.addEventListener('timeupdate', handleTimeUpdate);
     return () => v.removeEventListener('timeupdate', handleTimeUpdate);
-  }, [activeVideoUrl, muted]);
+  }, [activeVideoUrl, muted, useImageElement]);
 
   // Fade in caption shortly after video starts playing, then start typewriter
   useEffect(() => {
@@ -124,8 +201,14 @@ export function CinematicOverlay({ videoUrl, caption, captionTranslation, autoAd
 
   return (
     <div
+      ref={viewportRef}
       className={`cinematic-overlay ${fadingOut ? 'cinematic-fade-out' : ''}`}
+      style={panoramaEnabled ? { overflow: 'hidden' } : undefined}
       onClick={(e) => {
+        if (panoramaEnabled && draggedDistanceRef.current > 4) {
+          draggedDistanceRef.current = 0;
+          return;
+        }
         const v = videoRef.current;
         if (v && v.muted && !muted) {
           // First tap unmutes if autoplay was forced muted
@@ -137,24 +220,120 @@ export function CinematicOverlay({ videoUrl, caption, captionTranslation, autoAd
       role={autoAdvance ? undefined : 'button'}
       tabIndex={autoAdvance ? undefined : 0}
     >
-      <video
-        ref={videoRef}
-        src={activeVideoUrl}
-        playsInline
-        muted={muted}
-        onEnded={handleEnded}
-        onError={() => {
-          if (candidateIndex + 1 < videoCandidates.length) {
-            setCandidateIndex(candidateIndex + 1);
-          } else {
-            triggerEnd();
-          }
-        }}
-        className="cinematic-video"
-        disablePictureInPicture
-        disableRemotePlayback
-        controlsList="nodownload noplaybackrate"
-      />
+      {useImageElement ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={activeVideoUrl}
+          alt=""
+          onLoad={(event) => {
+            const target = event.currentTarget;
+            if (target.naturalWidth > 0 && target.naturalHeight > 0) {
+              setIntrinsicAspectRatio(target.naturalWidth / target.naturalHeight);
+            }
+          }}
+          onError={() => {
+            if (candidateIndex + 1 < videoCandidates.length) {
+              setCandidateIndex(candidateIndex + 1);
+            } else {
+              triggerEnd();
+            }
+          }}
+          onPointerDown={(event) => {
+            if (!panoramaEnabled || panoramaOverflow <= 0) return;
+            draggingRef.current = true;
+            draggedDistanceRef.current = 0;
+            dragStartXRef.current = event.clientX;
+            dragStartOffsetRef.current = dragOffsetX;
+            event.currentTarget.setPointerCapture(event.pointerId);
+          }}
+          onPointerMove={(event) => {
+            if (!panoramaEnabled || !draggingRef.current) return;
+            const delta = event.clientX - dragStartXRef.current;
+            draggedDistanceRef.current = Math.max(draggedDistanceRef.current, Math.abs(delta));
+            const nextOffset = Math.min(0, Math.max(-panoramaOverflow, dragStartOffsetRef.current + delta));
+            setDragOffsetX(nextOffset);
+          }}
+          onPointerUp={(event) => {
+            if (!panoramaEnabled) return;
+            draggingRef.current = false;
+            event.currentTarget.releasePointerCapture(event.pointerId);
+          }}
+          onPointerCancel={(event) => {
+            if (!panoramaEnabled) return;
+            draggingRef.current = false;
+            event.currentTarget.releasePointerCapture(event.pointerId);
+          }}
+          className="cinematic-video"
+          style={panoramaEnabled ? {
+            width: `${panoramaRenderWidth}px`,
+            height: '100%',
+            maxWidth: 'none',
+            objectFit: 'fill',
+            transform: `translate3d(${dragOffsetX}px, 0, 0)`,
+            touchAction: 'none',
+            cursor: panoramaOverflow > 0 ? (draggingRef.current ? 'grabbing' : 'grab') : 'default',
+          } : undefined}
+        />
+      ) : (
+        <video
+          ref={videoRef}
+          src={activeVideoUrl}
+          playsInline
+          muted={muted}
+          onLoadedMetadata={(event) => {
+            const { videoWidth, videoHeight } = event.currentTarget;
+            if (videoWidth > 0 && videoHeight > 0) {
+              setIntrinsicAspectRatio(videoWidth / videoHeight);
+            }
+          }}
+          onEnded={handleEnded}
+          onError={() => {
+            if (candidateIndex + 1 < videoCandidates.length) {
+              setCandidateIndex(candidateIndex + 1);
+            } else {
+              triggerEnd();
+            }
+          }}
+          onPointerDown={(event) => {
+            if (!panoramaEnabled || panoramaOverflow <= 0) return;
+            draggingRef.current = true;
+            draggedDistanceRef.current = 0;
+            dragStartXRef.current = event.clientX;
+            dragStartOffsetRef.current = dragOffsetX;
+            event.currentTarget.setPointerCapture(event.pointerId);
+          }}
+          onPointerMove={(event) => {
+            if (!panoramaEnabled || !draggingRef.current) return;
+            const delta = event.clientX - dragStartXRef.current;
+            draggedDistanceRef.current = Math.max(draggedDistanceRef.current, Math.abs(delta));
+            const nextOffset = Math.min(0, Math.max(-panoramaOverflow, dragStartOffsetRef.current + delta));
+            setDragOffsetX(nextOffset);
+          }}
+          onPointerUp={(event) => {
+            if (!panoramaEnabled) return;
+            draggingRef.current = false;
+            event.currentTarget.releasePointerCapture(event.pointerId);
+          }}
+          onPointerCancel={(event) => {
+            if (!panoramaEnabled) return;
+            draggingRef.current = false;
+            event.currentTarget.releasePointerCapture(event.pointerId);
+          }}
+          className="cinematic-video"
+          style={panoramaEnabled ? {
+            width: `${panoramaRenderWidth}px`,
+            height: '100%',
+            maxWidth: 'none',
+            objectFit: 'fill',
+            transform: `translate3d(${dragOffsetX}px, 0, 0)`,
+            touchAction: 'none',
+            cursor: panoramaOverflow > 0 ? (draggingRef.current ? 'grabbing' : 'grab') : 'default',
+          } : undefined}
+          disablePictureInPicture
+          disableRemotePlayback
+          controlsList="nodownload noplaybackrate"
+        />
+      )}
       {caption && (
         <div
           className={`cinematic-subtitle-bar ${captionVisible ? 'cinematic-subtitle-visible' : ''}`}

--- a/apps/client/components/scene/SceneView.tsx
+++ b/apps/client/components/scene/SceneView.tsx
@@ -18,6 +18,9 @@ interface SceneViewProps {
   backgroundTransition?: 'fade' | 'cut';
   ambientDescription?: string;
   cinematic?: { videoUrl: string; caption?: string; captionTranslation?: string; autoAdvance: boolean; muted?: boolean } | null;
+  cinematicMediaFit?: 'cover' | 'panorama';
+  cinematicAuthoredDimensions?: { width: number; height: number };
+  onCinematicPanoramaDeltaChange?: (deltaX: number) => void;
   onCinematicEnd?: () => void;
   npcName?: string;
   npcColor?: string;
@@ -64,6 +67,9 @@ export function SceneView({
   ambientDescription = '',
   cinematic = null,
   onCinematicEnd = () => {},
+  cinematicMediaFit = 'cover',
+  cinematicAuthoredDimensions,
+  onCinematicPanoramaDeltaChange,
   npcName = '',
   npcColor = 'var(--color-primary)',
   npcSpriteUrl = '',
@@ -158,6 +164,9 @@ export function SceneView({
           captionTranslation={cinematic.captionTranslation}
           autoAdvance={cinematic.autoAdvance}
           muted={cinematic.muted ?? false}
+          mediaFit={cinematicMediaFit}
+          authoredDimensions={cinematicAuthoredDimensions}
+          onPanoramaDeltaChange={onCinematicPanoramaDeltaChange}
           targetLang={targetLang}
           onEnd={handleCinematicEnd}
         />


### PR DESCRIPTION
### Motivation
- Provide a backstage runtime to validate true horizontal panorama overflow and pointer-drag framing without changing production onboarding wiring. 
- Give an explicit, repo-visible fallback asset and authored-dimensions path so panorama mode can be tested even before final wide media is checked in. 

### Description
- Add a backstage-only runtime page at `/backstage/panorama-runtime` gated by `?demo=TONG-DEMO-ACCESS` that exposes a panorama vs cover toggle and a live `transformX` readout. 
- Extend `CinematicOverlay` to support a `mediaFit='panorama'` mode that computes an authored/fallback aspect ratio, produces deterministic horizontal overflow, and implements pointer-based drag with a callback `onPanoramaDeltaChange`; it also accepts image fallbacks for repo-visible stand-ins. 
- Thread optional panorama props through `SceneView` via `cinematicMediaFit`, `cinematicAuthoredDimensions`, and `onCinematicPanoramaDeltaChange` while preserving default cover behavior and existing callers. 

### Testing
- Ran the repo queue planner via `python .agents/skills/_functional-qa/scripts/issue_router.py plan 258` which completed successfully. 
- Started the client (`npm run ds:build && npx next dev -p 3004`) and validated the backstage route rendering and behavior with a headless browser drag script that observed `transformX` change from `0.00px` to `-11.43px` and that switching to Cover mode resets `transformX` to `0.00px`. 
- Performed a TypeScript check with `npx tsc --noEmit` in `apps/client` which succeeded. 
- How to test locally: run the client on a non-default port, open `http://localhost:3004/backstage/panorama-runtime?demo=TONG-DEMO-ACCESS`, drag horizontally in Panorama mode to confirm a non-zero `transformX`, toggle to Cover mode to confirm `transformX` returns to zero, and run `npx tsc --noEmit`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7d2943d90832a94627146f7c02041)