### PR TITLE
feat: add deploy promotion workflows and route-human wiring

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,226 @@
+name: Deploy Production
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Approved commit SHA, branch, or tag to promote to production"
+        required: true
+        type: string
+        default: "main"
+      pr_number:
+        description: "Optional PR number for GitHub writeback"
+        required: false
+        type: string
+      issue_ref:
+        description: "Optional issue ref for writeback and route-human, e.g. erniesg/tong#291"
+        required: false
+        type: string
+      note:
+        description: "Optional approval note, release note, or rollback hint"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  deployments: write
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: deploy-production-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: ${{ steps.summary.outputs.public_url }}
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+      NEXT_PUBLIC_TONG_PUBLIC_DOMAIN: ${{ vars.NEXT_PUBLIC_TONG_PUBLIC_DOMAIN }}
+      NEXT_PUBLIC_TONG_API_BASE: ${{ vars.NEXT_PUBLIC_TONG_API_BASE }}
+      NEXT_PUBLIC_TONG_ASSETS_BASE_URL: ${{ vars.NEXT_PUBLIC_TONG_ASSETS_BASE_URL }}
+      NEXT_PUBLIC_TONG_EXTENSION_ZIP_URL: ${{ vars.NEXT_PUBLIC_TONG_EXTENSION_ZIP_URL }}
+      NEXT_PUBLIC_TONG_YOUTUBE_DEMO_URL: ${{ vars.NEXT_PUBLIC_TONG_YOUTUBE_DEMO_URL }}
+      NEXT_PUBLIC_TONG_DEMO_PASSWORD_HINT: ${{ vars.NEXT_PUBLIC_TONG_DEMO_PASSWORD_HINT }}
+      TONG_ASSETS_R2_BUCKET: ${{ vars.TONG_ASSETS_R2_BUCKET }}
+      TONG_RUNTIME_ASSET_MANIFEST_KEY: ${{ vars.TONG_RUNTIME_ASSET_MANIFEST_KEY }}
+      TONG_CLIENT_WORKER_NAME: ${{ vars.TONG_CLIENT_WORKER_NAME }}
+      TONG_CLIENT_WORKERS_URL: ${{ vars.TONG_CLIENT_WORKERS_URL }}
+      DISCORD_ROUTE_HUMAN_ENDPOINT: ${{ vars.DISCORD_ROUTE_HUMAN_ENDPOINT }}
+      DISCORD_ROUTE_HUMAN_MENTION: ${{ vars.DISCORD_ROUTE_HUMAN_MENTION }}
+      ROUTE_HUMAN_WEBHOOK_SECRET: ${{ secrets.ROUTE_HUMAN_WEBHOOK_SECRET }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: apps/client/package-lock.json
+
+      - id: deploy
+        continue-on-error: true
+        env:
+          TONG_DEPLOY_ENV: production
+          TONG_DEPLOY_REF: ${{ inputs.ref }}
+          TONG_DEPLOY_PR_NUMBER: ${{ inputs.pr_number }}
+          TONG_DEPLOY_ISSUE_REF: ${{ inputs.issue_ref }}
+          TONG_DEPLOY_NOTE: ${{ inputs.note }}
+          TONG_DEPLOY_SUMMARY_PATH: ${{ runner.temp }}/deployment-summary.json
+        run: ./scripts/deploy-client-cloudflare.sh --environment production --summary-file "$TONG_DEPLOY_SUMMARY_PATH"
+
+      - id: summary
+        if: steps.deploy.outcome == 'success'
+        env:
+          DEPLOY_SUMMARY_PATH: ${{ runner.temp }}/deployment-summary.json
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          summary = json.loads(Path(os.environ["DEPLOY_SUMMARY_PATH"]).read_text(encoding="utf-8"))
+          lines = [
+              "Production deployment completed.",
+              "",
+              f"- Environment: `{summary['environment']}`",
+              f"- Ref: `{summary.get('ref') or 'unknown'}`",
+              f"- PR: `{summary.get('pr_number') or 'none'}`",
+              f"- Issue: `{summary.get('issue_ref') or 'none'}`",
+              f"- Public URL: {summary['public_url']}",
+              f"- Workers URL: {summary['workers_url']}",
+              f"- API base: `{summary['api_base']}`",
+              f"- Assets base: `{summary['assets_base_url']}`",
+              f"- Assets bucket: `{summary['assets_bucket']}`",
+              "- Next action: monitor the live deployment; if rollback is required, rerun `Deploy Production` with the previous known-good ref.",
+          ]
+          if summary.get("note"):
+              lines.insert(8, f"- Note: {summary['note']}")
+
+          Path(os.environ["RUNNER_TEMP"]).joinpath("deployment-report.md").write_text(
+              "\n".join(lines).strip() + "\n",
+              encoding="utf-8",
+          )
+          output_path = Path(os.environ["GITHUB_OUTPUT"])
+          with output_path.open("a", encoding="utf-8") as handle:
+              handle.write(f"public_url<<__CODEX__\n{summary['public_url']}\n__CODEX__\n")
+          PY
+
+      - name: Step summary
+        if: steps.deploy.outcome == 'success'
+        run: cat "$RUNNER_TEMP/deployment-report.md" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Comment PR
+        if: steps.deploy.outcome == 'success' && inputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh pr comment "${{ inputs.pr_number }}" --repo "${{ github.repository }}" --body-file "$RUNNER_TEMP/deployment-report.md"
+
+      - name: Comment issue
+        if: steps.deploy.outcome == 'success' && inputs.pr_number == '' && inputs.issue_ref != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ inputs.issue_ref }}
+        run: gh issue comment "${ISSUE_NUMBER##*#}" --repo "${{ github.repository }}" --body-file "$RUNNER_TEMP/deployment-report.md"
+
+      - name: Build failure report
+        if: steps.deploy.outcome != 'success'
+        env:
+          DEPLOY_REF: ${{ inputs.ref }}
+          ISSUE_REF: ${{ inputs.issue_ref }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          NOTE: ${{ inputs.note }}
+          SOURCE_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          python3 - <<'PY'
+          import os
+          from pathlib import Path
+
+          lines = [
+              "Production deployment failed.",
+              "",
+              "- Environment: `production`",
+              f"- Ref: `{os.environ.get('DEPLOY_REF') or 'unknown'}`",
+              f"- PR: `{os.environ.get('PR_NUMBER') or 'none'}`",
+              f"- Issue: `{os.environ.get('ISSUE_REF') or 'none'}`",
+              f"- Workflow run: {os.environ['SOURCE_URL']}",
+              "- Next action: inspect the failing deploy job, confirm rollback or fix path with a human approver, then rerun production with an approved ref.",
+          ]
+          if os.environ.get("NOTE"):
+              lines.insert(6, f"- Note: {os.environ['NOTE']}")
+          Path(os.environ["RUNNER_TEMP"]).joinpath("deployment-failure.md").write_text(
+              "\n".join(lines).strip() + "\n",
+              encoding="utf-8",
+          )
+          PY
+
+      - name: Failure summary
+        if: steps.deploy.outcome != 'success'
+        run: cat "$RUNNER_TEMP/deployment-failure.md" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Comment PR failure
+        if: steps.deploy.outcome != 'success' && inputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh pr comment "${{ inputs.pr_number }}" --repo "${{ github.repository }}" --body-file "$RUNNER_TEMP/deployment-failure.md"
+
+      - name: Comment issue failure
+        if: steps.deploy.outcome != 'success' && inputs.pr_number == '' && inputs.issue_ref != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ inputs.issue_ref }}
+        run: gh issue comment "${ISSUE_NUMBER##*#}" --repo "${{ github.repository }}" --body-file "$RUNNER_TEMP/deployment-failure.md"
+
+      - name: Route failure to human review
+        if: steps.deploy.outcome != 'success' && inputs.issue_ref != '' && env.DISCORD_ROUTE_HUMAN_ENDPOINT != '' && env.ROUTE_HUMAN_WEBHOOK_SECRET != ''
+        continue-on-error: true
+        env:
+          ISSUE_REF: ${{ inputs.issue_ref }}
+          DEPLOY_REF: ${{ inputs.ref }}
+          NOTE: ${{ inputs.note }}
+          SOURCE_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import urllib.request
+
+          notes = [
+              f"Production deploy failed for ref {os.environ.get('DEPLOY_REF') or os.environ.get('ISSUE_REF')}.",
+              "Open the workflow run and deployment summary for the exact blocker context.",
+          ]
+          if os.environ.get("NOTE"):
+              notes.append(os.environ["NOTE"])
+
+          payload = {
+              "repository": os.environ["GITHUB_REPOSITORY"],
+              "issueRef": os.environ["ISSUE_REF"],
+              "action": "deploy-production-failed",
+              "mention": os.environ.get("DISCORD_ROUTE_HUMAN_MENTION", ""),
+              "notes": notes,
+              "sourceUrl": os.environ["SOURCE_URL"],
+          }
+
+          request = urllib.request.Request(
+              os.environ["DISCORD_ROUTE_HUMAN_ENDPOINT"],
+              data=json.dumps(payload).encode("utf-8"),
+              headers={
+                  "Authorization": f"Bearer {os.environ['ROUTE_HUMAN_WEBHOOK_SECRET']}",
+                  "Content-Type": "application/json",
+              },
+              method="POST",
+          )
+          with urllib.request.urlopen(request) as response:
+              if response.status >= 300:
+                  raise SystemExit(f"route-human endpoint returned {response.status}")
+          PY
+
+      - name: Fail job when deploy step failed
+        if: steps.deploy.outcome != 'success'
+        run: exit 1

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,226 @@
+name: Deploy Staging
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Validated commit SHA, branch, or tag to promote to staging"
+        required: true
+        type: string
+        default: "main"
+      pr_number:
+        description: "Optional PR number for GitHub writeback"
+        required: false
+        type: string
+      issue_ref:
+        description: "Optional issue ref for writeback and route-human, e.g. erniesg/tong#291"
+        required: false
+        type: string
+      note:
+        description: "Optional promotion note or checkpoint context"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  deployments: write
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: deploy-staging-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: staging
+      url: ${{ steps.summary.outputs.public_url }}
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+      NEXT_PUBLIC_TONG_PUBLIC_DOMAIN: ${{ vars.NEXT_PUBLIC_TONG_PUBLIC_DOMAIN }}
+      NEXT_PUBLIC_TONG_API_BASE: ${{ vars.NEXT_PUBLIC_TONG_API_BASE }}
+      NEXT_PUBLIC_TONG_ASSETS_BASE_URL: ${{ vars.NEXT_PUBLIC_TONG_ASSETS_BASE_URL }}
+      NEXT_PUBLIC_TONG_EXTENSION_ZIP_URL: ${{ vars.NEXT_PUBLIC_TONG_EXTENSION_ZIP_URL }}
+      NEXT_PUBLIC_TONG_YOUTUBE_DEMO_URL: ${{ vars.NEXT_PUBLIC_TONG_YOUTUBE_DEMO_URL }}
+      NEXT_PUBLIC_TONG_DEMO_PASSWORD_HINT: ${{ vars.NEXT_PUBLIC_TONG_DEMO_PASSWORD_HINT }}
+      TONG_ASSETS_R2_BUCKET: ${{ vars.TONG_ASSETS_R2_BUCKET }}
+      TONG_RUNTIME_ASSET_MANIFEST_KEY: ${{ vars.TONG_RUNTIME_ASSET_MANIFEST_KEY }}
+      TONG_CLIENT_WORKER_NAME: ${{ vars.TONG_CLIENT_WORKER_NAME }}
+      TONG_CLIENT_WORKERS_URL: ${{ vars.TONG_CLIENT_WORKERS_URL }}
+      DISCORD_ROUTE_HUMAN_ENDPOINT: ${{ vars.DISCORD_ROUTE_HUMAN_ENDPOINT }}
+      DISCORD_ROUTE_HUMAN_MENTION: ${{ vars.DISCORD_ROUTE_HUMAN_MENTION }}
+      ROUTE_HUMAN_WEBHOOK_SECRET: ${{ secrets.ROUTE_HUMAN_WEBHOOK_SECRET }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: apps/client/package-lock.json
+
+      - id: deploy
+        continue-on-error: true
+        env:
+          TONG_DEPLOY_ENV: staging
+          TONG_DEPLOY_REF: ${{ inputs.ref }}
+          TONG_DEPLOY_PR_NUMBER: ${{ inputs.pr_number }}
+          TONG_DEPLOY_ISSUE_REF: ${{ inputs.issue_ref }}
+          TONG_DEPLOY_NOTE: ${{ inputs.note }}
+          TONG_DEPLOY_SUMMARY_PATH: ${{ runner.temp }}/deployment-summary.json
+        run: ./scripts/deploy-client-cloudflare.sh --environment staging --summary-file "$TONG_DEPLOY_SUMMARY_PATH"
+
+      - id: summary
+        if: steps.deploy.outcome == 'success'
+        env:
+          DEPLOY_SUMMARY_PATH: ${{ runner.temp }}/deployment-summary.json
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          summary = json.loads(Path(os.environ["DEPLOY_SUMMARY_PATH"]).read_text(encoding="utf-8"))
+          lines = [
+              "Staging deployment completed.",
+              "",
+              f"- Environment: `{summary['environment']}`",
+              f"- Ref: `{summary.get('ref') or 'unknown'}`",
+              f"- PR: `{summary.get('pr_number') or 'none'}`",
+              f"- Issue: `{summary.get('issue_ref') or 'none'}`",
+              f"- Public URL: {summary['public_url']}",
+              f"- Workers URL: {summary['workers_url']}",
+              f"- API base: `{summary['api_base']}`",
+              f"- Assets base: `{summary['assets_base_url']}`",
+              f"- Assets bucket: `{summary['assets_bucket']}`",
+              "- Next action: review staging, then promote the same ref through `Deploy Production` once approved.",
+          ]
+          if summary.get("note"):
+              lines.insert(8, f"- Note: {summary['note']}")
+
+          Path(os.environ["RUNNER_TEMP"]).joinpath("deployment-report.md").write_text(
+              "\n".join(lines).strip() + "\n",
+              encoding="utf-8",
+          )
+          output_path = Path(os.environ["GITHUB_OUTPUT"])
+          with output_path.open("a", encoding="utf-8") as handle:
+              handle.write(f"public_url<<__CODEX__\n{summary['public_url']}\n__CODEX__\n")
+          PY
+
+      - name: Step summary
+        if: steps.deploy.outcome == 'success'
+        run: cat "$RUNNER_TEMP/deployment-report.md" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Comment PR
+        if: steps.deploy.outcome == 'success' && inputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh pr comment "${{ inputs.pr_number }}" --repo "${{ github.repository }}" --body-file "$RUNNER_TEMP/deployment-report.md"
+
+      - name: Comment issue
+        if: steps.deploy.outcome == 'success' && inputs.pr_number == '' && inputs.issue_ref != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ inputs.issue_ref }}
+        run: gh issue comment "${ISSUE_NUMBER##*#}" --repo "${{ github.repository }}" --body-file "$RUNNER_TEMP/deployment-report.md"
+
+      - name: Build failure report
+        if: steps.deploy.outcome != 'success'
+        env:
+          DEPLOY_REF: ${{ inputs.ref }}
+          ISSUE_REF: ${{ inputs.issue_ref }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          NOTE: ${{ inputs.note }}
+          SOURCE_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          python3 - <<'PY'
+          import os
+          from pathlib import Path
+
+          lines = [
+              "Staging deployment failed.",
+              "",
+              "- Environment: `staging`",
+              f"- Ref: `{os.environ.get('DEPLOY_REF') or 'unknown'}`",
+              f"- PR: `{os.environ.get('PR_NUMBER') or 'none'}`",
+              f"- Issue: `{os.environ.get('ISSUE_REF') or 'none'}`",
+              f"- Workflow run: {os.environ['SOURCE_URL']}",
+              "- Next action: inspect the failing deploy job, then rerun staging or route the blocker to a human reviewer.",
+          ]
+          if os.environ.get("NOTE"):
+              lines.insert(6, f"- Note: {os.environ['NOTE']}")
+          Path(os.environ["RUNNER_TEMP"]).joinpath("deployment-failure.md").write_text(
+              "\n".join(lines).strip() + "\n",
+              encoding="utf-8",
+          )
+          PY
+
+      - name: Failure summary
+        if: steps.deploy.outcome != 'success'
+        run: cat "$RUNNER_TEMP/deployment-failure.md" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Comment PR failure
+        if: steps.deploy.outcome != 'success' && inputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh pr comment "${{ inputs.pr_number }}" --repo "${{ github.repository }}" --body-file "$RUNNER_TEMP/deployment-failure.md"
+
+      - name: Comment issue failure
+        if: steps.deploy.outcome != 'success' && inputs.pr_number == '' && inputs.issue_ref != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ inputs.issue_ref }}
+        run: gh issue comment "${ISSUE_NUMBER##*#}" --repo "${{ github.repository }}" --body-file "$RUNNER_TEMP/deployment-failure.md"
+
+      - name: Route failure to human review
+        if: steps.deploy.outcome != 'success' && inputs.issue_ref != '' && env.DISCORD_ROUTE_HUMAN_ENDPOINT != '' && env.ROUTE_HUMAN_WEBHOOK_SECRET != ''
+        continue-on-error: true
+        env:
+          ISSUE_REF: ${{ inputs.issue_ref }}
+          DEPLOY_REF: ${{ inputs.ref }}
+          NOTE: ${{ inputs.note }}
+          SOURCE_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import urllib.request
+
+          notes = [
+              f"Staging deploy failed for ref {os.environ.get('DEPLOY_REF') or os.environ.get('ISSUE_REF')}.",
+              "Open the workflow run and deployment summary for the exact blocker context.",
+          ]
+          if os.environ.get("NOTE"):
+              notes.append(os.environ["NOTE"])
+
+          payload = {
+              "repository": os.environ["GITHUB_REPOSITORY"],
+              "issueRef": os.environ["ISSUE_REF"],
+              "action": "deploy-staging-failed",
+              "mention": os.environ.get("DISCORD_ROUTE_HUMAN_MENTION", ""),
+              "notes": notes,
+              "sourceUrl": os.environ["SOURCE_URL"],
+          }
+
+          request = urllib.request.Request(
+              os.environ["DISCORD_ROUTE_HUMAN_ENDPOINT"],
+              data=json.dumps(payload).encode("utf-8"),
+              headers={
+                  "Authorization": f"Bearer {os.environ['ROUTE_HUMAN_WEBHOOK_SECRET']}",
+                  "Content-Type": "application/json",
+              },
+              method="POST",
+          )
+          with urllib.request.urlopen(request) as response:
+              if response.status >= 300:
+                  raise SystemExit(f"route-human endpoint returned {response.status}")
+          PY
+
+      - name: Fail job when deploy step failed
+        if: steps.deploy.outcome != 'success'
+        run: exit 1

--- a/.github/workflows/issue-queue-orchestrator.yml
+++ b/.github/workflows/issue-queue-orchestrator.yml
@@ -1,0 +1,253 @@
+name: Issue Queue Orchestrator
+
+on:
+  schedule:
+    - cron: "17 2 * * *"
+  workflow_dispatch:
+    inputs:
+      action:
+        description: "queue | run | retry | hold | route-human"
+        required: false
+        type: string
+        default: "queue"
+      issue_ref:
+        description: "Optional issue ref, e.g. erniesg/tong#123"
+        required: false
+        type: string
+      dry_run:
+        description: "Preview without dispatching provider workflows"
+        required: false
+        type: boolean
+        default: true
+      max_dispatches:
+        description: "Maximum issues to dispatch in one run"
+        required: false
+        type: string
+        default: "2"
+      provider:
+        description: "Provider override: auto | codex | claude"
+        required: false
+        type: string
+        default: "auto"
+  issue_comment:
+    types: [created]
+
+permissions:
+  actions: write
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: issue-queue-orchestrator-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  resolve:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'issue_comment'
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.resolve.outputs.should_run }}
+      requested: ${{ steps.resolve.outputs.requested }}
+      reason: ${{ steps.resolve.outputs.reason }}
+      action: ${{ steps.resolve.outputs.action }}
+      issue_ref: ${{ steps.resolve.outputs.issue_ref }}
+      dry_run: ${{ steps.resolve.outputs.dry_run }}
+      max_dispatches: ${{ steps.resolve.outputs.max_dispatches }}
+      provider: ${{ steps.resolve.outputs.provider }}
+      source_issue_number: ${{ steps.resolve.outputs.source_issue_number }}
+      source_is_pr: ${{ steps.resolve.outputs.source_is_pr }}
+      command_text: ${{ steps.resolve.outputs.command_text }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - id: resolve
+        env:
+          ISSUE_QUEUE_TRUSTED_LOGINS: ${{ vars.ISSUE_QUEUE_TRUSTED_LOGINS }}
+        run: python3 .agents/skills/_functional-qa/scripts/resolve_issue_queue_request.py
+
+      - name: Comment blocker
+        if: github.event_name == 'issue_comment' && steps.resolve.outputs.requested == 'true' && steps.resolve.outputs.should_run != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          cat <<'EOF' > "$RUNNER_TEMP/orchestrator-blocked.md"
+          Repo orchestration did not start.
+
+          Reason: ${{ steps.resolve.outputs.reason }}
+
+          Supported commands:
+          - `/tong queue`
+          - `/tong run #123`
+          - `/tong retry #123`
+          - `/tong hold #123`
+          - `/tong route-human #123`
+
+          Legacy compatibility: `/codex ...` still works for the queue orchestrator.
+          Raw `@codex ...` remains reserved for direct Codex cloud tasks and reviews, not the repo queue orchestrator.
+          EOF
+
+          if [ "${{ steps.resolve.outputs.source_is_pr }}" = "true" ]; then
+            gh pr comment "${{ steps.resolve.outputs.source_issue_number }}" --repo "${{ github.repository }}" --body-file "$RUNNER_TEMP/orchestrator-blocked.md"
+          else
+            gh issue comment "${{ steps.resolve.outputs.source_issue_number }}" --repo "${{ github.repository }}" --body-file "$RUNNER_TEMP/orchestrator-blocked.md"
+          fi
+
+  plan_and_dispatch:
+    needs: resolve
+    if: needs.resolve.outputs.should_run == 'true'
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GITHUB_TOKEN: ${{ github.token }}
+      DISCORD_ROUTE_HUMAN_ENDPOINT: ${{ vars.DISCORD_ROUTE_HUMAN_ENDPOINT }}
+      DISCORD_ROUTE_HUMAN_MENTION: ${{ vars.DISCORD_ROUTE_HUMAN_MENTION }}
+      ROUTE_HUMAN_WEBHOOK_SECRET: ${{ secrets.ROUTE_HUMAN_WEBHOOK_SECRET }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - id: plan
+        run: |
+          set -euo pipefail
+          args=(python3 .agents/skills/_functional-qa/scripts/remote_agent_queue.py plan
+            --provider "${{ needs.resolve.outputs.provider }}")
+          if [ -n "${{ needs.resolve.outputs.issue_ref }}" ]; then
+            args+=("${{ needs.resolve.outputs.issue_ref }}")
+          fi
+          queue_dir="$("${args[@]}")"
+          echo "queue_dir=$queue_dir" >> "$GITHUB_OUTPUT"
+
+      - id: dispatch
+        run: |
+          set -euo pipefail
+          args=(python3 .agents/skills/_functional-qa/scripts/dispatch_issue_queue.py
+            --queue-dir "${{ steps.plan.outputs.queue_dir }}"
+            --action "${{ needs.resolve.outputs.action }}"
+            --max-dispatches "${{ needs.resolve.outputs.max_dispatches }}"
+            --json)
+          if [ -n "${{ needs.resolve.outputs.issue_ref }}" ]; then
+            args+=(--issue-ref "${{ needs.resolve.outputs.issue_ref }}")
+          fi
+          if [ "${{ needs.resolve.outputs.dry_run }}" = "true" ]; then
+            args+=(--dry-run)
+          fi
+          "${args[@]}" > "$RUNNER_TEMP/dispatch-summary.json"
+
+      - name: Step summary
+        run: cat "${{ steps.plan.outputs.queue_dir }}/dispatch-summary.md" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Acknowledge source thread
+        if: github.event_name == 'issue_comment' && needs.resolve.outputs.source_issue_number != ''
+        env:
+          SOURCE_ISSUE_NUMBER: ${{ needs.resolve.outputs.source_issue_number }}
+          SOURCE_IS_PR: ${{ needs.resolve.outputs.source_is_pr }}
+          ACTION_NAME: ${{ needs.resolve.outputs.action }}
+          DRY_RUN: ${{ needs.resolve.outputs.dry_run }}
+        run: |
+          python3 - <<'PY' > "$RUNNER_TEMP/orchestrator-ack.md"
+          import json
+          import os
+          from pathlib import Path
+
+          summary = json.loads(Path(os.environ["RUNNER_TEMP"]) .joinpath("dispatch-summary.json").read_text(encoding="utf-8"))
+          lines = [
+              "Repo orchestration processed the request.",
+              "",
+              f"- Action: `{os.environ['ACTION_NAME']}`",
+              f"- Dry run: `{os.environ['DRY_RUN']}`",
+              f"- Requested provider: `{summary.get('provider_policy', {}).get('requested_provider', 'auto')}`",
+              f"- Default provider: `{summary.get('provider_policy', {}).get('default_provider', 'codex')}`",
+              f"- Dispatched: `{summary['counts']['dispatched']}`",
+              f"- Skipped: `{summary['counts']['skipped']}`",
+              "",
+          ]
+          if summary["launched"]:
+              lines.append("Launched:")
+              for item in summary["launched"][:5]:
+                  lines.append(f"- `{item['issue_ref']}` -> `{item['provider']}` / `{item['branch_name']}` ({item['result']})")
+              lines.append("")
+          if summary["skipped"]:
+              lines.append("Skipped:")
+              for item in summary["skipped"][:5]:
+                  provider = item.get("provider")
+                  provider_text = f" [{provider}]" if provider else ""
+                  lines.append(f"- `{item['issue_ref']}`{provider_text}: {item['reason']}")
+          print("\n".join(lines).strip())
+          PY
+
+          if [ "$SOURCE_IS_PR" = "true" ]; then
+            gh pr comment "$SOURCE_ISSUE_NUMBER" --repo "${{ github.repository }}" --body-file "$RUNNER_TEMP/orchestrator-ack.md"
+          else
+            gh issue comment "$SOURCE_ISSUE_NUMBER" --repo "${{ github.repository }}" --body-file "$RUNNER_TEMP/orchestrator-ack.md"
+          fi
+
+      - name: Notify Discord app on route-human
+        if: needs.resolve.outputs.action == 'route-human' && env.DISCORD_ROUTE_HUMAN_ENDPOINT != '' && env.ROUTE_HUMAN_WEBHOOK_SECRET != ''
+        continue-on-error: true
+        env:
+          ACTION_NAME: ${{ needs.resolve.outputs.action }}
+          ISSUE_REF: ${{ needs.resolve.outputs.issue_ref }}
+          SOURCE_ISSUE_NUMBER: ${{ needs.resolve.outputs.source_issue_number }}
+          SOURCE_IS_PR: ${{ needs.resolve.outputs.source_is_pr }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import urllib.request
+          from pathlib import Path
+
+          summary_path = Path(os.environ["RUNNER_TEMP"]) / "dispatch-summary.json"
+          summary = json.loads(summary_path.read_text(encoding="utf-8"))
+          issue_ref = os.environ.get("ISSUE_REF", "").strip()
+          mention = os.environ.get("DISCORD_ROUTE_HUMAN_MENTION", "").strip()
+          notes = []
+          for item in summary.get("skipped", []):
+              if issue_ref and item.get("issue_ref") != issue_ref:
+                  continue
+              reason = str(item.get("reason") or "").strip()
+              if reason:
+                  notes.append(reason)
+          if not notes:
+              for item in summary.get("skipped", [])[:3]:
+                  reason = str(item.get("reason") or "").strip()
+                  if reason:
+                      notes.append(reason)
+
+          payload = {
+              "repository": os.environ["GITHUB_REPOSITORY"],
+              "issueRef": issue_ref,
+              "action": os.environ["ACTION_NAME"],
+              "mention": mention,
+              "notes": notes,
+              "provider": summary.get("provider_policy", {}).get("default_provider", "codex"),
+          }
+          for item in summary.get("launched", []) + summary.get("skipped", []):
+              if issue_ref and item.get("issue_ref") == issue_ref and item.get("provider"):
+                  payload["provider"] = item["provider"]
+                  break
+          source_issue_number = os.environ.get("SOURCE_ISSUE_NUMBER", "").strip()
+          if source_issue_number:
+              source_kind = "pull" if os.environ.get("SOURCE_IS_PR") == "true" else "issues"
+              payload["sourceUrl"] = f"https://github.com/{os.environ['GITHUB_REPOSITORY']}/{source_kind}/{source_issue_number}"
+
+          request = urllib.request.Request(
+              os.environ["DISCORD_ROUTE_HUMAN_ENDPOINT"],
+              data=json.dumps(payload).encode("utf-8"),
+              headers={
+                  "Authorization": f"Bearer {os.environ['ROUTE_HUMAN_WEBHOOK_SECRET']}",
+                  "Content-Type": "application/json",
+              },
+              method="POST",
+          )
+          with urllib.request.urlopen(request) as response:
+              if response.status >= 300:
+                  raise SystemExit(f"Discord route-human endpoint returned {response.status}")
+          PY

--- a/apps/client/wrangler.toml
+++ b/apps/client/wrangler.toml
@@ -28,3 +28,53 @@ TONG_RUNTIME_ASSET_MANIFEST_KEY = "runtime-assets/manifest.json"
 
 [observability.logs]
 enabled = true
+
+[env.staging]
+name = "tong-berlayar-web-staging"
+workers_dev = true
+preview_urls = true
+keep_vars = true
+
+[env.staging.assets]
+binding = "ASSETS"
+directory = ".open-next/assets"
+
+[[env.staging.r2_buckets]]
+binding = "TONG_ASSETS_BUCKET"
+bucket_name = "tong-assets"
+preview_bucket_name = "tong-assets"
+
+[env.staging.vars]
+NEXT_PUBLIC_TONG_PUBLIC_DOMAIN = "staging.tong.berlayar.ai"
+NEXT_PUBLIC_TONG_API_BASE = "https://tong-api.erniesg.workers.dev"
+NEXT_PUBLIC_TONG_ASSETS_BASE_URL = "https://assets.tong.berlayar.ai"
+NEXT_PUBLIC_TONG_EXTENSION_ZIP_URL = "https://github.com/erniesg/tong/archive/refs/heads/main.zip"
+NEXT_PUBLIC_TONG_YOUTUBE_DEMO_URL = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+NEXT_PUBLIC_TONG_DEMO_PASSWORD_HINT = "Ask demo host for access password."
+TONG_ASSETS_R2_BUCKET = "tong-assets"
+TONG_RUNTIME_ASSET_MANIFEST_KEY = "runtime-assets/manifest.json"
+
+[env.production]
+name = "tong-berlayar-web"
+workers_dev = true
+preview_urls = true
+keep_vars = true
+
+[env.production.assets]
+binding = "ASSETS"
+directory = ".open-next/assets"
+
+[[env.production.r2_buckets]]
+binding = "TONG_ASSETS_BUCKET"
+bucket_name = "tong-assets"
+preview_bucket_name = "tong-assets"
+
+[env.production.vars]
+NEXT_PUBLIC_TONG_PUBLIC_DOMAIN = "tong.berlayar.ai"
+NEXT_PUBLIC_TONG_API_BASE = "https://tong-api.erniesg.workers.dev"
+NEXT_PUBLIC_TONG_ASSETS_BASE_URL = "https://assets.tong.berlayar.ai"
+NEXT_PUBLIC_TONG_EXTENSION_ZIP_URL = "https://github.com/erniesg/tong/archive/refs/heads/main.zip"
+NEXT_PUBLIC_TONG_YOUTUBE_DEMO_URL = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+NEXT_PUBLIC_TONG_DEMO_PASSWORD_HINT = "Ask demo host for access password."
+TONG_ASSETS_R2_BUCKET = "tong-assets"
+TONG_RUNTIME_ASSET_MANIFEST_KEY = "runtime-assets/manifest.json"

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -33,3 +33,44 @@ npm --prefix apps/worker run deploy
 - `POST /api/v1/scenes/hangout/respond`
 - `GET /api/v1/learn/sessions`
 - `POST /api/v1/learn/sessions`
+- `POST /api/v1/discord/route-human`
+- `POST /api/v1/discord/interactions`
+
+## Discord route-human app
+
+This worker can host the `route-human` Discord app surface for the issue queue.
+
+Required worker secrets:
+
+- `DISCORD_BOT_TOKEN`
+- `DISCORD_PUBLIC_KEY`
+- `DISCORD_ROUTE_HUMAN_CHANNEL_ID`
+- `GITHUB_ROUTE_HUMAN_TOKEN`
+- `ROUTE_HUMAN_WEBHOOK_SECRET`
+
+Required GitHub repo config for the workflow:
+
+- variable `DISCORD_ROUTE_HUMAN_ENDPOINT`
+  Example: `https://tong-api.erniesg.workers.dev/api/v1/discord/route-human`
+- variable `DISCORD_ROUTE_HUMAN_MENTION`
+  Example: `<@703190962431721492>` or `<@&role_id>`
+- variable `ISSUE_QUEUE_TRUSTED_LOGINS`
+  Example: `tong-route-human-bot`
+- secret `ROUTE_HUMAN_WEBHOOK_SECRET`
+
+Discord app setup:
+
+1. Create a new app in the [Discord Developer Portal](https://discord.com/developers/applications).
+2. Copy the app `Public Key`, `Application ID`, and bot token.
+3. Install the bot to your server with at least `bot` scope and `Send Messages` permission.
+4. Set the app `Interactions Endpoint URL` to:
+   `https://tong-api.erniesg.workers.dev/api/v1/discord/interactions`
+5. Store the worker secrets with `wrangler secret put ...`, then deploy the worker.
+
+Behavior:
+
+- The GitHub workflow posts a signed request to `/api/v1/discord/route-human`.
+- The worker sends a Discord message with buttons for `Run now`, `Retry`, `Hold`, `Need context`, and `Add note`.
+- Button clicks write back to GitHub by posting `/tong ...` comments on the issue, so the repo-native queue orchestrator remains the durable control plane.
+- Legacy `/codex ...` comments still remain accepted by the orchestrator for older cards or manual maintainer fallback.
+- `Add note` opens a Discord modal and mirrors the note back to GitHub as a human review comment.

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -641,6 +641,489 @@ async function readJsonBody(request: Request): Promise<Record<string, any>> {
   return JSON.parse(text);
 }
 
+const DISCORD_API_BASE_URL = 'https://discord.com/api/v10';
+const GITHUB_API_BASE_URL = 'https://api.github.com';
+const GITHUB_ROUTE_HUMAN_USER_AGENT = 'tong-route-human/1.0 (+https://github.com/erniesg/tong)';
+const DISCORD_EPHEMERAL_FLAG = 1 << 6;
+const ROUTE_HUMAN_NOTE_INPUT_ID = 'route_human_note';
+
+type ParsedIssueRef = {
+  repository: string;
+  issueNumber: number;
+  url: string;
+};
+
+type DiscordActor = {
+  id: string;
+  username: string;
+  roleIds: string[];
+};
+
+type RouteHumanInteraction = {
+  action: string;
+  issueRef: string;
+  permissionTag: string;
+};
+
+function parseIssueRef(raw: string | undefined | null): ParsedIssueRef | null {
+  const trimmed = String(raw || '').trim();
+  const match = /^([^#]+)#(\d+)$/.exec(trimmed);
+  if (!match) return null;
+  return {
+    repository: match[1],
+    issueNumber: Number(match[2]),
+    url: `https://github.com/${match[1]}/issues/${match[2]}`,
+  };
+}
+
+function hexToBytes(raw: string): ArrayBuffer {
+  const value = raw.trim();
+  if (!value || value.length % 2 !== 0) {
+    throw new Error('invalid_hex');
+  }
+
+  const bytes = new Uint8Array(value.length / 2);
+  for (let index = 0; index < bytes.length; index += 1) {
+    const pair = value.slice(index * 2, index * 2 + 2);
+    const parsed = Number.parseInt(pair, 16);
+    if (Number.isNaN(parsed)) {
+      throw new Error('invalid_hex');
+    }
+    bytes[index] = parsed;
+  }
+  return bytes.buffer.slice(0);
+}
+
+async function verifyDiscordRequest(bodyText: string, signature: string, timestamp: string, publicKey: string): Promise<boolean> {
+  const key = await crypto.subtle.importKey('raw', hexToBytes(publicKey), { name: 'Ed25519' }, false, ['verify']);
+  return crypto.subtle.verify({ name: 'Ed25519' }, key, hexToBytes(signature), new TextEncoder().encode(`${timestamp}${bodyText}`));
+}
+
+function interactionResponse(type: number, data?: Record<string, unknown>): Response {
+  return jsonResponse(200, data ? { type, data } : { type });
+}
+
+function ephemeralInteractionMessage(content: string): Response {
+  return interactionResponse(4, {
+    content,
+    flags: DISCORD_EPHEMERAL_FLAG,
+  });
+}
+
+function hasRecordedRouteHumanDecision(content: string | undefined | null): boolean {
+  return String(content || '').includes('Decision recorded:');
+}
+
+function buildRecordedRouteHumanSummary(action: string, actor: DiscordActor): string {
+  return `Decision recorded: \`${action}\` by ${actor.username}.`;
+}
+
+function disableRouteHumanActionComponents(components: Array<Record<string, any>> | undefined): Array<Record<string, any>> {
+  return (components || []).map((row) => {
+    if (!Array.isArray(row?.components)) {
+      return row;
+    }
+
+    return {
+      ...row,
+      components: row.components.map((component: Record<string, any>) => {
+        if (component?.type === 2 && typeof component?.custom_id === 'string') {
+          return {
+            ...component,
+            disabled: true,
+          };
+        }
+
+        return component;
+      }),
+    };
+  });
+}
+
+function updateRecordedRouteHumanMessage(interaction: Record<string, any>, action: string, actor: DiscordActor): Response {
+  const existingContent = String(interaction?.message?.content || '').trim();
+  const updatedContent = [existingContent, '', buildRecordedRouteHumanSummary(action, actor)].filter(Boolean).join('\n');
+
+  return interactionResponse(7, {
+    content: updatedContent,
+    allowed_mentions: { parse: [] },
+    components: disableRouteHumanActionComponents(interaction?.message?.components),
+  });
+}
+
+function parseDiscordPermissionTag(mention: string | undefined | null): string {
+  const trimmed = String(mention || '').trim();
+  const userMatch = /^<@!?(\d+)>$/.exec(trimmed);
+  if (userMatch) return `u:${userMatch[1]}`;
+  const roleMatch = /^<@&(\d+)>$/.exec(trimmed);
+  if (roleMatch) return `r:${roleMatch[1]}`;
+  return '*';
+}
+
+function buildDiscordAllowedMentions(mention: string | undefined | null): Record<string, unknown> {
+  const trimmed = String(mention || '').trim();
+  const userMatch = /^<@!?(\d+)>$/.exec(trimmed);
+  if (userMatch) {
+    return {
+      parse: [],
+      users: [userMatch[1]],
+    };
+  }
+
+  const roleMatch = /^<@&(\d+)>$/.exec(trimmed);
+  if (roleMatch) {
+    return {
+      parse: [],
+      roles: [roleMatch[1]],
+    };
+  }
+
+  return { parse: [] };
+}
+
+function buildRouteHumanCustomId(action: string, issueRef: string, permissionTag: string): string {
+  return ['rh', action, issueRef, permissionTag || '*'].join('|');
+}
+
+function parseRouteHumanCustomId(raw: string | undefined | null): RouteHumanInteraction | null {
+  const parts = String(raw || '').split('|');
+  if (parts.length !== 4 || parts[0] !== 'rh') {
+    return null;
+  }
+
+  const [, action, issueRef, permissionTag] = parts;
+  if (!action || !issueRef) {
+    return null;
+  }
+
+  return {
+    action,
+    issueRef,
+    permissionTag: permissionTag || '*',
+  };
+}
+
+function getDiscordActor(interaction: Record<string, any>): DiscordActor {
+  const user = interaction?.member?.user || interaction?.user || {};
+  return {
+    id: String(user?.id || ''),
+    username: String(user?.global_name || user?.username || 'Discord user'),
+    roleIds: Array.isArray(interaction?.member?.roles) ? interaction.member.roles.map((value: unknown) => String(value)) : [],
+  };
+}
+
+function isDiscordActorAllowed(actor: DiscordActor, permissionTag: string): boolean {
+  if (!permissionTag || permissionTag === '*') return true;
+  if (permissionTag.startsWith('u:')) return actor.id === permissionTag.slice(2);
+  if (permissionTag.startsWith('r:')) return actor.roleIds.includes(permissionTag.slice(2));
+  return false;
+}
+
+function collectComponentTextValue(components: Array<Record<string, any>> | undefined, targetId: string): string {
+  for (const component of components || []) {
+    if (component?.custom_id === targetId && typeof component?.value === 'string') {
+      return component.value.trim();
+    }
+
+    if (Array.isArray(component?.components)) {
+      const nested = collectComponentTextValue(component.components, targetId);
+      if (nested) return nested;
+    }
+
+    if (component?.component && typeof component.component === 'object') {
+      const nested = collectComponentTextValue([component.component], targetId);
+      if (nested) return nested;
+    }
+  }
+
+  return '';
+}
+
+async function postDiscordChannelMessage(payload: Record<string, unknown>, env: Record<string, any>): Promise<Record<string, any>> {
+  const channelId = String(env?.DISCORD_ROUTE_HUMAN_CHANNEL_ID || '').trim();
+  const token = String(env?.DISCORD_BOT_TOKEN || '').trim();
+  if (!channelId || !token) {
+    throw new Error('discord_route_human_not_configured');
+  }
+
+  const response = await fetch(`${DISCORD_API_BASE_URL}/channels/${channelId}/messages`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bot ${token}`,
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    throw new Error(`discord_message_failed:${response.status}:${await response.text()}`);
+  }
+
+  return (await response.json()) as Record<string, any>;
+}
+
+async function postGitHubIssueComment(issueRef: string, body: string, env: Record<string, any>): Promise<Record<string, any>> {
+  const parsed = parseIssueRef(issueRef);
+  if (!parsed) {
+    throw new Error('invalid_issue_ref');
+  }
+
+  const token = String(env?.GITHUB_ROUTE_HUMAN_TOKEN || '').trim();
+  if (!token) {
+    throw new Error('github_route_human_not_configured');
+  }
+
+  const response = await fetch(`${GITHUB_API_BASE_URL}/repos/${parsed.repository}/issues/${parsed.issueNumber}/comments`, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      'User-Agent': GITHUB_ROUTE_HUMAN_USER_AGENT,
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+    body: JSON.stringify({ body }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`github_comment_failed:${response.status}:${await response.text()}`);
+  }
+
+  return (await response.json()) as Record<string, any>;
+}
+
+function formatDiscordDecisionComment(action: string, issueRef: string, actor: DiscordActor): string {
+  const sourceLine = `Human review decision from Discord by ${actor.username} (${actor.id}).`;
+
+  if (action === 'need-context') {
+    return [`/tong hold ${issueRef}`, '', 'Need more context before continuing.', sourceLine].join('\n').trim();
+  }
+
+  if (action === 'run' || action === 'retry' || action === 'hold') {
+    return [`/tong ${action} ${issueRef}`, '', sourceLine].join('\n').trim();
+  }
+
+  throw new Error(`unsupported_action:${action}`);
+}
+
+function formatDiscordNoteComment(note: string, actor: DiscordActor): string {
+  return [
+    `Human review note from Discord by ${actor.username} (${actor.id}):`,
+    '',
+    note.trim(),
+  ].join('\n').trim();
+}
+
+async function handleDiscordRouteHumanRequest(request: Request, env: Record<string, any>): Promise<Response> {
+  const expectedSecret = String(env?.ROUTE_HUMAN_WEBHOOK_SECRET || '').trim();
+  if (!expectedSecret) {
+    return jsonResponse(503, { error: 'route_human_webhook_not_configured' });
+  }
+
+  const authorization = request.headers.get('Authorization') || '';
+  if (authorization !== `Bearer ${expectedSecret}`) {
+    return jsonResponse(401, { error: 'unauthorized' });
+  }
+
+  const body = await readJsonBody(request);
+  const issueRef = String(body.issueRef || body.issue_ref || '').trim();
+  const parsedIssue = parseIssueRef(issueRef);
+  if (!parsedIssue) {
+    return jsonResponse(400, { error: 'invalid_issue_ref' });
+  }
+
+  const mention = String(body.mention || '').trim();
+  const permissionTag = parseDiscordPermissionTag(mention);
+  const notes = Array.isArray(body.notes)
+    ? body.notes.map((value: unknown) => String(value).trim()).filter((value: string) => value.length > 0).slice(0, 5)
+    : [];
+  const sourceUrl = String(body.sourceUrl || body.source_url || '').trim();
+  const action = String(body.action || 'route-human').trim() || 'route-human';
+
+  const contentLines = [
+    mention,
+    `Human review requested for \`${issueRef}\``,
+    '',
+    `Repository: \`${parsedIssue.repository}\``,
+    `Issue: ${parsedIssue.url}`,
+    `Action: \`${action}\``,
+  ].filter(Boolean);
+
+  if (notes.length > 0) {
+    contentLines.push('', 'Current notes:');
+    for (const note of notes) {
+      contentLines.push(`- ${note}`);
+    }
+  }
+
+  contentLines.push('', 'Choose one below, or tap `Add note` for free-form context.');
+
+  const linkButtons: Array<Record<string, unknown>> = [
+    {
+      type: 2,
+      style: 5,
+      label: 'Open issue',
+      url: parsedIssue.url,
+    },
+  ];
+
+  if (sourceUrl && sourceUrl !== parsedIssue.url) {
+    linkButtons.push({
+      type: 2,
+      style: 5,
+      label: 'Open source',
+      url: sourceUrl,
+    });
+  }
+
+  const discordPayload = {
+    content: contentLines.join('\n').trim(),
+    allowed_mentions: buildDiscordAllowedMentions(mention),
+    components: [
+      {
+        type: 1,
+        components: [
+          {
+            type: 2,
+            style: 3,
+            label: 'Run now',
+            custom_id: buildRouteHumanCustomId('run', issueRef, permissionTag),
+          },
+          {
+            type: 2,
+            style: 1,
+            label: 'Retry',
+            custom_id: buildRouteHumanCustomId('retry', issueRef, permissionTag),
+          },
+          {
+            type: 2,
+            style: 4,
+            label: 'Hold',
+            custom_id: buildRouteHumanCustomId('hold', issueRef, permissionTag),
+          },
+          {
+            type: 2,
+            style: 2,
+            label: 'Need context',
+            custom_id: buildRouteHumanCustomId('need-context', issueRef, permissionTag),
+          },
+          {
+            type: 2,
+            style: 2,
+            label: 'Add note',
+            custom_id: buildRouteHumanCustomId('note', issueRef, permissionTag),
+          },
+        ],
+      },
+      {
+        type: 1,
+        components: linkButtons,
+      },
+    ],
+  };
+
+  const message = await postDiscordChannelMessage(discordPayload, env);
+  return jsonResponse(200, {
+    ok: true,
+    issueRef,
+    discordMessageId: String(message?.id || ''),
+  });
+}
+
+async function handleDiscordInteractionRequest(request: Request, env: Record<string, any>): Promise<Response> {
+  const publicKey = String(env?.DISCORD_PUBLIC_KEY || '').trim();
+  if (!publicKey) {
+    return jsonResponse(503, { error: 'discord_public_key_not_configured' });
+  }
+
+  const signature = request.headers.get('X-Signature-Ed25519') || request.headers.get('x-signature-ed25519') || '';
+  const timestamp = request.headers.get('X-Signature-Timestamp') || request.headers.get('x-signature-timestamp') || '';
+  const bodyText = await request.text();
+  if (!signature || !timestamp) {
+    return jsonResponse(401, { error: 'missing_signature_headers' });
+  }
+
+  const verified = await verifyDiscordRequest(bodyText, signature, timestamp, publicKey);
+  if (!verified) {
+    return new Response('invalid request signature', { status: 401 });
+  }
+
+  const interaction = bodyText ? JSON.parse(bodyText) : {};
+  if (interaction?.type === 1) {
+    return interactionResponse(1);
+  }
+
+  const actor = getDiscordActor(interaction);
+
+  if (interaction?.type === 3) {
+    const parsed = parseRouteHumanCustomId(interaction?.data?.custom_id);
+    if (!parsed) {
+      return ephemeralInteractionMessage('This review card is not configured for Tong route-human actions.');
+    }
+    if (!isDiscordActorAllowed(actor, parsed.permissionTag)) {
+      return ephemeralInteractionMessage('This review card is assigned to another reviewer.');
+    }
+    if (hasRecordedRouteHumanDecision(interaction?.message?.content)) {
+      return ephemeralInteractionMessage('This review card already recorded a decision.');
+    }
+
+    if (parsed.action === 'note') {
+      return interactionResponse(9, {
+        custom_id: buildRouteHumanCustomId('note-submit', parsed.issueRef, parsed.permissionTag),
+        title: 'Route-human note',
+        components: [
+          {
+            type: 18,
+            label: 'What should happen next?',
+            description: 'Add blockers, clarification, or the decision you want captured.',
+            component: {
+              type: 4,
+              custom_id: ROUTE_HUMAN_NOTE_INPUT_ID,
+              style: 2,
+              max_length: 1000,
+              required: true,
+              placeholder: 'Add context for the issue queue.',
+            },
+          },
+        ],
+      });
+    }
+
+    try {
+      await postGitHubIssueComment(parsed.issueRef, formatDiscordDecisionComment(parsed.action, parsed.issueRef, actor), env);
+    } catch (error) {
+      return ephemeralInteractionMessage(error instanceof Error ? error.message : 'Failed to write back to GitHub.');
+    }
+
+    return updateRecordedRouteHumanMessage(interaction, parsed.action, actor);
+  }
+
+  if (interaction?.type === 5) {
+    const parsed = parseRouteHumanCustomId(interaction?.data?.custom_id);
+    if (!parsed || parsed.action !== 'note-submit') {
+      return ephemeralInteractionMessage('Unsupported modal submission.');
+    }
+    if (!isDiscordActorAllowed(actor, parsed.permissionTag)) {
+      return ephemeralInteractionMessage('This review card is assigned to another reviewer.');
+    }
+
+    const note = collectComponentTextValue(interaction?.data?.components, ROUTE_HUMAN_NOTE_INPUT_ID);
+    if (!note) {
+      return ephemeralInteractionMessage('The note was empty.');
+    }
+
+    try {
+      await postGitHubIssueComment(parsed.issueRef, formatDiscordNoteComment(note, actor), env);
+    } catch (error) {
+      return ephemeralInteractionMessage(error instanceof Error ? error.message : 'Failed to save the note to GitHub.');
+    }
+
+    return ephemeralInteractionMessage(`Saved your note to GitHub for \`${parsed.issueRef}\`.`);
+  }
+
+  return ephemeralInteractionMessage('Unsupported Discord interaction.');
+}
+
 const PLAYTEST_ID_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
 function generatePlaytestId(length = 12): string {
   const bytes = new Uint8Array(length);
@@ -1736,11 +2219,19 @@ async function handleRequest(request: Request): Promise<Response> {
       return noContent();
     }
 
+    const env = (globalThis as any).__env || {};
     const url = new URL(request.url);
     const pathname = url.pathname;
 
+    if (pathname === '/api/v1/discord/interactions' && request.method === 'POST') {
+      return handleDiscordInteractionRequest(request, env);
+    }
+
+    if (pathname === '/api/v1/discord/route-human' && request.method === 'POST') {
+      return handleDiscordRouteHumanRequest(request, env);
+    }
+
     if (pathname === '/health') {
-      const env = (globalThis as any).__env;
       return jsonResponse(200, { ok: true, service: 'tong-api', hasResend: !!env?.RESEND_API_KEY, hasDB: !!env?.DB });
     }
 

--- a/docs/deployment-track.md
+++ b/docs/deployment-track.md
@@ -9,6 +9,7 @@ Keep deployment independent from demo implementation so the same client can run:
 ## Frontend hosting
 1. Fastest path: Vercel for Next.js web build.
 2. Parallel path: Cloudflare Pages/Workers using equivalent client build output.
+3. Shared promotion path: explicit GitHub Environment-backed staging and production workflows.
 
 ## Backend hosting
 1. Local: run in development for integration testing.
@@ -64,6 +65,15 @@ This uploads the runtime asset files to `tong-assets`, publishes the runtime man
 
 `npm run deploy:client:cf` now runs this publish step before the Cloudflare worker deploy so the client build does not point at a stale asset host.
 
+Environment-specific shortcuts:
+
+```bash
+npm run deploy:client:cf:staging
+npm run deploy:client:cf:production
+```
+
+The deploy script accepts `--environment staging|production` and can emit a machine-readable JSON summary with `--summary-file`.
+
 ### Boundary rule
 
 1. Runtime app requests for character, scene, and world content must resolve from `tong-assets`.
@@ -90,6 +100,59 @@ Notes:
 
 ## Demo safety rule
 If remote host fails, switch to `local-mock` and continue the same run-of-show.
+
+## Promotion workflows (`#291`)
+
+Use explicit GitHub Environment-backed promotion workflows instead of ad hoc shell runs:
+
+1. `.github/workflows/deploy-staging.yml`
+2. `.github/workflows/deploy-production.yml`
+
+### Promotion entry points
+
+1. Staging deploys are promoted manually from a validated PR, merge commit, or known-good ref.
+2. Production deploys are promoted manually from an approved source ref only.
+3. Production must stay behind GitHub Environment approval on the `production` environment.
+
+### Environment boundaries
+
+Configure the following as GitHub Environment-scoped variables and secrets on both `staging` and `production`:
+
+1. `CLOUDFLARE_API_TOKEN`
+2. `CLOUDFLARE_ACCOUNT_ID`
+3. `NEXT_PUBLIC_TONG_PUBLIC_DOMAIN`
+4. `NEXT_PUBLIC_TONG_API_BASE`
+5. `NEXT_PUBLIC_TONG_ASSETS_BASE_URL`
+6. `NEXT_PUBLIC_TONG_EXTENSION_ZIP_URL`
+7. `NEXT_PUBLIC_TONG_YOUTUBE_DEMO_URL`
+8. `NEXT_PUBLIC_TONG_DEMO_PASSWORD_HINT`
+9. `TONG_ASSETS_R2_BUCKET`
+10. `TONG_RUNTIME_ASSET_MANIFEST_KEY`
+11. `TONG_CLIENT_WORKER_NAME`
+12. `TONG_CLIENT_WORKERS_URL` (optional override when the Workers URL does not follow the worker name)
+
+Optional human-routing config for deploy failures:
+
+1. `DISCORD_ROUTE_HUMAN_ENDPOINT`
+2. `DISCORD_ROUTE_HUMAN_MENTION`
+3. `ROUTE_HUMAN_WEBHOOK_SECRET`
+
+### Deployment summaries
+
+Both promotion workflows should publish a deployment summary back into GitHub with:
+
+1. environment
+2. source ref
+3. linked PR or issue, when supplied
+4. public URL and Workers URL
+5. success or failure
+6. rollback or next action
+
+### Failure handling
+
+1. If a promoted deploy fails and an `issue_ref` is attached, route the blocker back to the human-review surface.
+2. Do not let failed promotions disappear into raw logs.
+3. Keep production approval separate from merge approval.
 
 ## Current worker path
 1. Worker source: `apps/worker/src/index.ts`

--- a/docs/handoff-notes.md
+++ b/docs/handoff-notes.md
@@ -16,3 +16,9 @@ Current note:
 - Contract touch points: `packages/contracts/**`, `apps/client/app/globals.css`, `apps/client/components/scene/**`, `apps/client/lib/content/shanghai/**`
 - Integration risks: shared scene files and contract fixtures can drift if edited in parallel
 - Next owner: whoever takes the next cross-stream integration pass
+
+- Area: Remote orchestration deploy promotion
+- Scope: GitHub deploy workflows, Cloudflare client deploy script, Discord route-human wiring, and the shared `package.json` script entry
+- Contract touch points: `.github/workflows/**`, `scripts/deploy-client-cloudflare.sh`, `apps/worker/src/index.ts`, `package.json`, `docs/deployment-track.md`
+- Integration risks: `package.json` and workflow entrypoints should not drift from the provider-neutral queue control plane landing in `#293`
+- Next owner: infra-deploy until the promotion workflow PR lands

--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
     "secrets:sync:cf": "./scripts/sync-cf-secrets-from-env.sh",
     "build:client:cf": "npm --prefix apps/client run cf:build",
     "deploy:client:cf": "./scripts/deploy-client-cloudflare.sh",
+    "deploy:client:cf:staging": "./scripts/deploy-client-cloudflare.sh --environment staging",
+    "deploy:client:cf:production": "./scripts/deploy-client-cloudflare.sh --environment production",
     "setup:worktrees": "./scripts/setup-worktrees.sh",
     "codex:cloud-plan": "python .agents/skills/_functional-qa/scripts/codex_cloud_queue.py plan",
     "build:extension": "npm --prefix apps/extension run build",

--- a/scripts/deploy-client-cloudflare.sh
+++ b/scripts/deploy-client-cloudflare.sh
@@ -2,12 +2,95 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-ENV_FILE="${1:-$ROOT_DIR/.env}"
+ENV_FILE="$ROOT_DIR/.env"
+DEPLOY_ENV="${TONG_DEPLOY_ENV:-production}"
+SUMMARY_PATH="${TONG_DEPLOY_SUMMARY_PATH:-}"
+DEPLOY_REF="${TONG_DEPLOY_REF:-${GITHUB_SHA:-}}"
+DEPLOY_PR_NUMBER="${TONG_DEPLOY_PR_NUMBER:-}"
+DEPLOY_ISSUE_REF="${TONG_DEPLOY_ISSUE_REF:-}"
+DEPLOY_NOTE="${TONG_DEPLOY_NOTE:-}"
+
+usage() {
+  cat <<'EOF'
+Usage: ./scripts/deploy-client-cloudflare.sh [options]
+
+Options:
+  --environment, --env <staging|production>  Deployment target (default: production)
+  --env-file <path>                          Optional env file to read fallback values from
+  --summary-file <path>                      Optional JSON summary output path
+  --ref <git-ref>                            Optional source ref to record in the summary
+  --pr-number <number>                       Optional PR number to record in the summary
+  --issue-ref <owner/repo#123>               Optional issue ref to record in the summary
+  --note <text>                              Optional promotion note to record in the summary
+  -h, --help                                 Show this help text
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --environment|--env)
+      DEPLOY_ENV="${2:-}"
+      shift 2
+      ;;
+    --env-file)
+      ENV_FILE="${2:-}"
+      shift 2
+      ;;
+    --summary-file)
+      SUMMARY_PATH="${2:-}"
+      shift 2
+      ;;
+    --ref)
+      DEPLOY_REF="${2:-}"
+      shift 2
+      ;;
+    --pr-number)
+      DEPLOY_PR_NUMBER="${2:-}"
+      shift 2
+      ;;
+    --issue-ref)
+      DEPLOY_ISSUE_REF="${2:-}"
+      shift 2
+      ;;
+    --note)
+      DEPLOY_NOTE="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      if [[ "$1" == /* || "$1" == .* || "$1" == *.env ]]; then
+        ENV_FILE="$1"
+        shift
+      else
+        echo "Unknown argument: $1" >&2
+        usage >&2
+        exit 1
+      fi
+      ;;
+  esac
+done
 
 if ! command -v npx >/dev/null 2>&1; then
   echo "Missing required command: npx" >&2
   exit 1
 fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "Missing required command: python3" >&2
+  exit 1
+fi
+
+case "$DEPLOY_ENV" in
+  staging|production)
+    ;;
+  *)
+    echo "Unsupported deployment environment: $DEPLOY_ENV" >&2
+    exit 1
+    ;;
+esac
 
 read_env_value() {
   local key="$1"
@@ -24,10 +107,26 @@ read_env_value() {
   printf "%s" "${line#*=}"
 }
 
+default_public_domain() {
+  if [[ "$DEPLOY_ENV" == "staging" ]]; then
+    printf "staging.tong.berlayar.ai"
+  else
+    printf "tong.berlayar.ai"
+  fi
+}
+
+default_worker_name() {
+  if [[ "$DEPLOY_ENV" == "staging" ]]; then
+    printf "tong-berlayar-web-staging"
+  else
+    printf "tong-berlayar-web"
+  fi
+}
+
 PUBLIC_DOMAIN="${NEXT_PUBLIC_TONG_PUBLIC_DOMAIN:-}"
 if [[ -z "$PUBLIC_DOMAIN" ]]; then PUBLIC_DOMAIN="$(read_env_value NEXT_PUBLIC_TONG_PUBLIC_DOMAIN)"; fi
 if [[ -z "$PUBLIC_DOMAIN" ]]; then PUBLIC_DOMAIN="${TONG_PUBLIC_DOMAIN:-}"; fi
-if [[ -z "$PUBLIC_DOMAIN" ]]; then PUBLIC_DOMAIN="tong.berlayar.ai"; fi
+if [[ -z "$PUBLIC_DOMAIN" ]]; then PUBLIC_DOMAIN="$(default_public_domain)"; fi
 
 API_BASE="${NEXT_PUBLIC_TONG_API_BASE:-}"
 if [[ -z "$API_BASE" ]]; then API_BASE="$(read_env_value NEXT_PUBLIC_TONG_API_BASE)"; fi
@@ -58,8 +157,20 @@ RUNTIME_ASSET_MANIFEST_KEY="${TONG_RUNTIME_ASSET_MANIFEST_KEY:-}"
 if [[ -z "$RUNTIME_ASSET_MANIFEST_KEY" ]]; then RUNTIME_ASSET_MANIFEST_KEY="$(read_env_value TONG_RUNTIME_ASSET_MANIFEST_KEY)"; fi
 if [[ -z "$RUNTIME_ASSET_MANIFEST_KEY" ]]; then RUNTIME_ASSET_MANIFEST_KEY="runtime-assets/manifest.json"; fi
 
+WRANGLER_ENV="${TONG_CLOUDFLARE_ENV:-}"
+if [[ -z "$WRANGLER_ENV" ]]; then WRANGLER_ENV="$(read_env_value TONG_CLOUDFLARE_ENV)"; fi
+if [[ -z "$WRANGLER_ENV" ]]; then WRANGLER_ENV="$DEPLOY_ENV"; fi
+
+CLIENT_WORKER_NAME="${TONG_CLIENT_WORKER_NAME:-}"
+if [[ -z "$CLIENT_WORKER_NAME" ]]; then CLIENT_WORKER_NAME="$(read_env_value TONG_CLIENT_WORKER_NAME)"; fi
+if [[ -z "$CLIENT_WORKER_NAME" ]]; then CLIENT_WORKER_NAME="$(default_worker_name)"; fi
+
+WORKERS_URL="${TONG_CLIENT_WORKERS_URL:-}"
+if [[ -z "$WORKERS_URL" ]]; then WORKERS_URL="$(read_env_value TONG_CLIENT_WORKERS_URL)"; fi
+if [[ -z "$WORKERS_URL" ]]; then WORKERS_URL="https://${CLIENT_WORKER_NAME}.erniesg.workers.dev"; fi
+
 echo "[1/5] Installing client dependencies..."
-npm --prefix "$ROOT_DIR/apps/client" install
+npm --prefix "$ROOT_DIR/apps/client" ci
 
 echo "[2/5] Publishing runtime assets to R2..."
 NEXT_PUBLIC_TONG_ASSETS_BASE_URL="$ASSETS_BASE_URL" \
@@ -67,24 +178,61 @@ TONG_ASSETS_R2_BUCKET="$ASSETS_BUCKET" \
 TONG_RUNTIME_ASSET_MANIFEST_KEY="$RUNTIME_ASSET_MANIFEST_KEY" \
   npm --prefix "$ROOT_DIR" run runtime-assets:upload
 
-echo "[3/5] Building + deploying Next.js app to Cloudflare Workers (OpenNext)..."
+echo "[3/5] Building Next.js app for Cloudflare Workers (OpenNext)..."
 NEXT_PUBLIC_TONG_PUBLIC_DOMAIN="$PUBLIC_DOMAIN" \
 NEXT_PUBLIC_TONG_API_BASE="$API_BASE" \
 NEXT_PUBLIC_TONG_ASSETS_BASE_URL="$ASSETS_BASE_URL" \
 NEXT_PUBLIC_TONG_EXTENSION_ZIP_URL="$EXTENSION_ZIP_URL" \
 NEXT_PUBLIC_TONG_YOUTUBE_DEMO_URL="$YOUTUBE_DEMO_URL" \
 NEXT_PUBLIC_TONG_DEMO_PASSWORD_HINT="$DEMO_PASSWORD_HINT" \
-  npm --prefix "$ROOT_DIR/apps/client" run cf:deploy
+  npm --prefix "$ROOT_DIR/apps/client" run cf:build
 
-echo "[4/5] Attaching custom domain trigger ($PUBLIC_DOMAIN)..."
+echo "[4/5] Deploying Cloudflare worker environment ($WRANGLER_ENV) + custom domain ($PUBLIC_DOMAIN)..."
 npx --prefix "$ROOT_DIR/apps/client" wrangler deploy \
   --config "$ROOT_DIR/apps/client/wrangler.toml" \
+  --env "$WRANGLER_ENV" \
   --domain "$PUBLIC_DOMAIN" \
   --keep-vars
 
 echo "[5/5] Deployment complete."
 echo
+echo "Deployment environment: $DEPLOY_ENV"
 echo "Public URL: https://$PUBLIC_DOMAIN"
-echo "Workers URL: https://tong-berlayar-web.erniesg.workers.dev"
+echo "Workers URL: $WORKERS_URL"
 echo "API base wired into frontend build: $API_BASE"
 echo "Runtime assets wired into frontend build: $ASSETS_BASE_URL"
+
+if [[ -n "$SUMMARY_PATH" ]]; then
+  mkdir -p "$(dirname "$SUMMARY_PATH")"
+  export DEPLOY_ENV DEPLOY_REF DEPLOY_PR_NUMBER DEPLOY_ISSUE_REF DEPLOY_NOTE
+  export PUBLIC_DOMAIN API_BASE ASSETS_BASE_URL ASSETS_BUCKET RUNTIME_ASSET_MANIFEST_KEY
+  export WRANGLER_ENV CLIENT_WORKER_NAME WORKERS_URL
+  python3 - "$SUMMARY_PATH" <<'PY'
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+summary_path = Path(sys.argv[1])
+payload = {
+    "environment": os.environ.get("DEPLOY_ENV", "production"),
+    "deployed_at": datetime.now(timezone.utc).isoformat(),
+    "ref": os.environ.get("DEPLOY_REF", ""),
+    "pr_number": os.environ.get("DEPLOY_PR_NUMBER", ""),
+    "issue_ref": os.environ.get("DEPLOY_ISSUE_REF", ""),
+    "note": os.environ.get("DEPLOY_NOTE", ""),
+    "public_domain": os.environ["PUBLIC_DOMAIN"],
+    "public_url": f"https://{os.environ['PUBLIC_DOMAIN']}",
+    "workers_url": os.environ["WORKERS_URL"],
+    "api_base": os.environ["API_BASE"],
+    "assets_base_url": os.environ["ASSETS_BASE_URL"],
+    "assets_bucket": os.environ["ASSETS_BUCKET"],
+    "runtime_asset_manifest_key": os.environ["RUNTIME_ASSET_MANIFEST_KEY"],
+    "wrangler_env": os.environ["WRANGLER_ENV"],
+    "client_worker_name": os.environ["CLIENT_WORKER_NAME"],
+}
+summary_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+PY
+  echo "Deployment summary JSON: $SUMMARY_PATH"
+fi


### PR DESCRIPTION
### Motivation

- Remote agent PRs still stop short of a repo-native staging and production promotion path.
- Production must stay human-gated, while staging and deploy failures need explicit GitHub/Discord handoff rather than silent logs.
- Discord `route-human` must keep writing repo-native `/tong ...` comments back to GitHub, with `/codex ...` preserved only as compatibility.

### Description

- Added `deploy-staging.yml` and `deploy-production.yml` with explicit GitHub Environment boundaries, deployment summaries, PR/issue writeback, and route-human failure escalation.
- Added `issue-queue-orchestrator.yml` so repo-native `/tong queue|run|retry|hold|route-human` commands can drive the provider-neutral queue planner and dispatch flow introduced in `#293`.
- Updated `scripts/deploy-client-cloudflare.sh`, `apps/client/wrangler.toml`, and `package.json` to support staging/production promotion, runtime asset publication, and Cloudflare client deploy wiring.
- Updated `apps/worker/src/index.ts` and `apps/worker/README.md` so the Discord route-human surface writes back `/tong ...` comments while still accepting `/codex ...` for legacy compatibility.
- Updated `docs/deployment-track.md` and `docs/handoff-notes.md` to make the staging/production boundary and shared-zone ownership explicit.

### Dependency

- This PR is intentionally stacked on top of `#293` because the orchestrator workflow calls the provider-neutral queue scripts added there.
- Merge order: `#293` first, then this PR.

### Testing

- `bash -n scripts/deploy-client-cloudflare.sh`
- `ruby -e 'require "yaml"; %w[.github/workflows/issue-queue-orchestrator.yml .github/workflows/deploy-staging.yml .github/workflows/deploy-production.yml].each { |p| YAML.load_file(p); puts p }'`
- `git diff --cached --check && git diff --check`
- `python3 .agents/skills/_functional-qa/scripts/test_remote_agent_orchestration.py`
- `python3 .agents/skills/_functional-qa/scripts/remote_agent_queue.py plan erniesg/tong#291`

### How to test

1. Merge or locally include `#293` so the provider-neutral queue scripts exist.
2. Dispatch `Issue Queue Orchestrator` with `/tong route-human #291` or a `workflow_dispatch` action and confirm the workflow resolves repo-native commands while `/codex ...` remains compatibility-only.
3. Run `Deploy Staging` with a known ref and verify the workflow writes a deployment summary plus URLs back to the PR/issue.
4. Confirm `Deploy Production` is bound to the `production` GitHub Environment so promotion still requires explicit human approval.

Fixes #291