### PR TITLE
fix(autofix): add production domain fallback for API base URL

### DIFF
--- a/apps/client/lib/public-api-base.ts
+++ b/apps/client/lib/public-api-base.ts
@@ -1,3 +1,10 @@
+const PRODUCTION_API = 'https://tong-api.erniesg.workers.dev';
+
+const KNOWN_DOMAINS: Record<string, string> = {
+  'tong.berlayar.ai': PRODUCTION_API,
+  'staging.tong.berlayar.ai': PRODUCTION_API,
+};
+
 export function getPublicApiBase(): string {
   if (process.env.NEXT_PUBLIC_TONG_API_BASE) {
     return process.env.NEXT_PUBLIC_TONG_API_BASE;
@@ -7,6 +14,16 @@ export function getPublicApiBase(): string {
     return 'http://localhost:8787';
   }
 
+  const hostname = window.location.hostname;
+
+  if (KNOWN_DOMAINS[hostname]) {
+    return KNOWN_DOMAINS[hostname];
+  }
+
+  if (hostname.endsWith('.tong-berlayar-web.pages.dev')) {
+    return PRODUCTION_API;
+  }
+
   const protocol = window.location.protocol === 'https:' ? 'https:' : 'http:';
-  return `${protocol}//${window.location.hostname}:8787`;
+  return `${protocol}//${hostname}:8787`;
 }


### PR DESCRIPTION
## Summary
- The deployed client at `tong.berlayar.ai` has `NEXT_PUBLIC_TONG_API_BASE` not baked into the JS bundle, causing `getPublicApiBase()` to fall back to `hostname:8787` which doesn't exist in production
- All playtest sessions fail with `ERR_CONNECTION_REFUSED` because the client tries to reach `https://tong.berlayar.ai:8787` instead of `https://tong-api.erniesg.workers.dev`
- This adds a hardcoded fallback map for known production/staging domains so the client works even when the env var is missing from the build

## Root cause
The `NEXT_PUBLIC_TONG_API_BASE` env var must be set at **build time** for Next.js to inline it. The wrangler.toml `[vars]` section has it, but those are runtime Worker bindings — they aren't available during `next build` unless also set as a shell env var. The last deployment was built without it.

## Test plan
- [ ] Verify `tsc --noEmit` passes (confirmed locally)
- [ ] After deploy, verify `tong.berlayar.ai/playtest/<id>` redirects to `/game` and the API calls succeed
- [ ] Verify localhost dev still falls back to `localhost:8787`

Auto-fix from daily pipeline run 2026-04-28.

https://claude.ai/code/session_01GiAs1BY4neMc6kK8EvsDEB

---
_Generated by [Claude Code](https://claude.ai/code/session_01GiAs1BY4neMc6kK8EvsDEB)_