### PR TITLE
Add hangout fixture loader & Shanghai H1 fixture routing

### DIFF
--- a/apps/client/app/api/ai/hangout/route.ts
+++ b/apps/client/app/api/ai/hangout/route.ts
@@ -12,7 +12,7 @@ import {
 import { CHARACTER_MAP, HAEUN, TUTORIAL_VIDEO_CONFIG } from '@/lib/content/characters';
 import { POJANGMACHA } from '@/lib/content/pojangmacha';
 import { runtimeAssetUrl } from '@/lib/runtime-assets';
-import { getShanghaiFixture } from '@/lib/content/shanghai/fixtures';
+import { getSceneFixture, resolveFixtureId } from '@/lib/hangout/fixture-loader';
 import { runFixture, type HangoutEvent } from '@/lib/hangout/fixture-runtime';
 import { validateLine } from '@/lib/ai/validators/voice-rules';
 import type { Character, RelationshipStage, Relationship } from '@/lib/types/relationship';
@@ -233,16 +233,17 @@ function readHangoutConfig(req: Request, body?: Record<string, unknown>) {
   const url = new URL(req.url);
   const modeParam = url.searchParams.get('mode') ?? (typeof body?.mode === 'string' ? body.mode : null);
   const mode: HangoutMode = modeParam === 'fixture' ? 'fixture' : 'dynamic';
-  const directFixtureId = url.searchParams.get('fixtureId') ?? (typeof body?.fixtureId === 'string' ? body.fixtureId : null);
-  const city = url.searchParams.get('city') ?? (typeof body?.city === 'string' ? body.city : null);
-  const scene = url.searchParams.get('scene') ?? (typeof body?.scene === 'string' ? body.scene : null);
-  const fixtureId = directFixtureId || (city === 'shanghai' && scene === 'h1' ? 'shanghai/h1-negotiation' : null);
+  const fixtureId = resolveFixtureId({
+    fixtureId: url.searchParams.get('fixtureId') ?? (typeof body?.fixtureId === 'string' ? body.fixtureId : null),
+    city: url.searchParams.get('city') ?? (typeof body?.city === 'string' ? body.city : null),
+    scene: url.searchParams.get('scene') ?? (typeof body?.scene === 'string' ? body.scene : null),
+  });
 
   return { mode, fixtureId };
 }
 
 function buildFixtureResponse(fixtureId: string) {
-  const fixture = getShanghaiFixture(fixtureId);
+  const fixture = getSceneFixture(fixtureId);
   if (!fixture) {
     return new Response(`Unknown fixtureId: ${fixtureId}`, { status: 404 });
   }

--- a/apps/client/lib/hangout/fixture-loader.ts
+++ b/apps/client/lib/hangout/fixture-loader.ts
@@ -1,0 +1,38 @@
+import type { SceneFixture } from './fixture-types';
+import { getShanghaiFixture } from '@/lib/content/shanghai/fixtures';
+
+const FIXTURE_SCENE_ALIASES: Record<string, string> = {
+  'shanghai:h1': 'shanghai/h1-negotiation',
+};
+
+export function resolveFixtureId(params: {
+  fixtureId?: string | null;
+  city?: string | null;
+  scene?: string | null;
+}): string | null {
+  const directFixtureId = normalizeNullableString(params.fixtureId);
+  if (directFixtureId) {
+    return directFixtureId;
+  }
+
+  const city = normalizeNullableString(params.city);
+  const scene = normalizeNullableString(params.scene);
+  if (!city || !scene) {
+    return null;
+  }
+
+  return FIXTURE_SCENE_ALIASES[`${city}:${scene}`] ?? null;
+}
+
+export function getSceneFixture(fixtureId: string): SceneFixture | null {
+  return getShanghaiFixture(fixtureId);
+}
+
+function normalizeNullableString(value: string | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}


### PR DESCRIPTION
### Motivation
- Provide a generic, centralized way to resolve and load hangout scene fixtures so the API can support deterministic, inspectable fixture playback for onboarding and QA.
- Support the Shanghai onboarding flow alias `city=shanghai&scene=h1` by resolving it to the existing `shanghai/h1-negotiation` fixture.
- Keep the existing dynamic AI-driven hangout behavior untouched while adding an additive fixture-mode path.

### Description
- Added a new loader module `apps/client/lib/hangout/fixture-loader.ts` that normalizes direct `fixtureId` values and maps `city:scene` aliases to fixture IDs (includes alias `shanghai:h1` → `shanghai/h1-negotiation`).
- Updated the hangout route `apps/client/app/api/ai/hangout/route.ts` to use `resolveFixtureId` and `getSceneFixture` for `mode=fixture` handling, preserving current `dynamic` behavior and existing validation (400 when missing fixtureId, 404 when unknown fixtureId).
- Kept all changes additive and delegated fixture retrieval to the new loader so future cities/fixtures can be added without changing the route.

### Testing
- `tsc -p apps/client/tsconfig.json --noEmit` completed successfully with no type errors.
- Running the fixture runtime unit file directly (`node --test` / `tsx --test`) failed in this ad-hoc environment due to module-alias/ESM path resolution for `@/` imports and test runner resolution, not due to fixture logic.
- How to test (manual / integration):
  - `GET /api/ai/hangout?mode=fixture&fixtureId=shanghai/h1-negotiation` should stream SSE tool-call events for the fixture.
  - `GET /api/ai/hangout?mode=fixture&city=shanghai&scene=h1` should resolve to the same fixture and stream the same SSE events.
  - `GET /api/ai/hangout?mode=fixture` should return HTTP 400.
  - `GET /api/ai/hangout?mode=fixture&fixtureId=does/not-exist` should return HTTP 404.
  - `POST /api/ai/hangout` (no `mode=fixture`) should retain the existing dynamic AI behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e88da3ac38832a9c5eeb9ac1cc944c)