### PR TITLE
fix(autofix): resolve DNS cache overflow and production API base URL

### DIFF
--- a/apps/client/app/backstage/playtest/page.tsx
+++ b/apps/client/app/backstage/playtest/page.tsx
@@ -279,9 +279,14 @@ export default function PlaytestViewerPage() {
     fetchSessions().then(async (list) => {
       setSessions(list);
       setLoading(false);
-      const metas = await Promise.allSettled(
-        list.map((s) => fetchDeviceMeta(s.sessionId)),
-      );
+      const BATCH = 5;
+      const metas: PromiseSettledResult<DeviceMeta | null>[] = [];
+      for (let i = 0; i < list.length; i += BATCH) {
+        const batch = await Promise.allSettled(
+          list.slice(i, i + BATCH).map((s) => fetchDeviceMeta(s.sessionId)),
+        );
+        metas.push(...batch);
+      }
       setSessions((prev) =>
         prev.map((s, i) => ({
           ...s,

--- a/apps/client/lib/public-api-base.ts
+++ b/apps/client/lib/public-api-base.ts
@@ -3,6 +3,10 @@ export function getPublicApiBase(): string {
     return process.env.NEXT_PUBLIC_TONG_API_BASE;
   }
 
+  if (typeof window !== 'undefined' && window.location.hostname === 'tong.berlayar.ai') {
+    return 'https://tong-api.erniesg.workers.dev';
+  }
+
   if (typeof window === 'undefined') {
     return 'http://localhost:8787';
   }

--- a/scripts/playtest-interactive-smoke.py
+++ b/scripts/playtest-interactive-smoke.py
@@ -43,14 +43,24 @@ def write_json(path: Path, payload: Any) -> None:
 
 
 def http_request(url: str, method: str = "GET", data: bytes | None = None,
-                 content_type: str | None = None, timeout: int = 10) -> Any:
+                 content_type: str | None = None, timeout: int = 30,
+                 retries: int = 3) -> Any:
     import urllib.request
     headers: dict[str, str] = {"User-Agent": UA}
     if content_type:
         headers["Content-Type"] = content_type
-    req = urllib.request.Request(url, data=data, headers=headers, method=method)
-    with urllib.request.urlopen(req, timeout=timeout) as resp:
-        return resp.read(), resp.headers
+    for attempt in range(retries):
+        req = urllib.request.Request(url, data=data, headers=headers, method=method)
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                return resp.read(), resp.headers
+        except urllib.error.HTTPError as e:
+            if e.code in (502, 503, 504) and attempt < retries - 1:
+                wait = 2 ** (attempt + 1)
+                print(f"  ⟳ {e.code} on {method} {url}, retrying in {wait}s...", flush=True)
+                time.sleep(wait)
+                continue
+            raise
 
 
 class InteractivePlaytest:
@@ -131,6 +141,7 @@ class InteractivePlaytest:
             context = await browser.new_context(
                 viewport=VIEWPORT,
                 user_agent=UA + " Chrome/124.0.0.0 Safari/537.36",
+                ignore_https_errors=True,
             )
             page = await context.new_page()
 

--- a/scripts/playtest-smoke.py
+++ b/scripts/playtest-smoke.py
@@ -39,15 +39,25 @@ UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
 
 
 def http_request(url: str, method: str = "GET", data: bytes | None = None,
-                 content_type: str | None = None, timeout: int = 10) -> Any:
+                 content_type: str | None = None, timeout: int = 30,
+                 retries: int = 3) -> Any:
     """HTTP request with browser User-Agent to avoid Cloudflare blocks."""
     import urllib.request
     headers: dict[str, str] = {"User-Agent": UA}
     if content_type:
         headers["Content-Type"] = content_type
-    req = urllib.request.Request(url, data=data, headers=headers, method=method)
-    with urllib.request.urlopen(req, timeout=timeout) as resp:
-        return resp.read(), resp.headers
+    for attempt in range(retries):
+        req = urllib.request.Request(url, data=data, headers=headers, method=method)
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                return resp.read(), resp.headers
+        except urllib.error.HTTPError as e:
+            if e.code in (502, 503, 504) and attempt < retries - 1:
+                wait = 2 ** (attempt + 1)
+                print(f"  ⟳ {e.code} on {method} {url}, retrying in {wait}s...", flush=True)
+                time.sleep(wait)
+                continue
+            raise
 
 
 def utc_stamp() -> str:
@@ -264,6 +274,7 @@ class PlaytestSmokeTest:
             context = await browser.new_context(
                 viewport=VIEWPORT,
                 user_agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
+                ignore_https_errors=True,
             )
             page = await context.new_page()
 


### PR DESCRIPTION
## Summary
- **Backstage playtest page**: Batch concurrent `fetchDeviceMeta` calls (5 at a time) instead of firing 50+ simultaneous `Promise.allSettled` requests, which overwhelmed Cloudflare's DNS cache causing 503 "DNS cache overflow" errors
- **Production API base URL**: Fix `getPublicApiBase()` to detect `tong.berlayar.ai` and return `https://tong-api.erniesg.workers.dev` instead of falling back to `localhost:8787` (the `NEXT_PUBLIC_TONG_API_BASE` env var is set in `wrangler.toml` as a runtime var but Next.js needs it at build time for client-side inlining)
- **Smoke test resilience**: Add retry with exponential backoff for 502/503/504 errors and `ignore_https_errors` for headless CI environments in both `playtest-smoke.py` and `playtest-interactive-smoke.py`

## Test plan
- [ ] Type check passes (`npx tsc --noEmit`)
- [ ] Deploy to production and verify playtest page redirects to `/game` instead of showing "Could not load session"
- [ ] Verify backstage /backstage/playtest loads without 503 errors when fetching device metadata
- [ ] Run `python3 scripts/playtest-smoke.py` against production after deploy

Auto-fix from daily pipeline run 2026-04-27.

https://claude.ai/code/session_01QfGfbeH9thi7ytgXsdjy2M

---
_Generated by [Claude Code](https://claude.ai/code/session_01QfGfbeH9thi7ytgXsdjy2M)_