### PR TITLE
Add fixture-loader and wire Shanghai H1 fixture into hangout runtime

### DIFF
--- a/apps/client/app/api/ai/hangout/route.ts
+++ b/apps/client/app/api/ai/hangout/route.ts
@@ -12,7 +12,7 @@ import {
 import { CHARACTER_MAP, HAEUN, TUTORIAL_VIDEO_CONFIG } from '@/lib/content/characters';
 import { POJANGMACHA } from '@/lib/content/pojangmacha';
 import { runtimeAssetUrl } from '@/lib/runtime-assets';
-import { getShanghaiFixture } from '@/lib/content/shanghai/fixtures';
+import { loadSceneFixture, resolveFixtureId } from '@/lib/hangout/fixture-loader';
 import { runFixture, type HangoutEvent } from '@/lib/hangout/fixture-runtime';
 import { validateLine } from '@/lib/ai/validators/voice-rules';
 import type { Character, RelationshipStage, Relationship } from '@/lib/types/relationship';
@@ -236,13 +236,17 @@ function readHangoutConfig(req: Request, body?: Record<string, unknown>) {
   const directFixtureId = url.searchParams.get('fixtureId') ?? (typeof body?.fixtureId === 'string' ? body.fixtureId : null);
   const city = url.searchParams.get('city') ?? (typeof body?.city === 'string' ? body.city : null);
   const scene = url.searchParams.get('scene') ?? (typeof body?.scene === 'string' ? body.scene : null);
-  const fixtureId = directFixtureId || (city === 'shanghai' && scene === 'h1' ? 'shanghai/h1-negotiation' : null);
+  const fixtureId = resolveFixtureId({
+    fixtureId: directFixtureId,
+    city,
+    scene,
+  });
 
   return { mode, fixtureId };
 }
 
 function buildFixtureResponse(fixtureId: string) {
-  const fixture = getShanghaiFixture(fixtureId);
+  const fixture = loadSceneFixture(fixtureId);
   if (!fixture) {
     return new Response(`Unknown fixtureId: ${fixtureId}`, { status: 404 });
   }

--- a/apps/client/lib/hangout/fixture-loader.ts
+++ b/apps/client/lib/hangout/fixture-loader.ts
@@ -1,0 +1,26 @@
+import { getShanghaiFixture } from '@/lib/content/shanghai/fixtures';
+import type { SceneFixture } from '@/lib/hangout/fixture-types';
+
+export function resolveFixtureId(input: {
+  fixtureId?: string | null;
+  city?: string | null;
+  scene?: string | null;
+}): string | null {
+  if (input.fixtureId) {
+    return input.fixtureId;
+  }
+
+  if (input.city === 'shanghai' && input.scene === 'h1') {
+    return 'shanghai/h1-negotiation';
+  }
+
+  return null;
+}
+
+export function loadSceneFixture(fixtureId: string): SceneFixture | null {
+  if (fixtureId.startsWith('shanghai/')) {
+    return getShanghaiFixture(fixtureId);
+  }
+
+  return null;
+}


### PR DESCRIPTION
### Motivation
- Make the hangout API generic for scene fixtures and support the Shanghai H1 onboarding alias without hardcoding logic in the route. 
- Keep changes additive so other city fixture packs can be added later through a loader/registry.

### Description
- Added a new loader module `apps/client/lib/hangout/fixture-loader.ts` that provides `resolveFixtureId(...)` and `loadSceneFixture(...)`, mapping `city=shanghai&scene=h1` to `shanghai/h1-negotiation` and loading namespace-scoped fixtures. 
- Updated `apps/client/app/api/ai/hangout/route.ts` to use `resolveFixtureId` for fixture resolution and `loadSceneFixture` when serving `mode=fixture`, preserving existing 400/404 behavior and leaving `mode=dynamic` unchanged. 
- No destructive changes; existing Shanghai fixture payloads and the fixture runtime/types/tests already present remain intact and are used by the new loader.

### Testing
- Ran TypeScript compile: `cd apps/client && npx tsc --noEmit`, which succeeded. 
- Executed unit test runner attempts for `apps/client/lib/hangout/fixture-runtime.test.ts` with `node --test` and `npx tsx --test`, both of which failed in this ad-hoc environment due to local path alias resolution (`@/...`) and ESM import resolution rather than failures in the fixture logic itself. 
- The repository contains focused fixture unit tests that cover seed determinism, beat ordering, tong-beat timing, exercise-hooks, webtoon emission, and credit-gate pause/resume, and these tests are the ones to run in CI/local dev with project path aliasing enabled.

How to test
- Start the dev server using your normal workflow and verify streaming fixtures by calling `GET /api/ai/hangout?mode=fixture&fixtureId=shanghai/h1-negotiation` which should return an SSE stream of tool events. 
- Verify alias resolution with `GET /api/ai/hangout?mode=fixture&city=shanghai&scene=h1` and validation cases: `GET /api/ai/hangout?mode=fixture` → `400`, and `GET /api/ai/hangout?mode=fixture&fixtureId=unknown/fixture` → `404`. 
- Run the fixture runtime tests in a local environment that supports the repo path aliases (for example via your normal `npm`/`dev` test flow or CI) to validate seed stability, beat ordering, tong-after-beat ordering, exercise-hook ordering, webtoon emission, and credit-gate pause/resume.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e88da3ac38832a9c5eeb9ac1cc944c)