### PR TITLE
Guided Shanghai H1 panoramic onboarding camera

### DIFF
--- a/apps/client/app/game/page.tsx
+++ b/apps/client/app/game/page.tsx
@@ -317,6 +317,10 @@ export default function GamePage() {
   const hangoutFixtureId = resolveHangoutFixtureId(searchParams);
   const routeFixtureMode = requestedMode === 'fixture' && !!hangoutFixtureId;
   const fixtureModeActive = Boolean(fixtureParam) || routeFixtureMode;
+  const isShanghaiH1OnboardingRoute = routeFixtureMode
+    && hangoutFixtureId === 'shanghai/h1-negotiation'
+    && searchParams.get('city') === 'shanghai'
+    && searchParams.get('scene') === 'h1';
   const hangoutApi = routeFixtureMode && hangoutFixtureId
     ? `/api/ai/hangout?mode=fixture&fixtureId=${encodeURIComponent(hangoutFixtureId)}`
     : '/api/ai/hangout';
@@ -468,6 +472,9 @@ export default function GamePage() {
   const [sceneReady, setSceneReady] = useState(false);
   const [continuePending, setContinuePending] = useState(false);
   const [fixtureSelectedPov, setFixtureSelectedPov] = useState<string | null>(null);
+  const [shanghaiPreludePanUnlocked, setShanghaiPreludePanUnlocked] = useState(false);
+  const [shanghaiPreludePendingUnlock, setShanghaiPreludePendingUnlock] = useState(false);
+  const [shanghaiPreludePairTapped, setShanghaiPreludePairTapped] = useState(false);
   const [sceneTurn, setSceneTurn] = useState<number>(1);
   const [hangoutCheckpointPhase, setHangoutCheckpointPhase] = useState<string | null>(null);
   const [hangoutResumeSource, setHangoutResumeSource] = useState<'checkpoint' | 'scenario_seed' | null>(null);
@@ -505,6 +512,14 @@ export default function GamePage() {
   const [chargePercent, setChargePercent] = useState(0);
   const [chargeNotifShown, setChargeNotifShown] = useState(false);
   const chargeNotifFiredRef = useRef(false);
+
+  useEffect(() => {
+    if (!isShanghaiH1OnboardingRoute) {
+      setShanghaiPreludePanUnlocked(false);
+      setShanghaiPreludePendingUnlock(false);
+      setShanghaiPreludePairTapped(false);
+    }
+  }, [isShanghaiH1OnboardingRoute]);
 
   // Time-based charge bar: 0→100% over random duration
   useEffect(() => {
@@ -1386,6 +1401,9 @@ export default function GamePage() {
         setCurrentMessage(null);
         setTongTip(null);
         setCurrentExercise(exercise);
+        if (isShanghaiH1OnboardingRoute && !shanghaiPreludePanUnlocked) {
+          setShanghaiPreludePendingUnlock(true);
+        }
         traceQA('tool_queue_show_exercise', { toolCallId: item.toolCallId, exerciseId: exercise.id, exerciseType: exercise.type });
         lastExerciseRef.current = exercise;
         sessionLogger.logExerciseShown(args.exerciseType, exercise.id, { objectiveId: args.objectiveId, hintItems: args.hintItems });
@@ -1533,7 +1551,7 @@ export default function GamePage() {
     setToolQueue((prev) => prev.slice(1));
     processingRef.current = false;
     traceQA('tool_queue_auto_advance', { toolName: item.toolName, remainingQueueLength: Math.max(toolQueue.length - 1, 0) });
-  }, [toolQueue, activeNpc, isIntroHangout, introAct]);
+  }, [toolQueue, activeNpc, isIntroHangout, introAct, isShanghaiH1OnboardingRoute, shanghaiPreludePanUnlocked]);
 
   /* ── Hangout handlers ───────────────────────────────────── */
 
@@ -1628,7 +1646,20 @@ export default function GamePage() {
 
     // Store result — overlay dismiss or auto-advance will pick it up
     exerciseResultRef.current = { exerciseId, correct };
-  }, [isIntroHangout, introExerciseCount, introAct]);
+    if (isShanghaiH1OnboardingRoute && shanghaiPreludePendingUnlock && !shanghaiPreludePanUnlocked) {
+      setShanghaiPreludePanUnlocked(true);
+      setShanghaiPreludePendingUnlock(false);
+    }
+  }, [isIntroHangout, introExerciseCount, introAct, isShanghaiH1OnboardingRoute, shanghaiPreludePendingUnlock, shanghaiPreludePanUnlocked]);
+
+  const handleShanghaiPreludePairTap = useCallback(() => {
+    if (shanghaiPreludePairTapped) return;
+    setShanghaiPreludePairTapped(true);
+    if (tongTip) {
+      setTongTip(null);
+    }
+    handleContinue();
+  }, [shanghaiPreludePairTapped, tongTip, handleContinue]);
 
   const advanceAfterExercise = useCallback(() => {
     const result = exerciseResultRef.current;
@@ -2543,6 +2574,12 @@ export default function GamePage() {
           onDismissTong={handleDismissTong}
           onWebtoonComplete={handleWebtoonComplete}
           onCreditGateDecision={handleCreditGateDecision}
+          shanghaiPrelude={{
+            enabled: isShanghaiH1OnboardingRoute && phase === 'hangout' && !currentWebtoon,
+            panUnlocked: shanghaiPreludePanUnlocked,
+            pairTapped: shanghaiPreludePairTapped,
+            onPairTap: handleShanghaiPreludePairTap,
+          }}
         />
         {/* Charge complete notification (auto-dismisses) */}
         {chargeNotifShown && (

--- a/apps/client/app/globals.css
+++ b/apps/client/app/globals.css
@@ -1882,6 +1882,91 @@ button.nav-link:hover {
   text-shadow: 0 1px 3px rgba(0, 0, 0, 0.8);
 }
 
+.shanghai-prelude-viewport {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  touch-action: pan-y;
+}
+
+.shanghai-prelude-viewport.is-unlocked {
+  cursor: grab;
+}
+
+.shanghai-prelude-viewport.is-unlocked.is-dragging {
+  cursor: grabbing;
+}
+
+.shanghai-prelude-panorama {
+  position: absolute;
+  inset: 0 auto 0 0;
+  height: 100%;
+  transition: transform 220ms ease-out;
+}
+
+.shanghai-prelude-viewport.is-dragging .shanghai-prelude-panorama {
+  transition: none;
+}
+
+.shanghai-prelude-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center bottom;
+  user-select: none;
+  pointer-events: none;
+}
+
+.shanghai-prelude-guided-copy {
+  position: absolute;
+  left: 12px;
+  right: 12px;
+  top: calc(64px + env(safe-area-inset-top, 0px));
+  z-index: 4;
+  border-radius: 12px;
+  padding: 10px 12px;
+  font-size: var(--game-text-sm);
+  line-height: 1.4;
+  color: #f6f3ed;
+  background: rgba(9, 13, 24, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  backdrop-filter: blur(4px);
+  pointer-events: none;
+}
+
+.shanghai-prelude-pair-tap {
+  position: absolute;
+  left: 30%;
+  top: 58%;
+  transform: translate(-50%, -50%);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 10px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 244, 228, 0.76);
+  background: rgba(10, 16, 28, 0.84);
+  color: #fff6ea;
+  box-shadow: 0 0 0 1px rgba(255, 210, 162, 0.22), 0 8px 20px rgba(0, 0, 0, 0.4);
+  animation: shanghai-pair-pulse 1.5s ease-in-out infinite;
+}
+
+.shanghai-prelude-pair-label {
+  font-size: var(--game-text-sm);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.shanghai-prelude-pair-sub {
+  font-size: var(--game-text-xs);
+  color: rgba(255, 244, 228, 0.92);
+}
+
+@keyframes shanghai-pair-pulse {
+  0%, 100% { transform: translate(-50%, -50%) scale(1); }
+  50% { transform: translate(-50%, -50%) scale(1.04); }
+}
+
 .dialogue-continue {
   margin-top: 0.5rem;
   text-align: center;

--- a/apps/client/components/scene/SceneView.tsx
+++ b/apps/client/components/scene/SceneView.tsx
@@ -12,6 +12,7 @@ import { TongOverlay } from './TongOverlay';
 import { CinematicOverlay } from './CinematicOverlay';
 import { ExerciseRenderer } from '../exercises/ExerciseRenderer';
 import { WebtoonPanel } from './WebtoonPanel';
+import { ShanghaiPreludeViewport } from './ShanghaiPreludeViewport';
 
 interface SceneViewProps {
   backgroundUrl: string;
@@ -44,6 +45,12 @@ interface SceneViewProps {
   onDismissTong?: () => void;
   onWebtoonComplete?: () => void;
   onCreditGateDecision?: (decision: 'spend' | 'skip') => void;
+  shanghaiPrelude?: {
+    enabled: boolean;
+    panUnlocked: boolean;
+    pairTapped: boolean;
+    onPairTap: () => void;
+  };
   // Extended props used by GamePageClient VN mode
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
@@ -90,6 +97,7 @@ export function SceneView({
   onDismissTong = () => {},
   onWebtoonComplete = () => {},
   onCreditGateDecision = () => {},
+  shanghaiPrelude,
 }: SceneViewProps) {
   const [exerciseDone, setExerciseDone] = useState(false);
   const [exerciseHidden, setExerciseHidden] = useState(false);
@@ -148,7 +156,16 @@ export function SceneView({
       {hudContent}
 
       {/* Layer 1: Background */}
-      <Background imageUrl={backgroundUrl} ambientDescription={ambientDescription} fade={backdropTransition} />
+      {shanghaiPrelude?.enabled ? (
+        <ShanghaiPreludeViewport
+          imageUrl={backgroundUrl}
+          panUnlocked={shanghaiPrelude.panUnlocked}
+          pairTapped={shanghaiPrelude.pairTapped}
+          onPairTap={shanghaiPrelude.onPairTap}
+        />
+      ) : (
+        <Background imageUrl={backgroundUrl} ambientDescription={ambientDescription} fade={backdropTransition} />
+      )}
 
       {/* Cinematic overlay (above everything when playing) */}
       {cinematic && (

--- a/apps/client/components/scene/ShanghaiPreludeViewport.tsx
+++ b/apps/client/components/scene/ShanghaiPreludeViewport.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { fallbackRuntimeAssetCandidates } from '@/lib/runtime-assets';
+
+type ShanghaiPreludeViewportProps = {
+  imageUrl: string;
+  panUnlocked: boolean;
+  pairTapped: boolean;
+  onPairTap: () => void;
+};
+
+const PANORAMA_WIDTH_FACTOR = 1.9;
+const REVEAL_THRESHOLD = 0.42;
+
+export function ShanghaiPreludeViewport({
+  imageUrl,
+  panUnlocked,
+  pairTapped,
+  onPairTap,
+}: ShanghaiPreludeViewportProps) {
+  const candidates = useMemo(() => fallbackRuntimeAssetCandidates(imageUrl), [imageUrl]);
+  const [candidateIndex, setCandidateIndex] = useState(0);
+  const [viewportWidth, setViewportWidth] = useState(390);
+  const [dragging, setDragging] = useState(false);
+  const [offsetX, setOffsetX] = useState(0);
+  const dragStartRef = useRef<{ x: number; offset: number } | null>(null);
+  const viewportRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setCandidateIndex(0);
+  }, [imageUrl]);
+
+  useEffect(() => {
+    const node = viewportRef.current;
+    if (!node) return;
+
+    const ro = new ResizeObserver((entries) => {
+      const width = entries[0]?.contentRect.width;
+      if (width && Number.isFinite(width)) {
+        setViewportWidth(width);
+      }
+    });
+    ro.observe(node);
+    return () => ro.disconnect();
+  }, []);
+
+  const panoramaWidth = Math.max(viewportWidth * PANORAMA_WIDTH_FACTOR, viewportWidth + 1);
+  const minOffset = viewportWidth - panoramaWidth;
+
+  useEffect(() => {
+    setOffsetX(minOffset);
+  }, [minOffset, imageUrl]);
+
+  const clamp = (value: number) => Math.min(0, Math.max(minOffset, value));
+
+  const onPointerDown = (x: number) => {
+    if (!panUnlocked) return;
+    dragStartRef.current = { x, offset: offsetX };
+    setDragging(true);
+  };
+
+  const onPointerMove = (x: number) => {
+    const dragState = dragStartRef.current;
+    if (!dragState || !panUnlocked) return;
+    const delta = dragState.x - x;
+    setOffsetX(clamp(dragState.offset + delta));
+  };
+
+  const onPointerEnd = () => {
+    setDragging(false);
+    dragStartRef.current = null;
+  };
+
+  const revealProgress = minOffset === 0 ? 0 : (offsetX - minOffset) / (0 - minOffset);
+  const pairVisible = panUnlocked && revealProgress >= REVEAL_THRESHOLD;
+  const activeImageUrl = candidates[candidateIndex] ?? '';
+
+  return (
+    <div className="absolute inset-0 overflow-hidden">
+      <div
+        ref={viewportRef}
+        className={`shanghai-prelude-viewport${panUnlocked ? ' is-unlocked' : ' is-guided'}${dragging ? ' is-dragging' : ''}`}
+        onMouseLeave={onPointerEnd}
+        onMouseUp={onPointerEnd}
+        onMouseMove={(e) => onPointerMove(e.clientX)}
+        onMouseDown={(e) => onPointerDown(e.clientX)}
+        onTouchStart={(e) => onPointerDown(e.touches[0]?.clientX ?? 0)}
+        onTouchMove={(e) => onPointerMove(e.touches[0]?.clientX ?? 0)}
+        onTouchEnd={onPointerEnd}
+        onWheel={(e) => {
+          if (!panUnlocked) return;
+          if (Math.abs(e.deltaX) < 0.5 && Math.abs(e.deltaY) < 0.5) return;
+          setOffsetX((prev) => clamp(prev + e.deltaX + e.deltaY * 0.4));
+        }}
+      >
+        {activeImageUrl ? (
+          <div
+            className="shanghai-prelude-panorama"
+            style={{ width: `${panoramaWidth}px`, transform: `translate3d(${offsetX}px, 0, 0)` }}
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={activeImageUrl}
+              alt="Shanghai dumpling shop prelude"
+              className="shanghai-prelude-image"
+              onError={(e) => {
+                if (candidateIndex + 1 < candidates.length) {
+                  setCandidateIndex(candidateIndex + 1);
+                  return;
+                }
+                (e.target as HTMLImageElement).style.display = 'none';
+              }}
+            />
+
+            {pairVisible && !pairTapped && (
+              <button
+                type="button"
+                className="shanghai-prelude-pair-tap"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onPairTap();
+                }}
+              >
+                <span className="shanghai-prelude-pair-label">守成 · 丁漫</span>
+                <span className="shanghai-prelude-pair-sub">Tap to listen in</span>
+              </button>
+            )}
+          </div>
+        ) : null}
+
+        {!panUnlocked && (
+          <div className="shanghai-prelude-guided-copy">Tong: Hold still. Catch their rhythm before you move.</div>
+        )}
+        {panUnlocked && !pairTapped && (
+          <div className="shanghai-prelude-guided-copy">Tong: Slide left. Shoucheng and Dingman are at the next table.</div>
+        )}
+        {pairTapped && (
+          <div className="shanghai-prelude-guided-copy">Tong: Good. Keep low and listen.</div>
+        )}
+      </div>
+
+      <div className="absolute inset-x-0 bottom-0 h-1/3 bg-gradient-to-t from-black/60 to-transparent pointer-events-none" />
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Make the Shanghai H1 onboarding feel like the Seoul onboarding (camera-led, guided first act) by presenting a right-edge crop of a wider panoramic source inside the portrait phone viewport and only unlocking free horizontal pan after Tong advances the scene.
- Enable an explicit in-world tap affordance for Shoucheng/Dingman that hands off into the existing eavesdrop/webtoon fixture progression without changing Seoul or other city onboarding behavior.

### Description
- Add `ShanghaiPreludeViewport` (`apps/client/components/scene/ShanghaiPreludeViewport.tsx`) which renders a wider panorama inside the 9:16 phone frame, starts at the right edge, supports a locked guided mode, and enables intentional touch/mouse/wheel panning after unlock with a reveal-threshold-based pair tap affordance.
- Wire the prelude into `SceneView` behind a new `shanghaiPrelude` prop so the `Background` fallback remains untouched and Seoul onboarding is unaffected (`apps/client/components/scene/SceneView.tsx`).
- Gate the behavior in `GamePage` to the exact route `mode=fixture&city=shanghai&scene=h1`, add runtime state for `panUnlocked`, `pendingUnlock`, and `pairTapped`, trigger `panUnlocked` after guided exercise completion, and implement `handleShanghaiPreludePairTap` to advance into the existing tool queue/webtoon flow (`apps/client/app/game/page.tsx`).
- Add UI styles and polish for the guided overlay, drag affordance, and pulsating pair tap target in `apps/client/app/globals.css`.

### Testing
- Type-check: `cd /workspace/tong/apps/client && npx tsc --noEmit` succeeded (TypeScript build OK).
- Lint: ESLint invocation failed due to no flat ESLint config in this environment and `apps/client` has no `lint` npm script; CI/local linting should be run with project-standard tooling (failed in this run).
- How to test manually: start the client app and open `/game?phase=hangout&city=shanghai&scene=h1&mode=fixture` and verify (1) initial framing shows the right edge crop and camera is locked during Act 1, (2) Tong-led exercise/progression can run while locked, (3) after guided advancement pan unlocks and horizontal pan reveals Shoucheng and Dingman, (4) the `守成 · 丁漫` tap affordance appears once revealed and tapping it continues into the existing eavesdrop/webtoon progression, and (5) Seoul onboarding remains unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e88dbe427c832a8ffdcd81155ab450)