### PR TITLE
fix(autofix): add ignore_https_errors to verification smoke test

### DIFF
--- a/scripts/playtest-smoke.py
+++ b/scripts/playtest-smoke.py
@@ -264,6 +264,7 @@ class PlaytestSmokeTest:
             context = await browser.new_context(
                 viewport=VIEWPORT,
                 user_agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
+                ignore_https_errors=True,
             )
             page = await context.new_page()
 


### PR DESCRIPTION
## Summary
- Add `ignore_https_errors=True` to the Playwright browser context in `scripts/playtest-smoke.py`
- Fixes `ERR_CERT_AUTHORITY_INVALID` failure when running the verification smoke test against `tong.berlayar.ai` in CI
- Matches the same fix already applied to the interactive smoke test in PR #326

## Test plan
- [x] Ran verification smoke test against production — 12/12 passed
- [ ] Verify smoke test still passes in CI

Auto-fix from daily pipeline run 2026-06-05.

https://claude.ai/code/session_01LrAJ9tCoWvH6tNXi8yQU7P

---
_Generated by [Claude Code](https://claude.ai/code/session_01LrAJ9tCoWvH6tNXi8yQU7P)_