### PR TITLE
fix: issue #240 - Playtest findings model and route-state ledger

### DIFF
--- a/apps/server/src/__tests__/playtest-findings.test.mjs
+++ b/apps/server/src/__tests__/playtest-findings.test.mjs
@@ -1,0 +1,91 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  ingestPlaytestFindings,
+  updateFindingRoute,
+  linkFindingGithubRefs,
+  reopenFinding,
+  storeFindingOverride,
+  listPlaytestFindings,
+} from '../playtest-findings.mjs';
+
+test('ingest creates stable finding identity and dedupes reruns', () => {
+  const findingsMap = new Map();
+  const payload = {
+    sessionId: 'session-1',
+    findings: [
+      {
+        category: 'translation',
+        severity: 'high',
+        description: 'Tooltip omits hanja annotation',
+        whatUserExpected: 'Hanja should be shown',
+        whatActuallyHappened: 'Only hangul appears',
+      },
+    ],
+  };
+
+  const first = ingestPlaytestFindings({ findingsMap, ...payload, analysisId: 'analysis-a' });
+  const second = ingestPlaytestFindings({ findingsMap, ...payload, analysisId: 'analysis-b' });
+
+  assert.equal(first.created, 1);
+  assert.equal(second.updated, 1);
+  assert.equal(findingsMap.size, 1);
+
+  const finding = first.findings[0];
+  assert.equal(finding.findingId, second.findings[0].findingId);
+  assert.deepEqual(second.findings[0].analysisIds.sort(), ['analysis-a', 'analysis-b']);
+  assert.equal(second.findings[0].occurrenceCount, 2);
+});
+
+test('route/link/override workflow updates audit-ready fields', () => {
+  const findingsMap = new Map();
+  const ingest = ingestPlaytestFindings({
+    findingsMap,
+    sessionId: 'session-2',
+    findings: [{ category: 'ux', severity: 'medium', description: 'Continue CTA looks disabled' }],
+  });
+  const findingId = ingest.findings[0].findingId;
+
+  const routed = updateFindingRoute({
+    findingsMap,
+    findingId,
+    routeStatus: 'update_issue',
+    reason: 'Duplicate of existing issue',
+    confidence: 0.92,
+    actor: 'qa-bot',
+  });
+  assert.equal(routed.routeStatus, 'update_issue');
+  assert.equal(routed.routeReason, 'Duplicate of existing issue');
+  assert.equal(routed.routeConfidence, 0.92);
+
+  const linked = linkFindingGithubRefs({
+    findingsMap,
+    findingId,
+    issueRef: 'erniesg/tong#240',
+    prRef: 'erniesg/tong#245',
+    actor: 'qa-bot',
+  });
+  assert.equal(linked.githubIssueRef, 'erniesg/tong#240');
+  assert.equal(linked.githubPrRef, 'erniesg/tong#245');
+
+  const overridden = storeFindingOverride({
+    findingsMap,
+    findingId,
+    override: { decision: 'human_review', note: 'Needs product triage' },
+    actor: 'reviewer-1',
+  });
+  assert.equal(overridden.humanOverride.decision, 'human_review');
+  assert.equal(overridden.humanOverride.actor, 'reviewer-1');
+
+  const reopened = reopenFinding({
+    findingsMap,
+    findingId,
+    reason: 'Reopened after regression',
+    actor: 'reviewer-1',
+  });
+  assert.equal(reopened.routeStatus, 'unrouted');
+
+  const unroutedOnly = listPlaytestFindings({ findingsMap, routeStatus: 'unrouted' });
+  assert.equal(unroutedOnly.length, 1);
+  assert.ok(reopened.auditTrail.length >= 5);
+});

--- a/apps/server/src/index.mjs
+++ b/apps/server/src/index.mjs
@@ -156,6 +156,14 @@ import {
   getAutoFixStatus,
 } from './autofix.mjs';
 import {
+  ingestPlaytestFindings,
+  listPlaytestFindings,
+  updateFindingRoute,
+  linkFindingGithubRefs,
+  reopenFinding,
+  storeFindingOverride,
+} from './playtest-findings.mjs';
+import {
   apifyXhsSearch,
   apifyInstagramSearch,
   apifySearch,
@@ -366,6 +374,7 @@ const state = {
   ingestionByUser: new Map(),
   integrationsByUser: new Map(),
   playtestSessions: new Map(),
+  playtestFindings: new Map(),
 };
 
 function ensureParentDir(filePath) {
@@ -461,6 +470,7 @@ function saveDurableState() {
     ingestionByUser: cloneMapEntries(state.ingestionByUser),
     integrationsByUser: cloneMapEntries(state.integrationsByUser),
     playtestSessions: cloneMapEntries(state.playtestSessions),
+    playtestFindings: cloneMapEntries(state.playtestFindings),
   };
   const tempPath = `${STATE_FILE_PATH}.tmp`;
   fs.writeFileSync(tempPath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
@@ -484,6 +494,7 @@ function loadDurableState() {
   state.ingestionByUser = restoreMap(parsed.ingestionByUser || []);
   state.integrationsByUser = restoreMap(parsed.integrationsByUser || []);
   state.playtestSessions = restoreMap(parsed.playtestSessions || []);
+  state.playtestFindings = restoreMap(parsed.playtestFindings || []);
 
   for (const [sessionId, gameSession] of state.sessions.entries()) {
     normalizeGameSessionState(gameSession);
@@ -5074,6 +5085,96 @@ const server = http.createServer(async (req, res) => {
       return;
     }
 
+    if (pathname === '/api/v1/playtest/findings' && req.method === 'GET') {
+      const routeStatus = url.searchParams.get('routeStatus');
+      const sessionId = url.searchParams.get('sessionId');
+      const findings = listPlaytestFindings({
+        findingsMap: state.playtestFindings,
+        routeStatus,
+        sessionId,
+      });
+      jsonResponse(res, 200, { findings, count: findings.length });
+      return;
+    }
+
+    if (pathname === '/api/v1/playtest/findings/ingest' && req.method === 'POST') {
+      const body = await readJsonBody(req);
+      let findings = Array.isArray(body.findings) ? body.findings : [];
+      const analysisId = typeof body.analysisId === 'string' ? body.analysisId.trim() : '';
+      if (analysisId && findings.length === 0) {
+        const analysis = getAnalysisResult(analysisId);
+        findings = Array.isArray(analysis?.result?.issues) ? analysis.result.issues : [];
+      }
+      const payload = ingestPlaytestFindings({
+        findingsMap: state.playtestFindings,
+        sessionId: body.sessionId,
+        findings,
+        analysisId: analysisId || null,
+      });
+      saveDurableState();
+      jsonResponse(res, 200, payload);
+      return;
+    }
+
+    if (pathname.match(/^\/api\/v1\/playtest\/findings\/[^/]+\/route$/) && req.method === 'POST') {
+      const findingId = pathname.split('/')[5];
+      const body = await readJsonBody(req);
+      const finding = updateFindingRoute({
+        findingsMap: state.playtestFindings,
+        findingId,
+        routeStatus: body.routeStatus,
+        reason: body.reason,
+        confidence: body.confidence,
+        actor: body.actor,
+      });
+      saveDurableState();
+      jsonResponse(res, 200, { finding });
+      return;
+    }
+
+    if (pathname.match(/^\/api\/v1\/playtest\/findings\/[^/]+\/link$/) && req.method === 'POST') {
+      const findingId = pathname.split('/')[5];
+      const body = await readJsonBody(req);
+      const finding = linkFindingGithubRefs({
+        findingsMap: state.playtestFindings,
+        findingId,
+        issueRef: body.issueRef,
+        prRef: body.prRef,
+        actor: body.actor,
+      });
+      saveDurableState();
+      jsonResponse(res, 200, { finding });
+      return;
+    }
+
+    if (pathname.match(/^\/api\/v1\/playtest\/findings\/[^/]+\/override$/) && req.method === 'POST') {
+      const findingId = pathname.split('/')[5];
+      const body = await readJsonBody(req);
+      const finding = storeFindingOverride({
+        findingsMap: state.playtestFindings,
+        findingId,
+        override: body.override,
+        actor: body.actor,
+      });
+      saveDurableState();
+      jsonResponse(res, 200, { finding });
+      return;
+    }
+
+    if (pathname.match(/^\/api\/v1\/playtest\/findings\/[^/]+\/reopen$/) && req.method === 'POST') {
+      const findingId = pathname.split('/')[5];
+      const body = await readJsonBody(req);
+      const finding = reopenFinding({
+        findingsMap: state.playtestFindings,
+        findingId,
+        reason: body.reason,
+        actor: body.actor,
+      });
+      saveDurableState();
+      jsonResponse(res, 200, { finding });
+      return;
+    }
+
     // ── Signals keyword + search routes (public) ─────────────────────
 
     if (pathname === '/api/v1/signals/keywords' && req.method === 'GET') {
@@ -5502,6 +5603,7 @@ export const __testing = {
     state.activeSessionByUser.clear();
     state.learnSessions = [...(FIXTURES.learnSessions.items || [])];
     state.ingestionByUser.clear();
+    state.playtestFindings.clear();
     ensureIngestionForUser(DEFAULT_USER_ID);
     saveDurableState();
   },

--- a/apps/server/src/playtest-findings.mjs
+++ b/apps/server/src/playtest-findings.mjs
@@ -1,0 +1,272 @@
+import crypto from 'node:crypto';
+
+const ROUTE_STATUSES = new Set([
+  'unrouted',
+  'skip',
+  'update_issue',
+  'new_issue',
+  'direct_pr',
+  'human_review',
+  'done',
+]);
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function normalizeString(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function toConfidence(value) {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return null;
+  return Math.max(0, Math.min(1, n));
+}
+
+function slugify(value) {
+  return normalizeString(value).toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '') || 'unknown';
+}
+
+function buildFingerprintKey(sessionId, finding) {
+  const stableFields = [
+    sessionId,
+    slugify(finding.category),
+    slugify(finding.severity),
+    slugify(finding.affectedComponent),
+    normalizeString(finding.description).toLowerCase(),
+    normalizeString(finding.whatUserExpected).toLowerCase(),
+    normalizeString(finding.whatActuallyHappened).toLowerCase(),
+  ];
+  const raw = stableFields.join('|');
+  const digest = crypto.createHash('sha256').update(raw).digest('hex');
+  return {
+    dedupeKey: digest,
+    findingId: `pf_${digest.slice(0, 16)}`,
+  };
+}
+
+function normalizeArtifactLinks(links) {
+  if (!Array.isArray(links)) return [];
+  return links
+    .map((link) => {
+      if (typeof link === 'string') {
+        const href = link.trim();
+        return href ? { href } : null;
+      }
+      if (!link || typeof link !== 'object') return null;
+      const href = normalizeString(link.href || link.url);
+      if (!href) return null;
+      return {
+        href,
+        label: normalizeString(link.label) || undefined,
+        type: normalizeString(link.type) || undefined,
+      };
+    })
+    .filter(Boolean);
+}
+
+export function normalizeRawFinding(raw) {
+  const finding = raw && typeof raw === 'object' ? raw : {};
+  return {
+    category: normalizeString(finding.category) || 'unknown',
+    severity: normalizeString(finding.severity) || 'unknown',
+    description: normalizeString(finding.description) || 'No description provided.',
+    whatUserExpected: normalizeString(finding.whatUserExpected) || undefined,
+    whatActuallyHappened: normalizeString(finding.whatActuallyHappened) || undefined,
+    suggestedFix: normalizeString(finding.suggestedFix) || undefined,
+    affectedComponent: normalizeString(finding.affectedComponent) || undefined,
+    inferredComponent: normalizeString(finding.inferredComponent || finding.affectedComponent) || undefined,
+    confidence: toConfidence(finding.confidence),
+    artifactLinks: normalizeArtifactLinks(finding.artifactLinks || finding.artifacts || []),
+  };
+}
+
+function appendAuditEvent(record, event) {
+  const auditEvent = {
+    at: nowIso(),
+    ...event,
+  };
+  record.auditTrail = Array.isArray(record.auditTrail) ? record.auditTrail : [];
+  record.auditTrail.push(auditEvent);
+}
+
+export function ingestPlaytestFindings({ findingsMap, sessionId, findings, analysisId = null }) {
+  const cleanSessionId = normalizeString(sessionId);
+  if (!cleanSessionId) {
+    throw new Error('sessionId_required');
+  }
+  if (!Array.isArray(findings) || findings.length === 0) {
+    throw new Error('findings_required');
+  }
+
+  let created = 0;
+  let updated = 0;
+  const records = [];
+
+  for (const rawFinding of findings) {
+    const normalized = normalizeRawFinding(rawFinding);
+    const { dedupeKey, findingId } = buildFingerprintKey(cleanSessionId, normalized);
+
+    const existing = findingsMap.get(findingId);
+    if (existing) {
+      existing.lastSeenAt = nowIso();
+      existing.occurrenceCount = (existing.occurrenceCount || 1) + 1;
+      existing.category = normalized.category;
+      existing.severity = normalized.severity;
+      existing.description = normalized.description;
+      existing.whatUserExpected = normalized.whatUserExpected;
+      existing.whatActuallyHappened = normalized.whatActuallyHappened;
+      existing.suggestedFix = normalized.suggestedFix;
+      existing.inferredComponent = normalized.inferredComponent;
+      existing.artifactLinks = normalized.artifactLinks;
+      if (analysisId) existing.analysisIds = [...new Set([...(existing.analysisIds || []), analysisId])];
+      appendAuditEvent(existing, {
+        type: 'finding.reobserved',
+        dedupeKey,
+        sessionId: cleanSessionId,
+      });
+      findingsMap.set(findingId, existing);
+      updated += 1;
+      records.push(existing);
+      continue;
+    }
+
+    const createdAt = nowIso();
+    const record = {
+      findingId,
+      dedupeKey,
+      sessionId: cleanSessionId,
+      createdAt,
+      updatedAt: createdAt,
+      firstSeenAt: createdAt,
+      lastSeenAt: createdAt,
+      category: normalized.category,
+      severity: normalized.severity,
+      description: normalized.description,
+      whatUserExpected: normalized.whatUserExpected,
+      whatActuallyHappened: normalized.whatActuallyHappened,
+      suggestedFix: normalized.suggestedFix,
+      inferredComponent: normalized.inferredComponent,
+      artifactLinks: normalized.artifactLinks,
+      routeStatus: 'unrouted',
+      routeReason: null,
+      routeConfidence: normalized.confidence,
+      githubIssueRef: null,
+      githubPrRef: null,
+      humanOverride: null,
+      occurrenceCount: 1,
+      analysisIds: analysisId ? [analysisId] : [],
+      auditTrail: [
+        {
+          at: createdAt,
+          type: 'finding.created',
+          sessionId: cleanSessionId,
+          dedupeKey,
+        },
+      ],
+    };
+
+    findingsMap.set(findingId, record);
+    created += 1;
+    records.push(record);
+  }
+
+  return {
+    sessionId: cleanSessionId,
+    analysisId,
+    created,
+    updated,
+    total: records.length,
+    findings: records,
+  };
+}
+
+export function listPlaytestFindings({ findingsMap, routeStatus = null, sessionId = null }) {
+  const byRoute = normalizeString(routeStatus);
+  const bySession = normalizeString(sessionId);
+  return [...findingsMap.values()]
+    .filter((item) => (!byRoute || item.routeStatus === byRoute) && (!bySession || item.sessionId === bySession))
+    .sort((a, b) => new Date(b.updatedAt || b.createdAt) - new Date(a.updatedAt || a.createdAt));
+}
+
+function getRequiredFinding(findingsMap, findingId) {
+  const record = findingsMap.get(findingId);
+  if (!record) {
+    const error = new Error('finding_not_found');
+    error.code = 'finding_not_found';
+    throw error;
+  }
+  return record;
+}
+
+export function updateFindingRoute({ findingsMap, findingId, routeStatus, reason = '', confidence = null, actor = '' }) {
+  const status = normalizeString(routeStatus);
+  if (!ROUTE_STATUSES.has(status)) {
+    throw new Error('invalid_route_status');
+  }
+  const record = getRequiredFinding(findingsMap, findingId);
+  record.routeStatus = status;
+  record.routeReason = normalizeString(reason) || null;
+  record.routeConfidence = toConfidence(confidence);
+  record.updatedAt = nowIso();
+  appendAuditEvent(record, {
+    type: 'route.updated',
+    routeStatus: status,
+    reason: record.routeReason,
+    confidence: record.routeConfidence,
+    actor: normalizeString(actor) || undefined,
+  });
+  findingsMap.set(findingId, record);
+  return record;
+}
+
+export function linkFindingGithubRefs({ findingsMap, findingId, issueRef = null, prRef = null, actor = '' }) {
+  const record = getRequiredFinding(findingsMap, findingId);
+  const nextIssueRef = normalizeString(issueRef) || null;
+  const nextPrRef = normalizeString(prRef) || null;
+  record.githubIssueRef = nextIssueRef;
+  record.githubPrRef = nextPrRef;
+  record.updatedAt = nowIso();
+  appendAuditEvent(record, {
+    type: 'github.linked',
+    issueRef: nextIssueRef,
+    prRef: nextPrRef,
+    actor: normalizeString(actor) || undefined,
+  });
+  findingsMap.set(findingId, record);
+  return record;
+}
+
+export function storeFindingOverride({ findingsMap, findingId, override, actor = '' }) {
+  const record = getRequiredFinding(findingsMap, findingId);
+  const cleanOverride = override && typeof override === 'object' ? structuredClone(override) : null;
+  record.humanOverride = {
+    ...(cleanOverride || {}),
+    actor: normalizeString(actor) || cleanOverride?.actor || null,
+    updatedAt: nowIso(),
+  };
+  record.updatedAt = nowIso();
+  appendAuditEvent(record, {
+    type: 'override.stored',
+    actor: normalizeString(actor) || undefined,
+  });
+  findingsMap.set(findingId, record);
+  return record;
+}
+
+export function reopenFinding({ findingsMap, findingId, reason = '', actor = '' }) {
+  return updateFindingRoute({
+    findingsMap,
+    findingId,
+    routeStatus: 'unrouted',
+    reason: normalizeString(reason) || 'reopened',
+    confidence: null,
+    actor,
+  });
+}
+
+export const __testing = {
+  buildFingerprintKey,
+  ROUTE_STATUSES,
+};

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -14,6 +14,7 @@ Typed contracts:
 - `objective-identity-map.sample.json` is the canonical alias bridge between graph objective ids and legacy fixture/api ids during migration.
 - `fixtures/game.start-or-resume.sample.json` now includes the additive nested session model used for player resume and QA seed routing.
 - `fixtures/game.session.sample.json`, `fixtures/scene.session.sample.json`, `fixtures/checkpoint.player-resume.sample.json`, and `fixtures/scenario.seed.review-ready.sample.json` are the canonical samples for progression/resume work.
+- `fixtures/playtest.findings.sample.json` captures the per-finding playtest ledger response used for routing and issue/PR linkage.
 
 Curriculum graph fixtures:
 - `fixtures/curriculum.graph.food-street.sample.json` is the canonical typed curriculum-graph sample.

--- a/packages/contracts/api-contract.md
+++ b/packages/contracts/api-contract.md
@@ -842,3 +842,35 @@ Response:
   "openAiApiKeyConfigured": false
 }
 ```
+
+## Playtest findings ledger
+
+### POST `/api/v1/playtest/findings/ingest`
+Normalizes `analysis.result.issues[]` (or direct `findings[]`) into persistent per-finding records keyed by a stable dedupe fingerprint.
+
+Request:
+```json
+{
+  "sessionId": "hK29sdL2pQ",
+  "analysisId": "analysis-4c66f2a"
+}
+```
+
+Response shape: `fixtures/playtest.findings.sample.json`.
+
+### GET `/api/v1/playtest/findings`
+Query options:
+- `routeStatus` (optional): `unrouted|skip|update_issue|new_issue|direct_pr|human_review|done`
+- `sessionId` (optional)
+
+### POST `/api/v1/playtest/findings/:findingId/route`
+Stores deterministic route-state transitions with reason/confidence for idempotent orchestration reruns.
+
+### POST `/api/v1/playtest/findings/:findingId/link`
+Attaches GitHub issue/PR refs to a finding record.
+
+### POST `/api/v1/playtest/findings/:findingId/override`
+Stores manual override metadata.
+
+### POST `/api/v1/playtest/findings/:findingId/reopen`
+Returns a previously-routed finding to `unrouted`.

--- a/packages/contracts/fixtures/playtest.findings.sample.json
+++ b/packages/contracts/fixtures/playtest.findings.sample.json
@@ -1,0 +1,48 @@
+{
+  "sessionId": "hK29sdL2pQ",
+  "analysisId": "analysis-4c66f2a",
+  "created": 2,
+  "updated": 0,
+  "total": 2,
+  "findings": [
+    {
+      "findingId": "pf_5fe1f6ad2bdff3ab",
+      "dedupeKey": "5fe1f6ad2bdff3ab2cd89f6f37a1f5847f0f8fb6bf4e6a80afb7bcf348bde755",
+      "sessionId": "hK29sdL2pQ",
+      "createdAt": "2026-04-20T10:30:00.000Z",
+      "updatedAt": "2026-04-20T10:30:00.000Z",
+      "firstSeenAt": "2026-04-20T10:30:00.000Z",
+      "lastSeenAt": "2026-04-20T10:30:00.000Z",
+      "category": "translation",
+      "severity": "high",
+      "description": "Dictionary tooltip omits hanja for key noun.",
+      "whatUserExpected": "Hanja appears next to hangul in tooltip.",
+      "whatActuallyHappened": "Tooltip only shows hangul and English gloss.",
+      "suggestedFix": "Include hanja lane in tooltip renderer.",
+      "inferredComponent": "client-overlay",
+      "artifactLinks": [
+        {
+          "href": "https://tong-runs.example/review/run-001/frame-14.png",
+          "label": "tooltip state",
+          "type": "screenshot"
+        }
+      ],
+      "routeStatus": "unrouted",
+      "routeReason": null,
+      "routeConfidence": 0.88,
+      "githubIssueRef": null,
+      "githubPrRef": null,
+      "humanOverride": null,
+      "occurrenceCount": 1,
+      "analysisIds": ["analysis-4c66f2a"],
+      "auditTrail": [
+        {
+          "at": "2026-04-20T10:30:00.000Z",
+          "type": "finding.created",
+          "sessionId": "hK29sdL2pQ",
+          "dedupeKey": "5fe1f6ad2bdff3ab2cd89f6f37a1f5847f0f8fb6bf4e6a80afb7bcf348bde755"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/contracts/types.ts
+++ b/packages/contracts/types.ts
@@ -1142,3 +1142,65 @@ export interface VolcTTSSynthesizeResponse {
   encoding: string;
   durationMs?: number;
 }
+
+export type PlaytestFindingRouteStatus =
+  | 'unrouted'
+  | 'skip'
+  | 'update_issue'
+  | 'new_issue'
+  | 'direct_pr'
+  | 'human_review'
+  | 'done';
+
+export interface PlaytestArtifactLink {
+  href: string;
+  label?: string;
+  type?: string;
+}
+
+export interface PlaytestFindingRouteAuditEvent {
+  at: string;
+  type: string;
+  routeStatus?: PlaytestFindingRouteStatus;
+  reason?: string | null;
+  confidence?: number | null;
+  issueRef?: string | null;
+  prRef?: string | null;
+  actor?: string;
+}
+
+export interface PlaytestFindingRecord {
+  findingId: string;
+  dedupeKey: string;
+  sessionId: string;
+  createdAt: string;
+  updatedAt: string;
+  firstSeenAt: string;
+  lastSeenAt: string;
+  category: string;
+  severity: string;
+  description: string;
+  whatUserExpected?: string;
+  whatActuallyHappened?: string;
+  suggestedFix?: string;
+  inferredComponent?: string;
+  artifactLinks: PlaytestArtifactLink[];
+  routeStatus: PlaytestFindingRouteStatus;
+  routeReason: string | null;
+  routeConfidence: number | null;
+  githubIssueRef: string | null;
+  githubPrRef: string | null;
+  humanOverride: Record<string, unknown> | null;
+  occurrenceCount: number;
+  analysisIds: string[];
+  auditTrail: PlaytestFindingRouteAuditEvent[];
+}
+
+export interface PlaytestFindingIngestResponse {
+  sessionId: string;
+  analysisId: string | null;
+  created: number;
+  updated: number;
+  total: number;
+  findings: PlaytestFindingRecord[];
+}


### PR DESCRIPTION
### Motivation
- Playtest analysis produced findings but the server had no first-class, persisted per-finding ledger to dedupe, route, or link issues idempotently. 
- Orchestration and auto-fix flows require deterministic finding identities, route-state transitions, and audit history to avoid duplicate work. 
- A compact server API and contract are needed so QA and automation can ingest analysis results, route them, and attach GitHub refs reliably.

### Description
- Add a new server-side module `apps/server/src/playtest-findings.mjs` providing normalization, SHA256 fingerprint dedupe, ingest/dedupe semantics, route-state transitions, GitHub link storage, manual overrides, reopen flow, and audit-trail events. 
- Wire the ledger into the server runtime state as `state.playtestFindings` with durable persistence in `saveDurableState()` / `loadDurableState()` and reset behavior in `__testing.resetState`. 
- Expose API endpoints in `apps/server/src/index.mjs`: `POST /api/v1/playtest/findings/ingest`, `GET /api/v1/playtest/findings`, `POST /api/v1/playtest/findings/:id/route`, `POST /api/v1/playtest/findings/:id/link`, `POST /api/v1/playtest/findings/:id/override`, and `POST /api/v1/playtest/findings/:id/reopen`. 
- Update shared contracts in `packages/contracts` with `types.ts` additions, `packages/contracts/fixtures/playtest.findings.sample.json`, and API docs in `packages/contracts/api-contract.md`, and add focused unit tests `apps/server/src/__tests__/playtest-findings.test.mjs`. 
- This PR fully implements the ledger + routing surface required by the issue and therefore closes the ticket on merge (Fixes #240). 

### Testing
- Unit tests: ran `node --test apps/server/src/__tests__/playtest-findings.test.mjs` and it passed (2 tests, both OK). 
- Local API verification: started the mock server and exercised the lifecycle using curl: `POST /api/v1/playtest/findings/ingest` → `POST /api/v1/playtest/findings/:id/route` → `POST /api/v1/playtest/findings/:id/link` → `GET /api/v1/playtest/findings?routeStatus=...&sessionId=...`, and responses showed stable `findingId`, updated `routeStatus`, attached `githubIssueRef`/`githubPrRef`, and audit entries. 
- Functional QA runs: created validate run `artifacts/qa-runs/functional-qa/erniesg-tong-240/20260422T191217Z` (reproduced) and verify-fix run `artifacts/qa-runs/functional-qa/erniesg-tong-240/20260422T191644Z` (fixed) with contract assertions and network trace recorded. 
- Known repo noise: `npm run demo:smoke` failed in this environment due to a missing runtime asset `/assets/app/tong_opening.mp4` unrelated to this change, and full `npm --prefix apps/server test` shows unrelated compositor/Remotion test failures in the environment; those failures are external to the new playtest-findings tests and do not block this server-API change.

How to test locally
- Run the unit test: `node --test apps/server/src/__tests__/playtest-findings.test.mjs`.
- Start the mock server: `node apps/server/src/index.mjs` and exercise the flow with HTTP calls to the endpoints listed above to observe ingest→route→link→list lifecycle.
- Reviewer artifacts: see QA bundles `artifacts/qa-runs/functional-qa/erniesg-tong-240/20260422T191217Z` and `artifacts/qa-runs/functional-qa/erniesg-tong-240/20260422T191644Z` for the reproduction and verify-run evidence.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e91c8c44a0832a97a3c7ac778b6a6d)