### PR TITLE
Shanghai H1: Panoramic guided onboarding viewport

### DIFF
--- a/apps/client/app/game/page.tsx
+++ b/apps/client/app/game/page.tsx
@@ -35,6 +35,7 @@ import { getRelationshipStage } from '@/lib/types/relationship';
 import { CityMap, CITY_ORDER } from '@/components/city-map/CityMap';
 import { KoreanText } from '@/components/shared/KoreanText';
 import { LearnPanel } from '@/components/learn/LearnPanel';
+import { ShanghaiPreludeViewport } from '@/components/scene/ShanghaiPreludeViewport';
 import { sessionLogger } from '@/lib/debug/session-logger';
 import { UILangProvider } from '@/lib/i18n/UILangContext';
 import { t } from '@/lib/i18n/ui-strings';
@@ -476,6 +477,9 @@ export default function GamePage() {
   const [availableScenarioSeedIds, setAvailableScenarioSeedIds] = useState<string[]>([]);
   const [dynamicBackdrop, setDynamicBackdrop] = useState<{ url: string; transition: 'fade' | 'cut'; ambientDescription?: string } | null>(null);
   const [cinematic, setCinematic] = useState<{ videoUrl: string; caption?: string; captionTranslation?: string; autoAdvance: boolean; muted?: boolean } | null>(null);
+  const [shanghaiPanUnlocked, setShanghaiPanUnlocked] = useState(false);
+  const [shanghaiPairRevealed, setShanghaiPairRevealed] = useState(false);
+  const [shanghaiPairTapped, setShanghaiPairTapped] = useState(false);
 
   const traceQA = useCallback((event: string, data: Record<string, unknown> = {}) => {
     if (!qaTrace) return;
@@ -900,6 +904,22 @@ export default function GamePage() {
     && chatLoading
     && (latestNpcSpeakInvocation.state === 'partial-call' || latestNpcSpeakInvocation.state === 'call')
   );
+  const isShanghaiH1OnboardingRoute =
+    phase === 'hangout'
+    && searchParams.get('city') === 'shanghai'
+    && searchParams.get('scene') === 'h1';
+  const shouldBlockContinueForShanghaiTap =
+    isShanghaiH1OnboardingRoute
+    && shanghaiPanUnlocked
+    && shanghaiPairRevealed
+    && !shanghaiPairTapped;
+
+  useEffect(() => {
+    if (isShanghaiH1OnboardingRoute) return;
+    setShanghaiPanUnlocked(false);
+    setShanghaiPairRevealed(false);
+    setShanghaiPairTapped(false);
+  }, [isShanghaiH1OnboardingRoute]);
 
   /* Auto-start scene when skipping to hangout */
   useEffect(() => {
@@ -1232,6 +1252,9 @@ export default function GamePage() {
           setIntroAct(2);
           console.log('[VN] Act 1 → Act 2 transition triggered by npc_speak');
         }
+        if (isShanghaiH1OnboardingRoute && !shanghaiPanUnlocked) {
+          setShanghaiPanUnlocked(true);
+        }
         if (isIntroHangout && !npcRevealed) setNpcRevealed(true);
         traceQA('tool_queue_blocking_message', { toolName: item.toolName, toolCallId: item.toolCallId });
         setCurrentMessage({
@@ -1533,7 +1556,7 @@ export default function GamePage() {
     setToolQueue((prev) => prev.slice(1));
     processingRef.current = false;
     traceQA('tool_queue_auto_advance', { toolName: item.toolName, remainingQueueLength: Math.max(toolQueue.length - 1, 0) });
-  }, [toolQueue, activeNpc, isIntroHangout, introAct]);
+  }, [toolQueue, activeNpc, isIntroHangout, introAct, isShanghaiH1OnboardingRoute, shanghaiPanUnlocked]);
 
   /* ── Hangout handlers ───────────────────────────────────── */
 
@@ -1579,6 +1602,13 @@ export default function GamePage() {
       traceQA('handle_continue_noop_scene_summary');
       return;
     }
+    if (shouldBlockContinueForShanghaiTap) {
+      setTongTip({
+        message: 'Tap Shoucheng and Dingman before we move in closer.',
+      });
+      traceQA('handle_continue_blocked_shanghai_tap_gate');
+      return;
+    }
     if (chatLoading) {
       traceQA('handle_continue_noop_chat_loading', { queueLength: toolQueue.length });
       return;
@@ -1606,7 +1636,7 @@ export default function GamePage() {
         hasChoices: !!choices,
       });
     }
-  }, [sceneSummary, chatLoading, tongTip, currentExercise, currentWebtoon, currentCreditGate, choices, toolQueue, append, buildScenePrompt, traceQA, fixtureModeActive]);
+  }, [sceneSummary, chatLoading, tongTip, currentExercise, currentWebtoon, currentCreditGate, choices, toolQueue, append, buildScenePrompt, traceQA, fixtureModeActive, shouldBlockContinueForShanghaiTap]);
 
   // Store exercise result so handleContinue can advance after user taps
   const exerciseResultRef = useRef<{ exerciseId: string; correct: boolean } | null>(null);
@@ -2501,6 +2531,20 @@ export default function GamePage() {
       <div className="game-frame">
         <SceneView
           backgroundUrl={resolvedDynamicBackdropUrl || SEOUL_FOOD_STREET_BACKDROP_URL}
+          backgroundLayer={isShanghaiH1OnboardingRoute ? (
+            <ShanghaiPreludeViewport
+              imageUrl={resolvedDynamicBackdropUrl || SEOUL_FOOD_STREET_BACKDROP_URL}
+              panUnlocked={shanghaiPanUnlocked}
+              tappedPair={shanghaiPairTapped}
+              onPairReveal={setShanghaiPairRevealed}
+              onPairTap={() => {
+                if (shanghaiPairTapped) return;
+                setShanghaiPairTapped(true);
+                setTongTip({ message: 'There they are. Keep your voice down and listen.' });
+                traceQA('shanghai_pair_tapped');
+              }}
+            />
+          ) : undefined}
           backgroundTransition={dynamicBackdrop?.transition}
           ambientDescription={dynamicBackdrop?.ambientDescription ?? 'A warm pojangmacha (street food tent) on a Seoul side street'}
           cinematic={cinematic}

--- a/apps/client/app/globals.css
+++ b/apps/client/app/globals.css
@@ -10816,3 +10816,87 @@ body:has(.playtest-pill-expanded) {
   color: var(--muted, #888);
   background: rgba(255,255,255,0.03);
 }
+
+.shanghai-prelude {
+  pointer-events: none;
+}
+
+.shanghai-prelude-viewport {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: auto;
+  touch-action: none;
+  background: #0f1118;
+}
+
+.shanghai-prelude-image {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 190%;
+  height: 100%;
+  object-fit: cover;
+  object-position: left center;
+  user-select: none;
+  -webkit-user-drag: none;
+  transition: transform 220ms ease-out;
+}
+
+.shanghai-prelude-viewport.is-guided .shanghai-prelude-image {
+  transition-duration: 420ms;
+}
+
+.shanghai-prelude-guidance {
+  position: absolute;
+  top: 16px;
+  left: 12px;
+  right: 12px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, rgba(13, 18, 30, 0.9), rgba(25, 32, 48, 0.72));
+  color: #f4f7ff;
+  font-size: var(--game-text-sm);
+  line-height: 1.35;
+  letter-spacing: 0.01em;
+  pointer-events: none;
+}
+
+.shanghai-pair-hotspot {
+  position: absolute;
+  left: calc(32% * 1.9);
+  bottom: 30%;
+  transform: translate(-50%, 0);
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  background: rgba(11, 22, 36, 0.82);
+  color: #f6f6f8;
+  font-size: var(--game-text-xs);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+  animation: shanghai-hotspot-pulse 1400ms ease-in-out infinite;
+}
+
+.shanghai-pair-hotspot.is-locked {
+  opacity: 0.55;
+  animation: none;
+}
+
+.shanghai-pair-hotspot-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: #ffcb5b;
+  box-shadow: 0 0 0 6px rgba(255, 203, 91, 0.2);
+}
+
+@keyframes shanghai-hotspot-pulse {
+  0%, 100% {
+    transform: translate(-50%, 0) scale(1);
+  }
+  50% {
+    transform: translate(-50%, -1px) scale(1.025);
+  }
+}

--- a/apps/client/components/scene/SceneView.tsx
+++ b/apps/client/components/scene/SceneView.tsx
@@ -15,6 +15,7 @@ import { WebtoonPanel } from './WebtoonPanel';
 
 interface SceneViewProps {
   backgroundUrl: string;
+  backgroundLayer?: React.ReactNode;
   backgroundTransition?: 'fade' | 'cut';
   ambientDescription?: string;
   cinematic?: { videoUrl: string; caption?: string; captionTranslation?: string; autoAdvance: boolean; muted?: boolean } | null;
@@ -60,6 +61,7 @@ const SPEAKER_COLORS: Record<string, string> = {
 
 export function SceneView({
   backgroundUrl,
+  backgroundLayer,
   backgroundTransition,
   ambientDescription = '',
   cinematic = null,
@@ -148,7 +150,9 @@ export function SceneView({
       {hudContent}
 
       {/* Layer 1: Background */}
-      <Background imageUrl={backgroundUrl} ambientDescription={ambientDescription} fade={backdropTransition} />
+      {backgroundLayer ?? (
+        <Background imageUrl={backgroundUrl} ambientDescription={ambientDescription} fade={backdropTransition} />
+      )}
 
       {/* Cinematic overlay (above everything when playing) */}
       {cinematic && (

--- a/apps/client/components/scene/ShanghaiPreludeViewport.tsx
+++ b/apps/client/components/scene/ShanghaiPreludeViewport.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+interface ShanghaiPreludeViewportProps {
+  imageUrl: string;
+  panUnlocked: boolean;
+  tappedPair: boolean;
+  onPairReveal?: (revealed: boolean) => void;
+  onPairTap: () => void;
+}
+
+const PANORAMA_WIDTH_RATIO = 1.9;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+export function ShanghaiPreludeViewport({
+  imageUrl,
+  panUnlocked,
+  tappedPair,
+  onPairReveal,
+  onPairTap,
+}: ShanghaiPreludeViewportProps) {
+  const viewportRef = useRef<HTMLDivElement>(null);
+  const [maxPan, setMaxPan] = useState(0);
+  const [panX, setPanX] = useState(0);
+  const dragRef = useRef<{ pointerId: number; startX: number; startPan: number } | null>(null);
+
+  useEffect(() => {
+    const viewport = viewportRef.current;
+    if (!viewport) return;
+
+    const updateSize = () => {
+      const nextMaxPan = Math.max(0, viewport.clientWidth * (PANORAMA_WIDTH_RATIO - 1));
+      setMaxPan(nextMaxPan);
+      setPanX((prev) => clamp(prev, 0, nextMaxPan));
+    };
+
+    updateSize();
+    const observer = new ResizeObserver(updateSize);
+    observer.observe(viewport);
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    if (!panUnlocked) {
+      setPanX(maxPan);
+    }
+  }, [panUnlocked, maxPan]);
+
+  const pairVisible = useMemo(() => {
+    if (maxPan <= 0) return false;
+    return panX <= maxPan * 0.58;
+  }, [panX, maxPan]);
+
+  useEffect(() => {
+    onPairReveal?.(pairVisible);
+  }, [pairVisible, onPairReveal]);
+
+  return (
+    <div className="shanghai-prelude absolute inset-0 overflow-hidden">
+      <div
+        ref={viewportRef}
+        className={`shanghai-prelude-viewport ${panUnlocked ? 'is-unlocked' : 'is-guided'}`}
+        onPointerDown={(event) => {
+          if (!panUnlocked) return;
+          dragRef.current = {
+            pointerId: event.pointerId,
+            startX: event.clientX,
+            startPan: panX,
+          };
+          event.currentTarget.setPointerCapture(event.pointerId);
+        }}
+        onPointerMove={(event) => {
+          if (!panUnlocked || !dragRef.current || dragRef.current.pointerId !== event.pointerId) return;
+          const dx = event.clientX - dragRef.current.startX;
+          setPanX(clamp(dragRef.current.startPan - dx, 0, maxPan));
+        }}
+        onPointerUp={(event) => {
+          if (!dragRef.current || dragRef.current.pointerId !== event.pointerId) return;
+          event.currentTarget.releasePointerCapture(event.pointerId);
+          dragRef.current = null;
+        }}
+        onPointerCancel={() => {
+          dragRef.current = null;
+        }}
+        onWheel={(event) => {
+          if (!panUnlocked) return;
+          const delta = Math.abs(event.deltaX) > Math.abs(event.deltaY) ? event.deltaX : event.deltaY;
+          if (delta === 0) return;
+          event.preventDefault();
+          setPanX((prev) => clamp(prev + delta, 0, maxPan));
+        }}
+      >
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={imageUrl}
+          alt=""
+          className="shanghai-prelude-image"
+          style={{ transform: `translate3d(${-panX}px, 0, 0)` }}
+          draggable={false}
+        />
+
+        <div className="shanghai-prelude-guidance" aria-live="polite">
+          {!panUnlocked && 'Tong: Stay still. Listen from this corner first.'}
+          {panUnlocked && !pairVisible && 'Tong: Good. Slide left slowly.'}
+          {panUnlocked && pairVisible && !tappedPair && 'Tong: There—Shoucheng and Dingman. Tap them.'}
+          {tappedPair && 'Tong: Keep low. We are in the conversation now.'}
+        </div>
+
+        {panUnlocked && pairVisible && (
+          <button
+            type="button"
+            className={`shanghai-pair-hotspot ${tappedPair ? 'is-locked' : ''}`}
+            onClick={onPairTap}
+            disabled={tappedPair}
+          >
+            <span className="shanghai-pair-hotspot-dot" />
+            <span className="shanghai-pair-hotspot-label">Shoucheng · Dingman</span>
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Make the Shanghai H1 onboarding feel like Seoul’s guided camera experience by presenting a wide panoramic scene inside the portrait viewport (right-edge crop first) rather than a literal page flow. 
- Guide the player through a Tong-led reveal, then unlock intentional horizontal pan and a tap affordance to enter the existing eavesdrop/webtoon path.

### Description
- Add `ShanghaiPreludeViewport` component to render a 1.9x panoramic background that starts on the right edge, enforces a guided (locked) pan state, and unlocks deliberate drag/wheel pan later; includes in-world Tong guidance and a tappable `Shoucheng · Dingman` hotspot. (new file: `apps/client/components/scene/ShanghaiPreludeViewport.tsx`)
- Extend `SceneView` with an additive `backgroundLayer` prop to allow scene-specific camera/viewport overrides while preserving the existing background pipeline. (modified: `apps/client/components/scene/SceneView.tsx`)
- Integrate Shanghai H1 route-gated state in the `/game` runtime, including pan unlock trigger (on scene advancement/tool arrival), pair-reveal state, tap gating that blocks continuing until tapped, and a tap callback that hands off into the existing webtoon/eavesdrop fixture flow; guarded behind `city=shanghai&scene=h1`. (modified: `apps/client/app/game/page.tsx`)
- Add CSS for the Shanghai prelude viewport, guidance overlay, and hotspot affordance. (modified: `apps/client/app/globals.css`)

### Testing
- Ran TypeScript type-check: `pnpm -C apps/client exec tsc --noEmit` succeeded without errors. 
- Attempted linting: `pnpm -C apps/client exec eslint ...` could not run in this environment because ESLint config resolution failed (ESLint v9 expected `eslint.config.js`), so no repo lint pass was performed here.
- How to test manually: run the client and open `/game?phase=hangout&city=shanghai&scene=h1&mode=fixture` and verify (1) the view starts on the right-edge crop, (2) no free horizontal pan initially, (3) Tong-led context/exercise plays while guided, (4) after scene advances horizontal pan unlocks and you can drag/scroll left to reveal the table, (5) a `Shoucheng · Dingman` hotspot appears and tapping it triggers the eavesdrop/webtoon progression, and (6) Seoul onboarding remains unchanged when not on the Shanghai H1 route.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e88dbe427c832a8ffdcd81155ab450)