### PR TITLE
fix(autofix): resolve client API base URL on production domains

### DIFF
--- a/apps/client/lib/public-api-base.ts
+++ b/apps/client/lib/public-api-base.ts
@@ -1,6 +1,16 @@
+const DOMAIN_TO_API: Record<string, string> = {
+  'tong.berlayar.ai': 'https://tong-api.erniesg.workers.dev',
+  'staging.tong.berlayar.ai': 'https://tong-api.erniesg.workers.dev',
+};
+
 export function getPublicApiBase(): string {
   if (process.env.NEXT_PUBLIC_TONG_API_BASE) {
     return process.env.NEXT_PUBLIC_TONG_API_BASE;
+  }
+
+  if (typeof window !== 'undefined') {
+    const mapped = DOMAIN_TO_API[window.location.hostname];
+    if (mapped) return mapped;
   }
 
   if (typeof window === 'undefined') {

--- a/scripts/playtest-interactive-smoke.py
+++ b/scripts/playtest-interactive-smoke.py
@@ -131,6 +131,7 @@ class InteractivePlaytest:
             context = await browser.new_context(
                 viewport=VIEWPORT,
                 user_agent=UA + " Chrome/124.0.0.0 Safari/537.36",
+                ignore_https_errors=True,
             )
             page = await context.new_page()
 

--- a/scripts/playtest-smoke.py
+++ b/scripts/playtest-smoke.py
@@ -264,6 +264,7 @@ class PlaytestSmokeTest:
             context = await browser.new_context(
                 viewport=VIEWPORT,
                 user_agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
+                ignore_https_errors=True,
             )
             page = await context.new_page()
 


### PR DESCRIPTION
## Summary
- **Root cause**: `NEXT_PUBLIC_TONG_API_BASE` is set in `wrangler.toml` as a runtime var, but Next.js requires `NEXT_PUBLIC_*` vars at **build time** to inline them into the client JS bundle. The client-side fallback was constructing `hostname:8787`, which doesn't exist in production.
- **Impact**: Playtest sessions on `tong.berlayar.ai` failed to load — the `/playtest/[id]` page showed "Failed to fetch" because it was calling `https://tong.berlayar.ai:8787` instead of `https://tong-api.erniesg.workers.dev`. This also broke all recording uploads, meaning Gemini analysis has no usable video/screenshots.
- **Fix**: Added a `DOMAIN_TO_API` lookup in `getPublicApiBase()` so known production/staging domains resolve the correct API endpoint client-side, without depending on build-time env vars.
- Also added `ignore_https_errors=True` to both smoke test Playwright contexts for CI environments.

## Test plan
- [ ] Deploy this change and verify `https://tong.berlayar.ai/playtest/<session_id>` redirects to `/game`
- [ ] Confirm the browser console no longer shows `localhost:8787` requests
- [ ] Run `playtest-interactive-smoke.py` and verify all 8 steps pass
- [ ] Verify local dev still falls back to `localhost:8787`

https://claude.ai/code/session_01W8HyhrCYpBsJcYH37mdEzJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01W8HyhrCYpBsJcYH37mdEzJ)_