### PR TITLE
fix(autofix): fix production API base fallback and null seed in playtest URL

### DIFF
--- a/apps/client/app/playtest/[id]/page.tsx
+++ b/apps/client/app/playtest/[id]/page.tsx
@@ -106,8 +106,7 @@ function buildGameUrl(config: PlaytestConfig): string {
     params.set('lang', config.language);
   }
 
-  // Propagate deterministic seed when present (no built-in game support yet — pass as extra param for future use)
-  if (config.seed !== undefined) {
+  if (config.seed != null) {
     params.set('seed', String(config.seed));
   }
 

--- a/apps/client/lib/public-api-base.ts
+++ b/apps/client/lib/public-api-base.ts
@@ -7,6 +7,11 @@ export function getPublicApiBase(): string {
     return 'http://localhost:8787';
   }
 
+  const hostname = window.location.hostname;
+  if (hostname === 'tong.berlayar.ai') {
+    return 'https://tong-api.erniesg.workers.dev';
+  }
+
   const protocol = window.location.protocol === 'https:' ? 'https:' : 'http:';
-  return `${protocol}//${window.location.hostname}:8787`;
+  return `${protocol}//${hostname}:8787`;
 }


### PR DESCRIPTION
## Summary\n\n- **Production API base**: `getPublicApiBase()` now returns `https://tong-api.erniesg.workers.dev` when running on `tong.berlayar.ai`, instead of trying unreachable port 8787 on the same host. This fixes the playtest page failing to load session config in production.\n- **Null seed in URL**: `buildGameUrl` no longer appends `seed=null` to the game URL when the session has no seed configured (checks `!= null` instead of `!== undefined`).\n\n## Test plan\n\n- [x] `npx tsc --noEmit` passes\n- [ ] Deploy and verify playtest page redirects to /game correctly on tong.berlayar.ai\n- [ ] Verify no `seed=null` in game URL when session has no seed\n\nAuto-fix from daily playtest pipeline.\n\nhttps://claude.ai/code/session_01TgHJugQr6weWQirZzYNEZs

---
_Generated by [Claude Code](https://claude.ai/code/session_01TgHJugQr6weWQirZzYNEZs)_