### PR TITLE
fix(autofix): align interactive smoke test selectors with PlaytestOverlay UI

### DIFF
--- a/scripts/playtest-interactive-smoke.py
+++ b/scripts/playtest-interactive-smoke.py
@@ -86,24 +86,43 @@ class InteractivePlaytest:
         return path
 
     async def get_annotation_count(self, page: Page) -> int:
-        """Read the annotation count from the pill toolbar."""
-        # Try expanded pill notes first
-        el = page.locator(".playtest-pill-notes")
-        if await el.count() > 0:
-            text = await el.text_content()
-            try:
-                return int(text.split()[0])
-            except (ValueError, IndexError):
-                pass
+        """Read the annotation count from the Notes button or pill badge."""
+        import re
+        # Try the Notes button text (visible when pill is expanded in tools view)
+        notes_btn = page.locator(".playtest-tool[title='Notes']")
+        if await notes_btn.count() > 0:
+            text = await notes_btn.text_content() or ""
+            m = re.search(r'(\d+)', text)
+            if m:
+                return int(m.group(1))
         # Try collapsed pill badge
         badge = page.locator(".playtest-pill-badge")
         if await badge.count() > 0:
-            text = await badge.text_content()
-            try:
-                return int(text.strip())
-            except (ValueError, IndexError):
-                pass
+            text = await badge.text_content() or ""
+            m = re.search(r'(\d+)', text)
+            if m:
+                return int(m.group(1))
         return 0
+
+    async def ensure_tools_view(self, page: Page) -> None:
+        """Dismiss AI reply/comment panels and return to tools view."""
+        # Dismiss AI reply if present
+        ai_skip = page.locator(".playtest-btn-small.playtest-btn-muted", has_text="Skip")
+        if await ai_skip.count() > 0:
+            await ai_skip.evaluate("el => el.click()")
+            await asyncio.sleep(0.5)
+        # Cancel comment panel if present
+        cancel_btn = page.locator(".playtest-btn-small.playtest-btn-muted", has_text="Cancel")
+        if await cancel_btn.count() > 0:
+            await cancel_btn.evaluate("el => el.click()")
+            await asyncio.sleep(0.3)
+        # Ensure pill is expanded
+        pill_expanded = page.locator(".playtest-pill-expanded")
+        if await pill_expanded.count() == 0:
+            pill_toggle = page.locator(".playtest-pill-toggle")
+            if await pill_toggle.count() > 0:
+                await pill_toggle.evaluate("el => el.click()")
+                await asyncio.sleep(0.5)
 
     async def run(self) -> bool:
         print(f"\n{'='*60}")
@@ -131,6 +150,7 @@ class InteractivePlaytest:
             context = await browser.new_context(
                 viewport=VIEWPORT,
                 user_agent=UA + " Chrome/124.0.0.0 Safari/537.36",
+                ignore_https_errors=True,
             )
             page = await context.new_page()
 
@@ -174,15 +194,15 @@ class InteractivePlaytest:
             count_before = await self.get_annotation_count(page)
             self.record("Initial annotation count is 0", count_before == 0, f"count={count_before}")
 
-            # 3. Use PEN tool — draw a circle on the game
+            # 3. Use DRAW tool — draw a circle on the game
             print("\n[3/8] Drawing with pen tool...", flush=True)
-            pen_btn = page.locator(".playtest-tool[title='Pen']")
-            await pen_btn.evaluate("el => el.click()")
+            draw_btn = page.locator(".playtest-tool[title='Draw']")
+            await draw_btn.evaluate("el => el.click()")
             await asyncio.sleep(0.3)
 
-            # Verify pen is active
-            pen_active = await pen_btn.evaluate("el => el.classList.contains('playtest-tool-active')")
-            self.record("Pen tool activated", pen_active)
+            # Verify draw tool is active
+            draw_active = await draw_btn.evaluate("el => el.classList.contains('playtest-tool-active')")
+            self.record("Draw tool activated", draw_active)
 
             # Color picker should appear
             colors_visible = await page.locator(".playtest-colors").count() > 0
@@ -195,7 +215,6 @@ class InteractivePlaytest:
                 if box:
                     cx, cy = box["x"] + box["width"] / 2, box["y"] + box["height"] / 2
                     r = 60
-                    # Draw arc via mouse moves
                     import math
                     await page.mouse.move(cx + r, cy)
                     await page.mouse.down()
@@ -209,26 +228,27 @@ class InteractivePlaytest:
                     self.record("Drawing created annotation", count_after_draw == 1, f"count={count_after_draw}")
                     await self.screenshot(page, "after-pen-draw")
             else:
-                self.record("Canvas appeared for pen tool", False, "no .playtest-canvas")
+                self.record("Canvas appeared for draw tool", False, "no .playtest-canvas")
 
-            # Deactivate pen
-            await pen_btn.evaluate("el => el.click()")
-            await asyncio.sleep(0.2)
-
-            # 4. Use HIGHLIGHT tool
-            print("\n[4/8] Highlighting area...", flush=True)
-            highlight_btn = page.locator(".playtest-tool[title='Highlight']")
-            await highlight_btn.evaluate("el => el.click()")
-            await asyncio.sleep(0.3)
-
-            highlight_active = await highlight_btn.evaluate("el => el.classList.contains('playtest-tool-active')")
-            self.record("Highlight tool activated", highlight_active)
+            # 4. Use thick pen (highlight mode) — draw a stroke
+            print("\n[4/8] Drawing with thick pen (highlight)...", flush=True)
+            # Draw tool should still be active; select the thick pen width
+            thick_btns = page.locator(".playtest-pill-row .playtest-tool").all()
+            thick_btns_list = await thick_btns
+            # The second button in the pen-width row is the thick pen
+            if len(thick_btns_list) >= 5:
+                thick_btn = thick_btns_list[4]  # Draw, Comment, Notes, thin, thick
+                await thick_btn.evaluate("el => el.click()")
+                await asyncio.sleep(0.3)
+                thick_active = await thick_btn.evaluate("el => el.classList.contains('playtest-tool-active')")
+                self.record("Thick pen activated", thick_active)
+            else:
+                self.record("Thick pen activated", False, f"found {len(thick_btns_list)} tool buttons")
 
             canvas = page.locator(".playtest-canvas")
             if await canvas.count() > 0:
                 box = await canvas.bounding_box()
                 if box:
-                    # Draw a horizontal highlight stroke
                     start_x = box["x"] + box["width"] * 0.2
                     end_x = box["x"] + box["width"] * 0.8
                     y = box["y"] + box["height"] * 0.4
@@ -240,86 +260,111 @@ class InteractivePlaytest:
                     await asyncio.sleep(0.3)
 
                     count_after_hl = await self.get_annotation_count(page)
-                    self.record("Highlight created annotation", count_after_hl == 2, f"count={count_after_hl}")
-                    await self.screenshot(page, "after-highlight")
+                    self.record("Thick pen created annotation", count_after_hl == 2, f"count={count_after_hl}")
+                    await self.screenshot(page, "after-thick-pen")
 
-            await highlight_btn.evaluate("el => el.click()")
+            # Deactivate draw tool
+            await draw_btn.evaluate("el => el.click()")
             await asyncio.sleep(0.2)
 
             # 5. Use COMMENT tool — pin a comment
             print("\n[5/8] Pinning a comment...", flush=True)
-            comment_btn = page.locator(".playtest-tool[title='Comment']")
+            comment_btn = page.locator(".playtest-tool[title='Comment — tap screen to place']")
             await comment_btn.evaluate("el => el.click()")
-            await asyncio.sleep(0.3)
+            await asyncio.sleep(0.5)
 
-            comment_active = await comment_btn.evaluate("el => el.classList.contains('playtest-tool-active')")
-            self.record("Comment tool activated", comment_active)
+            # Pill collapses and place-overlay appears
+            overlay = page.locator(".playtest-place-overlay")
+            overlay_visible = await overlay.count() > 0
+            self.record("Comment place overlay appeared", overlay_visible)
 
-            # Click on the game area to place comment pin
-            canvas = page.locator(".playtest-canvas")
-            if await canvas.count() > 0:
-                box = await canvas.bounding_box()
-                if box:
-                    await page.mouse.click(box["x"] + box["width"] * 0.6, box["y"] + box["height"] * 0.5)
+            if overlay_visible:
+                # Click on the overlay to place the comment
+                overlay_box = await overlay.bounding_box()
+                if overlay_box:
+                    tap_x = overlay_box["x"] + overlay_box["width"] * 0.6
+                    tap_y = overlay_box["y"] + overlay_box["height"] * 0.5
+                    await page.mouse.click(tap_x, tap_y)
                     await asyncio.sleep(0.5)
 
-                    # Comment popover should appear
-                    popover = page.locator(".playtest-comment-popover")
-                    popover_visible = await popover.count() > 0
-                    self.record("Comment popover appeared", popover_visible)
+                    # Comment input panel should appear
+                    comment_panel = page.locator(".playtest-pill-comment")
+                    panel_visible = await comment_panel.count() > 0
+                    self.record("Comment input panel appeared", panel_visible)
 
-                    if popover_visible:
-                        # Type a comment
+                    if panel_visible:
                         textarea = page.locator(".playtest-comment-input")
                         await textarea.fill("The Tong mascot animation is cute but the Skip button is hard to see")
                         await asyncio.sleep(0.3)
                         await self.screenshot(page, "comment-typed")
 
-                        # Click "Pin" to submit
                         pin_btn = page.locator(".playtest-btn-small", has_text="Pin")
                         await pin_btn.evaluate("el => el.click()")
+                        # Wait for AI reply or tools view to stabilize
+                        try:
+                            await page.locator(".playtest-ai-text").wait_for(timeout=5000)
+                        except Exception:
+                            pass
                         await asyncio.sleep(0.5)
+
+                        # Dismiss AI reply if it appeared, return to tools
+                        await self.ensure_tools_view(page)
 
                         count_after_comment = await self.get_annotation_count(page)
                         self.record("Comment created annotation", count_after_comment == 3, f"count={count_after_comment}")
 
-                        # Check pin dot appeared
-                        pins = page.locator(".playtest-pin")
-                        pin_count = await pins.count()
-                        self.record("Comment pin dot visible", pin_count > 0, f"pins={pin_count}")
+                        # Check marker dot appeared
+                        markers = page.locator(".playtest-marker")
+                        marker_count = await markers.count()
+                        self.record("Comment marker dot visible", marker_count > 0, f"markers={marker_count}")
 
                         await self.screenshot(page, "after-comment-pin")
 
             # 6. Add second comment
             print("\n[6/8] Adding second comment...", flush=True)
-            canvas = page.locator(".playtest-canvas")
-            if await canvas.count() > 0:
-                box = await canvas.bounding_box()
-                if box:
-                    await page.mouse.click(box["x"] + box["width"] * 0.3, box["y"] + box["height"] * 0.7)
-                    await asyncio.sleep(0.5)
+            await self.ensure_tools_view(page)
 
-                    popover = page.locator(".playtest-comment-popover")
-                    if await popover.count() > 0:
-                        textarea = page.locator(".playtest-comment-input")
-                        await textarea.fill("Expected tapping the character to show a translation tooltip")
-                        pin_btn = page.locator(".playtest-btn-small", has_text="Pin")
-                        await pin_btn.evaluate("el => el.click()")
+            comment_btn2 = page.locator(".playtest-tool[title='Comment — tap screen to place']")
+            if await comment_btn2.count() > 0:
+                await comment_btn2.evaluate("el => el.click()")
+                await asyncio.sleep(0.5)
+
+                overlay2 = page.locator(".playtest-place-overlay")
+                if await overlay2.count() > 0:
+                    overlay_box2 = await overlay2.bounding_box()
+                    if overlay_box2:
+                        await page.mouse.click(
+                            overlay_box2["x"] + overlay_box2["width"] * 0.3,
+                            overlay_box2["y"] + overlay_box2["height"] * 0.7,
+                        )
                         await asyncio.sleep(0.5)
 
-                        final_count = await self.get_annotation_count(page)
-                        self.record("Second comment pinned", final_count == 4, f"count={final_count}")
+                        comment_panel2 = page.locator(".playtest-pill-comment")
+                        if await comment_panel2.count() > 0:
+                            textarea2 = page.locator(".playtest-comment-input")
+                            await textarea2.fill("Expected tapping the character to show a translation tooltip")
+                            pin_btn2 = page.locator(".playtest-btn-small", has_text="Pin")
+                            await pin_btn2.evaluate("el => el.click()")
+                            await asyncio.sleep(1.0)
+
+                            await self.ensure_tools_view(page)
+
+                            final_count = await self.get_annotation_count(page)
+                            self.record("Second comment pinned", final_count == 4, f"count={final_count}")
+            else:
+                self.record("Comment button for 2nd comment", False, "button not found")
 
             await self.screenshot(page, "all-annotations-done")
 
             # 7. Verify final state
             print("\n[7/8] Verifying final annotation state...", flush=True)
+            await self.ensure_tools_view(page)
             final_count = await self.get_annotation_count(page)
             self.record("Final annotation count >= 3", final_count >= 3, f"count={final_count}")
 
-            # Check all pin dots
-            total_pins = await page.locator(".playtest-pin").count()
-            self.record("Multiple comment pins visible", total_pins >= 2, f"pins={total_pins}")
+            # Check marker dots (markers are temporal — they fade after ~4s, so at least 1 should be visible)
+            total_markers = await page.locator(".playtest-marker").count()
+            self.record("Comment markers visible", total_markers >= 1, f"markers={total_markers}")
 
             # Save console logs
             write_json(self.logs_dir / "console-messages.json", console_messages)

--- a/scripts/playtest-smoke.py
+++ b/scripts/playtest-smoke.py
@@ -264,6 +264,7 @@ class PlaytestSmokeTest:
             context = await browser.new_context(
                 viewport=VIEWPORT,
                 user_agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
+                ignore_https_errors=True,
             )
             page = await context.new_page()
 


### PR DESCRIPTION
## Summary

- **Fixed stale selectors**: `title='Pen'` → `title='Draw'`, removed non-existent `title='Highlight'` (now thick pen mode), `title='Comment'` → `title='Comment — tap screen to place'`
- **Fixed comment placement flow**: now taps the `.playtest-place-overlay` instead of the canvas, matching the actual UI flow (Comment button → overlay tap → input panel)
- **Fixed annotation counting**: reads from Notes button text or collapsed badge (`.playtest-pill-notes` class never existed)
- **Added `ensure_tools_view()` helper**: dismisses AI reply/comment panels between steps so counts and buttons are readable
- **Added `ignore_https_errors=True`** for headless Chromium
- **Relaxed temporal marker assertion**: markers fade after ~4s, so assert ≥1 instead of ≥2

Auto-fix from daily pipeline run 2026-05-23. All 19 tests now pass (was 0/19 due to crash).

## Test plan

- [x] `python3 scripts/playtest-interactive-smoke.py` — 19/19 PASS against https://tong.berlayar.ai

https://claude.ai/code/session_01AskzL3QywFP21tSdjc6YjU

---
_Generated by [Claude Code](https://claude.ai/code/session_01AskzL3QywFP21tSdjc6YjU)_