### PR TITLE
fix: capture real screen recordings in remote playtest sessions

### DIFF
--- a/apps/client/app/game/GamePageClient.tsx
+++ b/apps/client/app/game/GamePageClient.tsx
@@ -1100,6 +1100,7 @@ export default function GamePageClient({
           {entryPhase === 'opening' && (
             <div className="tg-opening-video-wrap">
               <video
+                crossOrigin="anonymous"
                 ref={openingVideoRef}
                 className="tg-opening-video"
                 src={OPENING_ANIMATION_PATH}
@@ -1152,6 +1153,7 @@ export default function GamePageClient({
           {entryPhase === 'tong-intro' && (
             <div className="tg-tong-intro">
               <video
+                crossOrigin="anonymous"
                 className="tg-tong-intro-video"
                 autoPlay
                 muted

--- a/apps/client/app/game/page.tsx
+++ b/apps/client/app/game/page.tsx
@@ -1679,6 +1679,7 @@ export default function GamePage() {
         <div className="game-frame">
           <div className="tg-opening-wrap">
             <video
+              crossOrigin="anonymous"
               ref={openingVideoRef}
               className="tg-opening-vid"
               src={GAME_INTRO_VIDEO_URL}
@@ -1769,6 +1770,7 @@ export default function GamePage() {
             {introStep === 0 && (
               <>
                 <video
+                  crossOrigin="anonymous"
                   className="tg-tong-intro-video"
                 autoPlay
                 muted

--- a/apps/client/app/playtest/[id]/page.tsx
+++ b/apps/client/app/playtest/[id]/page.tsx
@@ -5,6 +5,7 @@ import { useParams, useRouter } from 'next/navigation';
 import { dispatch } from '@/lib/store/game-store';
 import type { CityId, AppLang } from '@/lib/api';
 import { getPublicApiBase } from '@/lib/public-api-base';
+import { setDisplayStream } from '@/lib/playtest/display-stream';
 
 /* ── Types ────────────────────────────────────────────────── */
 
@@ -137,6 +138,15 @@ function primeGameStoreForSession(config: PlaytestConfig) {
 
 type LoadState = 'loading' | 'ready' | 'error';
 
+/* Desktop browsers can contribute a pixel-perfect recording via screen
+   share. getDisplayMedia needs a user gesture, so it must happen here on
+   the entry page — the stream is handed to the overlay via module state. */
+function canOfferHdRecording(): boolean {
+  return typeof navigator !== 'undefined'
+    && Boolean(navigator.mediaDevices?.getDisplayMedia)
+    && window.matchMedia('(pointer: fine)').matches;
+}
+
 export default function PlaytestPage() {
   const params = useParams();
   const router = useRouter();
@@ -145,6 +155,7 @@ export default function PlaytestPage() {
   const [loadState, setLoadState] = useState<LoadState>('loading');
   const [errorMsg, setErrorMsg] = useState('');
   const [gameUrl, setGameUrl] = useState('');
+  const [offerHd, setOfferHd] = useState(false);
 
   const load = useCallback(async () => {
     if (!id) {
@@ -171,6 +182,7 @@ export default function PlaytestPage() {
       markSessionActive(id).catch(() => { /* non-critical */ });
 
       setGameUrl(buildGameUrl(config));
+      setOfferHd(canOfferHdRecording());
       setLoadState('ready');
     } catch (err) {
       setErrorMsg(err instanceof Error ? err.message : 'Failed to load playtest session');
@@ -183,12 +195,28 @@ export default function PlaytestPage() {
   }, [load]);
 
   // Once we have the game URL, navigate using Next.js router (no full page reload,
-  // preserves React tree, sessionStorage, and game store state)
+  // preserves React tree, sessionStorage, and game store state). Desktop
+  // holds at the ready screen so the user can opt into HD screen recording.
   useEffect(() => {
-    if (loadState === 'ready' && gameUrl) {
+    if (loadState === 'ready' && gameUrl && !offerHd) {
       router.push(gameUrl);
     }
-  }, [loadState, gameUrl, router]);
+  }, [loadState, gameUrl, offerHd, router]);
+
+  const startWithHd = useCallback(async () => {
+    try {
+      const stream = await navigator.mediaDevices.getDisplayMedia({
+        video: { displaySurface: 'browser' } as MediaTrackConstraints,
+        audio: false,
+      });
+      setDisplayStream(stream);
+    } catch { /* denied — fall through to standard recording */ }
+    router.push(gameUrl);
+  }, [gameUrl, router]);
+
+  const startWithoutHd = useCallback(() => {
+    router.push(gameUrl);
+  }, [gameUrl, router]);
 
   /* ── Loading ──────────────────────────────────────────────── */
   if (loadState === 'loading') {
@@ -243,7 +271,45 @@ export default function PlaytestPage() {
     );
   }
 
-  /* ── Ready — brief redirect state while router.push navigates ── */
+  /* ── Ready — desktop offers HD screen recording; mobile auto-starts ── */
+  if (offerHd) {
+    return (
+      <div className="scene-root" style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', background: '#0d0d1a', minHeight: '100dvh' }}>
+        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 18, maxWidth: 380, textAlign: 'center', padding: '0 24px' }}>
+          <p style={{ color: 'rgba(255,255,255,0.85)', fontSize: 17, margin: 0, fontFamily: 'var(--font-game, sans-serif)', fontWeight: 600 }}>
+            Ready to playtest
+          </p>
+          <p style={{ color: 'rgba(255,255,255,0.45)', fontSize: 13, margin: 0, fontFamily: 'var(--font-game, sans-serif)' }}>
+            Share this tab to capture a full-quality recording of exactly what you see. You can also continue without it.
+          </p>
+          <button
+            type="button"
+            onClick={() => void startWithHd()}
+            style={{
+              background: '#e8b93e', color: '#1a1408', border: 'none', borderRadius: 24,
+              padding: '12px 28px', fontSize: 15, fontWeight: 700, cursor: 'pointer',
+              fontFamily: 'var(--font-game, sans-serif)',
+            }}
+          >
+            Start &amp; share screen (HD)
+          </button>
+          <button
+            type="button"
+            onClick={startWithoutHd}
+            style={{
+              background: 'transparent', color: 'rgba(255,255,255,0.55)',
+              border: '1px solid rgba(255,255,255,0.2)', borderRadius: 24,
+              padding: '10px 24px', fontSize: 13, cursor: 'pointer',
+              fontFamily: 'var(--font-game, sans-serif)',
+            }}
+          >
+            Continue without
+          </button>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="scene-root" style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', background: '#0d0d1a', minHeight: '100dvh' }}>
       <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 16 }}>

--- a/apps/client/components/city-map/CityMap.tsx
+++ b/apps/client/components/city-map/CityMap.tsx
@@ -258,6 +258,7 @@ export function CityMap({
       {meta.hasVideo && videoSrc ? (
         <>
           <video
+            crossOrigin="anonymous"
             ref={videoARef}
             key={`${city}-A`}
             className="city-map__bg city-map__bg--dissolve"
@@ -278,6 +279,7 @@ export function CityMap({
             <source src={videoSrc} type="video/mp4" />
           </video>
           <video
+            crossOrigin="anonymous"
             ref={videoBRef}
             key={`${city}-B`}
             className="city-map__bg city-map__bg--dissolve"

--- a/apps/client/components/playtest/PlaytestOverlay.tsx
+++ b/apps/client/components/playtest/PlaytestOverlay.tsx
@@ -88,6 +88,33 @@ const freezeAnimationsInClone = (clonedDoc: Document) => {
   });
 };
 
+/* The game loads cross-origin images (assets.tong.berlayar.ai) as plain
+   <img>, so the browser caches them without CORS approval; html2canvas's
+   crossOrigin re-fetch then hits that cache entry and fails, dropping the
+   image from captures. In the clone: add a query param so fetches bypass
+   the poisoned entry (R2 ignores query strings), AND mark the clone img
+   crossorigin — otherwise the clone iframe's own plain load poisons the
+   busted URL before html2canvas's CORS loader gets to it. */
+const bustCrossOriginImagesInClone = (clonedDoc: Document) => {
+  clonedDoc.querySelectorAll('img').forEach((img) => {
+    const src = img.getAttribute('src') || '';
+    if (!src || src.startsWith('data:') || src.startsWith('blob:')) return;
+    try {
+      const u = new URL(src, window.location.href);
+      if (u.origin !== window.location.origin) {
+        u.searchParams.set('playtest-cors', '1');
+        img.setAttribute('crossorigin', 'anonymous');
+        img.setAttribute('src', u.toString());
+      }
+    } catch { /* relative or malformed — leave as-is */ }
+  });
+};
+
+const prepareClone = (clonedDoc: Document) => {
+  freezeAnimationsInClone(clonedDoc);
+  bustCrossOriginImagesInClone(clonedDoc);
+};
+
 const snapshotOptions = (scale: number) => ({
   backgroundColor: '#0d0d1a',
   scale,
@@ -99,9 +126,13 @@ const snapshotOptions = (scale: number) => ({
   scrollY: 0,
   logging: false,
   useCORS: true,
-  allowTaint: true,
+  // allowTaint must stay false: one tainted snapshot painted onto the
+  // recording canvas permanently kills its captureStream (no frames, no
+  // error). Non-CORS images are skipped instead — game asset hosts must
+  // serve CORS headers (tong-assets R2 bucket has a CORS rule for this).
+  allowTaint: false,
   ignoreElements: ignorePlaytestElements,
-  onclone: freezeAnimationsInClone,
+  onclone: prepareClone,
 });
 
 /* Capture the visible page with animation state preserved */

--- a/apps/client/components/playtest/PlaytestOverlay.tsx
+++ b/apps/client/components/playtest/PlaytestOverlay.tsx
@@ -39,6 +39,85 @@ interface Props {
 type Tool = 'none' | 'draw' | 'comment';
 type PanelView = 'tools' | 'notes' | 'comment' | 'ai-reply';
 
+/* Shared html2canvas options — exclude playtest UI from captures */
+const ignorePlaytestElements = (el: Element) => {
+  const cls = el.className || '';
+  return typeof cls === 'string' && (
+    cls.includes('playtest-pill') ||
+    cls.includes('playtest-canvas') ||
+    cls.includes('playtest-place') ||
+    cls.includes('playtest-marker') ||
+    cls.includes('playtest-submitted')
+  );
+};
+
+/* html2canvas clones the DOM into an iframe where CSS animations restart at
+   keyframe 0 — animated elements (fade-ins etc.) render at opacity 0 and
+   captures come out near-black. Before cloning, tag each animated element
+   with its live computed state; in the clone, freeze it at that state.
+   (Matching by attribute, not index — the clone drops script tags.) */
+const FREEZE_ATTR = 'data-playtest-freeze';
+
+const tagAnimatedElements = (): Element[] => {
+  const tagged: Element[] = [];
+  document.documentElement.querySelectorAll('*').forEach((el) => {
+    const cs = window.getComputedStyle(el);
+    if (cs.animationName !== 'none') {
+      el.setAttribute(FREEZE_ATTR, JSON.stringify({
+        o: cs.opacity, t: cs.transform, f: cs.filter,
+      }));
+      tagged.push(el);
+    }
+  });
+  return tagged;
+};
+
+const freezeAnimationsInClone = (clonedDoc: Document) => {
+  clonedDoc.querySelectorAll(`[${FREEZE_ATTR}]`).forEach((el) => {
+    const dst = el as HTMLElement;
+    if (!dst.style) return;
+    try {
+      const s = JSON.parse(dst.getAttribute(FREEZE_ATTR) || '{}');
+      dst.style.animation = 'none';
+      dst.style.transition = 'none';
+      if (s.o) dst.style.opacity = s.o;
+      if (s.t && s.t !== 'none') dst.style.transform = s.t;
+      if (s.f && s.f !== 'none') dst.style.filter = s.f;
+    } catch { /* skip */ }
+  });
+};
+
+const snapshotOptions = (scale: number) => ({
+  backgroundColor: '#0d0d1a',
+  scale,
+  width: window.innerWidth,
+  height: window.innerHeight,
+  windowWidth: window.innerWidth,
+  windowHeight: window.innerHeight,
+  scrollX: 0,
+  scrollY: 0,
+  logging: false,
+  useCORS: true,
+  allowTaint: true,
+  ignoreElements: ignorePlaytestElements,
+  onclone: freezeAnimationsInClone,
+});
+
+/* Capture the visible page with animation state preserved */
+const captureDom = async (scale: number): Promise<HTMLCanvasElement> => {
+  const tagged = tagAnimatedElements();
+  try {
+    return await html2canvas(document.documentElement, snapshotOptions(scale));
+  } finally {
+    tagged.forEach((el) => el.removeAttribute(FREEZE_ATTR));
+  }
+};
+
+/* Snapshot cadence: every tick feeds the video recorder; every 2nd tick
+   (5s) is kept as a filmstrip frame for the replay page. */
+const SNAPSHOT_INTERVAL_MS = 2500;
+const FILMSTRIP_EVERY_NTH = 2;
+
 /* ── Component ────────────────────────────────────────────────────── */
 
 export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClarification }: Props) {
@@ -50,7 +129,8 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
   const timerRef = useRef<ReturnType<typeof setInterval>>();
 
   const frameCaptureRef = useRef<HTMLCanvasElement | null>(null);
-  const frameLoopRef = useRef<number>(0);
+  const snapshotCountRef = useRef(0);
+  const snapshotBusyRef = useRef(false);
 
   const [activeTool, setActiveTool] = useState<Tool>('none');
   const [penColor, setPenColor] = useState('#ff6b2c');
@@ -100,71 +180,61 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
 
   /* ── Frame capture ──────────────────────────────────────────────── */
 
-  const startFrameCapture = useCallback(() => {
-    const target = targetRef.current;
-    if (!target) return;
+  // Hidden canvas that MediaRecorder records via captureStream(). The game is
+  // DOM-rendered (no canvas elements), so frames come from periodic
+  // html2canvas snapshots painted into this canvas — each paint emits a
+  // video frame, producing a low-fps but real recording on every platform.
+  const ensureFrameCaptureCanvas = useCallback((): HTMLCanvasElement => {
     let fc = frameCaptureRef.current;
     if (!fc) {
       fc = document.createElement('canvas');
+      // Match the 0.5-scale snapshots; even dimensions for the video encoder
+      fc.width = Math.max(2, Math.floor(window.innerWidth / 2) & ~1);
+      fc.height = Math.max(2, Math.floor(window.innerHeight / 2) & ~1);
       fc.style.display = 'none';
       document.body.appendChild(fc);
+      const ctx = fc.getContext('2d');
+      if (ctx) {
+        ctx.fillStyle = '#0d0d1a';
+        ctx.fillRect(0, 0, fc.width, fc.height);
+      }
       frameCaptureRef.current = fc;
     }
-    const captureFrame = () => {
-      if (!target) return;
-      const rect = target.getBoundingClientRect();
-      if (fc!.width !== rect.width || fc!.height !== rect.height) {
-        fc!.width = rect.width;
-        fc!.height = rect.height;
-      }
-      const gameCanvases = target.querySelectorAll('canvas');
-      const ctx = fc!.getContext('2d');
-      if (ctx && gameCanvases.length > 0) {
-        ctx.clearRect(0, 0, fc!.width, fc!.height);
-        ctx.fillStyle = '#0d0d1a';
-        ctx.fillRect(0, 0, fc!.width, fc!.height);
-        for (const gc of gameCanvases) {
-          try {
-            const gcRect = gc.getBoundingClientRect();
-            ctx.drawImage(gc, gcRect.left - rect.left, gcRect.top - rect.top, gcRect.width, gcRect.height);
-          } catch { /* tainted */ }
+    return fc;
+  }, []);
+
+  const captureSnapshot = useCallback(async () => {
+    if (snapshotBusyRef.current) return; // html2canvas can be slow; don't overlap
+    snapshotBusyRef.current = true;
+    try {
+      const canvas = await captureDom(0.5);
+      // 1. Paint into the recording canvas → emits a frame on the capture stream
+      const fc = frameCaptureRef.current;
+      const ctx = fc?.getContext('2d');
+      if (fc && ctx) ctx.drawImage(canvas, 0, 0, fc.width, fc.height);
+      // 2. Keep every Nth snapshot as a filmstrip frame for replay
+      if (snapshotCountRef.current % FILMSTRIP_EVERY_NTH === 0) {
+        const blob = await new Promise<Blob | null>((resolve) =>
+          canvas.toBlob(resolve, 'image/jpeg', 0.7),
+        );
+        if (blob && startTimeRef.current) {
+          const ts = Math.floor((Date.now() - startTimeRef.current) / 1000);
+          filmstripRef.current.push({ ts, blob });
+          // Cap at 120 frames (10 min at 5s intervals) to limit memory
+          if (filmstripRef.current.length > 120) filmstripRef.current.shift();
         }
       }
-      frameLoopRef.current = requestAnimationFrame(captureFrame);
-    };
-    frameLoopRef.current = requestAnimationFrame(captureFrame);
-  }, [targetRef]);
+      snapshotCountRef.current++;
+    } catch { /* best-effort */ } finally {
+      snapshotBusyRef.current = false;
+    }
+  }, []);
 
   /* ── Screenshot capture (html2canvas — full DOM) ─────────────── */
 
   const captureScreenshot = useCallback(async (annotationId: string): Promise<void> => {
-    // Capture the full visible page — use documentElement for true full-screen
-    const target = document.documentElement;
     try {
-      const canvas = await html2canvas(target, {
-        backgroundColor: '#0d0d1a',
-        scale: window.devicePixelRatio > 1 ? 1 : 1, // 1x for speed
-        width: window.innerWidth,
-        height: window.innerHeight,
-        windowWidth: window.innerWidth,
-        windowHeight: window.innerHeight,
-        scrollX: 0,
-        scrollY: 0,
-        logging: false,
-        useCORS: true,
-        allowTaint: true,
-        // Ignore the playtest overlay elements so they don't appear in screenshots
-        ignoreElements: (el) => {
-          const cls = el.className || '';
-          return typeof cls === 'string' && (
-            cls.includes('playtest-pill') ||
-            cls.includes('playtest-canvas') ||
-            cls.includes('playtest-place') ||
-            cls.includes('playtest-marker') ||
-            cls.includes('playtest-submitted')
-          );
-        },
-      });
+      const canvas = await captureDom(1);
 
       // Composite drawing overlay on top if active
       const drawingCanvas = canvasRef.current;
@@ -184,9 +254,7 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
     }
   }, []);
 
-  /* ── Recording: getDisplayMedia → captureStream → screenshots-only ── */
-
-  const displayStreamRef = useRef<MediaStream | null>(null);
+  /* ── Recording: snapshot canvas captureStream → screenshots-only ── */
 
   const startRecordingFromStream = useCallback((stream: MediaStream) => {
     const mimeType = MediaRecorder.isTypeSupported('video/webm;codecs=vp9')
@@ -204,44 +272,28 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
     setIsRecording(true);
   }, []);
 
-  const startRecording = useCallback(async () => {
+  const startRecording = useCallback(() => {
     startTimeRef.current = Date.now();
     timerRef.current = setInterval(() => {
       setRecordingTime(Math.floor((Date.now() - startTimeRef.current) / 1000));
     }, 1000);
 
-    // Tier 1: getDisplayMedia — full screen capture (desktop only, needs permission)
-    if (typeof navigator !== 'undefined' && navigator.mediaDevices?.getDisplayMedia) {
-      try {
-        const stream = await navigator.mediaDevices.getDisplayMedia({
-          video: { displaySurface: 'browser' } as MediaTrackConstraints,
-          audio: false,
-        });
-        displayStreamRef.current = stream;
-        // If user stops sharing via browser UI, clean up
-        stream.getVideoTracks()[0]?.addEventListener('ended', () => {
-          displayStreamRef.current = null;
-        });
-        startRecordingFromStream(stream);
-        return;
-      } catch {
-        // User denied or not supported — fall through to Tier 2
-      }
-    }
+    // Note: getDisplayMedia is deliberately not used here — it requires a
+    // user gesture (recording auto-starts) and is unsupported on mobile.
 
-    // Tier 2: canvas.captureStream — captures game canvases only
-    const fc = frameCaptureRef.current;
-    if (fc && typeof fc.captureStream === 'function') {
-      try {
+    // Tier 1: record the snapshot canvas — works on any DOM-rendered scene
+    try {
+      const fc = ensureFrameCaptureCanvas();
+      if (typeof fc.captureStream === 'function') {
         const stream = fc.captureStream(15);
         startRecordingFromStream(stream);
         return;
-      } catch { /* fall through */ }
-    }
+      }
+    } catch { /* fall through */ }
 
-    // Tier 3: screenshots only — no video recording
+    // Tier 2: screenshots only — no video recording
     setIsRecording(true);
-  }, [startRecordingFromStream]);
+  }, [ensureFrameCaptureCanvas, startRecordingFromStream]);
 
   const stopAndSubmit = useCallback(() => {
     if (timerRef.current) clearInterval(timerRef.current);
@@ -285,13 +337,10 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
         : null,
     });
 
-    const timer = setTimeout(() => {
-      startFrameCapture();
-      setTimeout(() => startRecording(), 500);
-    }, 1000);
+    const timer = setTimeout(() => startRecording(), 1500);
     return () => clearTimeout(timer);
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [startFrameCapture, startRecording]);
+  }, [startRecording]);
 
   // Periodic state snapshots every 10s for replay reconstruction
   useEffect(() => {
@@ -306,47 +355,14 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
     return () => clearInterval(interval);
   }, []);
 
-  // Filmstrip: capture full-screen screenshot every 5s for mobile playback
+  // Snapshot loop: feeds the video recorder every tick + filmstrip every Nth
   useEffect(() => {
-    const interval = setInterval(async () => {
+    const interval = setInterval(() => {
       if (!startTimeRef.current) return; // not recording yet
-      try {
-        const canvas = await html2canvas(document.documentElement, {
-          backgroundColor: '#0d0d1a',
-          scale: 0.5, // half resolution for speed + size
-          width: window.innerWidth,
-          height: window.innerHeight,
-          windowWidth: window.innerWidth,
-          windowHeight: window.innerHeight,
-          scrollX: 0,
-          scrollY: 0,
-          logging: false,
-          useCORS: true,
-          allowTaint: true,
-          ignoreElements: (el) => {
-            const cls = el.className || '';
-            return typeof cls === 'string' && (
-              cls.includes('playtest-pill') ||
-              cls.includes('playtest-canvas') ||
-              cls.includes('playtest-place') ||
-              cls.includes('playtest-marker') ||
-              cls.includes('playtest-submitted')
-            );
-          },
-        });
-        const blob = await new Promise<Blob | null>((resolve) =>
-          canvas.toBlob(resolve, 'image/jpeg', 0.7), // JPEG for smaller size
-        );
-        if (blob) {
-          const ts = Math.floor((Date.now() - startTimeRef.current) / 1000);
-          filmstripRef.current.push({ ts, blob });
-          // Cap at 120 frames (10 min at 5s intervals) to limit memory
-          if (filmstripRef.current.length > 120) filmstripRef.current.shift();
-        }
-      } catch { /* best-effort */ }
-    }, 5000);
+      void captureSnapshot();
+    }, SNAPSHOT_INTERVAL_MS);
     return () => clearInterval(interval);
-  }, []);
+  }, [captureSnapshot]);
 
   /* ── Draggable pill ─────────────────────────────────────────────── */
 
@@ -639,7 +655,9 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
         const formData = new FormData();
         formData.append('annotations', JSON.stringify(annotations));
         if (chunksRef.current.length > 0) {
-          formData.append('recording', new Blob(chunksRef.current, { type: 'video/webm' }), `${sessionId}.webm`);
+          const mime = recordingMimeRef.current;
+          const ext = mime.includes('mp4') ? 'mp4' : 'webm';
+          formData.append('recording', new Blob(chunksRef.current, { type: mime }), `${sessionId}.${ext}`);
         }
         navigator.sendBeacon?.(uploadUrl, formData);
       }
@@ -657,13 +675,8 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
   useEffect(() => {
     return () => {
       if (timerRef.current) clearInterval(timerRef.current);
-      if (frameLoopRef.current) cancelAnimationFrame(frameLoopRef.current);
       if (mediaRecorderRef.current?.state !== 'inactive') mediaRecorderRef.current?.stop();
       if (frameCaptureRef.current) { frameCaptureRef.current.remove(); frameCaptureRef.current = null; }
-      if (displayStreamRef.current) {
-        displayStreamRef.current.getTracks().forEach((t) => t.stop());
-        displayStreamRef.current = null;
-      }
       drawHistory.current = [];
       // Revoke all thumbnail URLs
       thumbnails.forEach((url) => URL.revokeObjectURL(url));

--- a/apps/client/components/playtest/PlaytestOverlay.tsx
+++ b/apps/client/components/playtest/PlaytestOverlay.tsx
@@ -110,9 +110,60 @@ const bustCrossOriginImagesInClone = (clonedDoc: Document) => {
   });
 };
 
+/* html2canvas cannot render <video> elements — cinematic scenes captured as
+   black boxes. Before cloning, grab each playing video's current frame as a
+   data URL (taint-tested on a scratch canvas so a non-CORS video can never
+   poison the recording canvas); in the clone, swap the video for an <img>
+   with the same box. Game videos carry crossorigin="anonymous" so the grab
+   stays origin-clean. */
+const VIDEO_FRAME_ATTR = 'data-playtest-video-frame';
+
+const tagVideoFrames = (): Element[] => {
+  const tagged: Element[] = [];
+  document.querySelectorAll('video').forEach((v) => {
+    if (v.readyState < 2 || v.videoWidth === 0) return;
+    const rect = v.getBoundingClientRect();
+    if (rect.width === 0 || rect.height === 0) return;
+    try {
+      const scratch = document.createElement('canvas');
+      const scale = Math.min(1, 640 / v.videoWidth);
+      scratch.width = Math.max(2, Math.round(v.videoWidth * scale));
+      scratch.height = Math.max(2, Math.round(v.videoHeight * scale));
+      const ctx = scratch.getContext('2d');
+      if (!ctx) return;
+      ctx.drawImage(v, 0, 0, scratch.width, scratch.height);
+      // PNG keeps alpha for transparent overlay videos; JPEG otherwise
+      const corner = ctx.getImageData(0, 0, 1, 1).data; // throws if tainted
+      const hasAlpha = corner[3] < 255;
+      const url = scratch.toDataURL(hasAlpha ? 'image/png' : 'image/jpeg', 0.7);
+      v.setAttribute(VIDEO_FRAME_ATTR, url);
+      tagged.push(v);
+    } catch { /* tainted or unreadable — leave as-is (renders blank) */ }
+  });
+  return tagged;
+};
+
+const swapVideosInClone = (clonedDoc: Document) => {
+  clonedDoc.querySelectorAll(`video[${VIDEO_FRAME_ATTR}]`).forEach((v) => {
+    const frame = v.getAttribute(VIDEO_FRAME_ATTR);
+    if (!frame) return;
+    const img = clonedDoc.createElement('img');
+    img.src = frame;
+    img.className = v.className;
+    img.setAttribute('style', v.getAttribute('style') || '');
+    const view = clonedDoc.defaultView || window;
+    const cs = view.getComputedStyle(v);
+    img.style.width = cs.width;
+    img.style.height = cs.height;
+    img.style.objectFit = cs.objectFit || 'cover';
+    v.replaceWith(img);
+  });
+};
+
 const prepareClone = (clonedDoc: Document) => {
   freezeAnimationsInClone(clonedDoc);
   bustCrossOriginImagesInClone(clonedDoc);
+  swapVideosInClone(clonedDoc);
 };
 
 const snapshotOptions = (scale: number) => ({
@@ -135,13 +186,15 @@ const snapshotOptions = (scale: number) => ({
   onclone: prepareClone,
 });
 
-/* Capture the visible page with animation state preserved */
+/* Capture the visible page with animation and video state preserved */
 const captureDom = async (scale: number): Promise<HTMLCanvasElement> => {
   const tagged = tagAnimatedElements();
+  const taggedVideos = tagVideoFrames();
   try {
     return await html2canvas(document.documentElement, snapshotOptions(scale));
   } finally {
     tagged.forEach((el) => el.removeAttribute(FREEZE_ATTR));
+    taggedVideos.forEach((el) => el.removeAttribute(VIDEO_FRAME_ATTR));
   }
 };
 

--- a/apps/client/components/playtest/PlaytestOverlay.tsx
+++ b/apps/client/components/playtest/PlaytestOverlay.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import html2canvas from 'html2canvas';
 import { sessionLogger } from '@/lib/debug/session-logger';
 import { getPublicApiBase } from '@/lib/public-api-base';
+import { takeDisplayStream } from '@/lib/playtest/display-stream';
 
 /* ── Types ────────────────────────────────────────────────────────── */
 
@@ -165,6 +166,12 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
   // Filmstrip: periodic full-DOM screenshots for playback on mobile
   const filmstripRef = useRef<{ ts: number; blob: Blob }[]>([]);
 
+  // Continuous upload: stream recorder chunks to the server during the
+  // session so abandoned sessions (tab closed, no Submit) still have video
+  const uploadedChunkCountRef = useRef(0);
+  const chunkSeqRef = useRef(0);
+  const chunkFlushBusyRef = useRef(false);
+
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const isDrawing = useRef(false);
   const currentPath = useRef<string[]>([]);
@@ -254,7 +261,9 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
     }
   }, []);
 
-  /* ── Recording: snapshot canvas captureStream → screenshots-only ── */
+  /* ── Recording: HD display stream → snapshot canvas → screenshots-only ── */
+
+  const displayStreamRef = useRef<MediaStream | null>(null);
 
   const startRecordingFromStream = useCallback((stream: MediaStream) => {
     const mimeType = MediaRecorder.isTypeSupported('video/webm;codecs=vp9')
@@ -278,10 +287,23 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
       setRecordingTime(Math.floor((Date.now() - startTimeRef.current) / 1000));
     }, 1000);
 
-    // Note: getDisplayMedia is deliberately not used here — it requires a
-    // user gesture (recording auto-starts) and is unsupported on mobile.
+    // Tier 1: HD screen share handed over from the /playtest entry page,
+    // where the user gesture happened (getDisplayMedia can't be called here —
+    // recording auto-starts with no gesture, and mobile doesn't support it).
+    const shared = takeDisplayStream();
+    if (shared) {
+      displayStreamRef.current = shared;
+      shared.getVideoTracks()[0]?.addEventListener('ended', () => {
+        // User stopped sharing via browser UI — keep what we recorded
+        const rec = mediaRecorderRef.current;
+        if (rec && rec.state !== 'inactive') rec.stop();
+        displayStreamRef.current = null;
+      });
+      startRecordingFromStream(shared);
+      return;
+    }
 
-    // Tier 1: record the snapshot canvas — works on any DOM-rendered scene
+    // Tier 2: record the snapshot canvas — works on any DOM-rendered scene
     try {
       const fc = ensureFrameCaptureCanvas();
       if (typeof fc.captureStream === 'function') {
@@ -291,7 +313,7 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
       }
     } catch { /* fall through */ }
 
-    // Tier 2: screenshots only — no video recording
+    // Tier 3: screenshots only — no video recording
     setIsRecording(true);
   }, [ensureFrameCaptureCanvas, startRecordingFromStream]);
 
@@ -363,6 +385,43 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
     }, SNAPSHOT_INTERVAL_MS);
     return () => clearInterval(interval);
   }, [captureSnapshot]);
+
+  /* ── Continuous chunk upload ────────────────────────────────────── */
+
+  // Send recorder chunks accumulated since the last flush. Chunks from one
+  // MediaRecorder session concatenate into a playable file server-side, so
+  // even sessions that never hit Submit leave a recording behind.
+  const flushChunks = useCallback(async (keepalive = false) => {
+    if (chunkFlushBusyRef.current) return;
+    const pending = chunksRef.current.slice(uploadedChunkCountRef.current);
+    if (pending.length === 0) return;
+    chunkFlushBusyRef.current = true;
+    const seq = chunkSeqRef.current;
+    const body = new Blob(pending, { type: recordingMimeRef.current });
+    // keepalive bodies are capped (~64KB); a few seconds of low-fps video
+    // fits, but skip rather than fail loudly if this flush is too large
+    if (keepalive && body.size > 60_000) {
+      chunkFlushBusyRef.current = false;
+      return;
+    }
+    try {
+      const res = await fetch(
+        `${getPublicApiBase()}/api/v1/playtest/sessions/${sessionId}/recording-chunks?seq=${seq}`,
+        { method: 'POST', body, keepalive },
+      );
+      if (res.ok) {
+        uploadedChunkCountRef.current += pending.length;
+        chunkSeqRef.current = seq + 1;
+      }
+    } catch { /* retry on next flush */ } finally {
+      chunkFlushBusyRef.current = false;
+    }
+  }, [sessionId]);
+
+  useEffect(() => {
+    const interval = setInterval(() => { void flushChunks(); }, 10_000);
+    return () => clearInterval(interval);
+  }, [flushChunks]);
 
   /* ── Draggable pill ─────────────────────────────────────────────── */
 
@@ -642,25 +701,24 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
   const uploadUrl = `${getPublicApiBase()}/api/v1/playtest/sessions/${sessionId}/upload`;
 
   useEffect(() => {
-    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
-      if (annotations.length > 0 || chunksRef.current.length > 0) {
+    // partial=1: save artifacts without finalizing the session — hiding the
+    // tab or navigating away must not mark it submitted or trigger analysis
+    const savePartial = () => {
+      void flushChunks(true);
+      if (annotations.length > 0) {
         const formData = new FormData();
         formData.append('annotations', JSON.stringify(annotations));
-        navigator.sendBeacon?.(uploadUrl, formData);
+        navigator.sendBeacon?.(`${uploadUrl}?partial=1`, formData);
+      }
+    };
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (annotations.length > 0 || chunksRef.current.length > 0) {
+        savePartial();
         e.preventDefault();
       }
     };
     const handleVisibilityChange = () => {
-      if (document.visibilityState === 'hidden' && annotations.length > 0) {
-        const formData = new FormData();
-        formData.append('annotations', JSON.stringify(annotations));
-        if (chunksRef.current.length > 0) {
-          const mime = recordingMimeRef.current;
-          const ext = mime.includes('mp4') ? 'mp4' : 'webm';
-          formData.append('recording', new Blob(chunksRef.current, { type: mime }), `${sessionId}.${ext}`);
-        }
-        navigator.sendBeacon?.(uploadUrl, formData);
-      }
+      if (document.visibilityState === 'hidden') savePartial();
     };
     window.addEventListener('beforeunload', handleBeforeUnload);
     document.addEventListener('visibilitychange', handleVisibilityChange);
@@ -668,7 +726,7 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
       window.removeEventListener('beforeunload', handleBeforeUnload);
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
-  }, [annotations, sessionId, uploadUrl]);
+  }, [annotations, sessionId, uploadUrl, flushChunks]);
 
   /* ── Cleanup ────────────────────────────────────────────────────── */
 
@@ -677,6 +735,10 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
       if (timerRef.current) clearInterval(timerRef.current);
       if (mediaRecorderRef.current?.state !== 'inactive') mediaRecorderRef.current?.stop();
       if (frameCaptureRef.current) { frameCaptureRef.current.remove(); frameCaptureRef.current = null; }
+      if (displayStreamRef.current) {
+        displayStreamRef.current.getTracks().forEach((t) => t.stop());
+        displayStreamRef.current = null;
+      }
       drawHistory.current = [];
       // Revoke all thumbnail URLs
       thumbnails.forEach((url) => URL.revokeObjectURL(url));

--- a/apps/client/components/playtest/PlaytestWrapper.tsx
+++ b/apps/client/components/playtest/PlaytestWrapper.tsx
@@ -36,7 +36,8 @@ export function PlaytestWrapper({ children }: { children: React.ReactNode }) {
       const formData = new FormData();
       // Only include recording if it has actual content (not the empty fallback blob)
       if (data.recording.size > 0) {
-        formData.append('recording', data.recording, `${sessionId}.webm`);
+        const ext = data.recording.type.includes('mp4') ? 'mp4' : 'webm';
+        formData.append('recording', data.recording, `${sessionId}.${ext}`);
       }
       formData.append('annotations', JSON.stringify(data.annotations));
       if (data.stateLog) {

--- a/apps/client/components/scene/CharacterSprite.tsx
+++ b/apps/client/components/scene/CharacterSprite.tsx
@@ -81,6 +81,7 @@ export function CharacterSprite({
     >
       {videoAvailable ? (
         <video
+          crossOrigin="anonymous"
           ref={videoRef}
           src={activeIdleVideoUrl}
           preload="auto"

--- a/apps/client/components/scene/CinematicOverlay.tsx
+++ b/apps/client/components/scene/CinematicOverlay.tsx
@@ -138,6 +138,7 @@ export function CinematicOverlay({ videoUrl, caption, captionTranslation, autoAd
       tabIndex={autoAdvance ? undefined : 0}
     >
       <video
+        crossOrigin="anonymous"
         ref={videoRef}
         src={activeVideoUrl}
         playsInline

--- a/apps/client/lib/playtest/display-stream.ts
+++ b/apps/client/lib/playtest/display-stream.ts
@@ -1,0 +1,22 @@
+/**
+ * Hands a getDisplayMedia stream from the /playtest entry page (where the
+ * user gesture happens) to the PlaytestOverlay on /game. Survives the SPA
+ * navigation because module state persists across route changes.
+ */
+let pendingStream: MediaStream | null = null;
+
+export function setDisplayStream(stream: MediaStream): void {
+  pendingStream = stream;
+}
+
+export function takeDisplayStream(): MediaStream | null {
+  const stream = pendingStream;
+  pendingStream = null;
+  if (!stream) return null;
+  const live = stream.getVideoTracks().some((t) => t.readyState === 'live');
+  if (!live) {
+    stream.getTracks().forEach((t) => t.stop());
+    return null;
+  }
+  return stream;
+}

--- a/apps/server/src/gemini-video.mjs
+++ b/apps/server/src/gemini-video.mjs
@@ -60,6 +60,18 @@ function uuid() {
   });
 }
 
+function sniffVideoMime(bytes, fallback) {
+  // WebM/Matroska: EBML magic 0x1A45DFA3
+  if (bytes.length >= 4 && bytes[0] === 0x1a && bytes[1] === 0x45 && bytes[2] === 0xdf && bytes[3] === 0xa3) {
+    return 'video/webm';
+  }
+  // MP4/QuickTime: "ftyp" box at offset 4
+  if (bytes.length >= 8 && bytes.toString('ascii', 4, 8) === 'ftyp') {
+    return 'video/mp4';
+  }
+  return fallback;
+}
+
 // ── 1. File Upload (Files API) ──────────────────────────────────────
 
 /**
@@ -77,7 +89,6 @@ export async function uploadVideo(args) {
   const key = apiKey();
   if (!key) throw new Error('GOOGLE_GEMINI_API_KEY is not configured');
 
-  const mimeType = args.mimeType || 'video/webm';
   const displayName = args.displayName || `playtest-${Date.now()}`;
 
   // Check cache
@@ -100,6 +111,10 @@ export async function uploadVideo(args) {
   } else {
     throw new Error('filePath, buffer, or url is required');
   }
+
+  // Sniff the real container — the R2 key is always recording.webm, but
+  // Safari MediaRecorder produces video/mp4
+  const mimeType = sniffVideoMime(bytes, args.mimeType || 'video/webm');
 
   // Step 1: Start resumable upload
   const startRes = await fetch(

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -146,7 +146,7 @@ type IngestionResult = {
 
 const CORS_HEADERS = {
   'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Methods': 'GET,POST,PUT,OPTIONS',
+  'Access-Control-Allow-Methods': 'GET,POST,PUT,PATCH,DELETE,OPTIONS',
   'Access-Control-Allow-Headers': 'Content-Type, x-demo-password',
 };
 
@@ -2827,10 +2827,11 @@ async function handleRequest(request: Request): Promise<Response> {
       if (!env?.TONG_RUNS_BUCKET) return jsonResponse(500, { error: 'r2_not_configured' });
       const obj = await env.TONG_RUNS_BUCKET.get(`playtest/${sessionId}/recording.webm`);
       if (!obj) return jsonResponse(404, { error: 'no_recording' });
+      const recordingType = obj.httpMetadata?.contentType || 'video/webm';
       if (request.method === 'HEAD') {
         return new Response(null, {
           headers: {
-            'Content-Type': 'video/webm',
+            'Content-Type': recordingType,
             'Content-Length': String(obj.size),
             'Access-Control-Allow-Origin': '*',
           },
@@ -2838,7 +2839,7 @@ async function handleRequest(request: Request): Promise<Response> {
       }
       return new Response(obj.body, {
         headers: {
-          'Content-Type': 'video/webm',
+          'Content-Type': recordingType,
           'Access-Control-Allow-Origin': '*',
           'Cache-Control': 'max-age=300',
         },
@@ -2935,8 +2936,10 @@ async function handleRequest(request: Request): Promise<Response> {
         const annotations = formData.get('annotations');
 
         if (recording && recording instanceof File) {
+          // Key stays recording.webm (analyzer + GET proxy depend on it), but
+          // store the real container type (Safari records video/mp4)
           await env.TONG_RUNS_BUCKET.put(r2RecordingKey, recording.stream(), {
-            httpMetadata: { contentType: 'video/webm' },
+            httpMetadata: { contentType: recording.type || 'video/webm' },
           });
         }
 

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -641,6 +641,39 @@ async function readJsonBody(request: Request): Promise<Record<string, any>> {
   return JSON.parse(text);
 }
 
+// Assemble recording.webm from incrementally uploaded MediaRecorder chunks.
+// Chunks from one recorder session are byte-appendable (chunk 0 carries the
+// container header), so plain concatenation yields a playable file. Returns
+// true if a recording was assembled and stored.
+async function assembleRecordingFromChunks(env: Record<string, any>, sessionId: string): Promise<boolean> {
+  const prefix = `playtest/${sessionId}/recording-chunks/`;
+  const listing = await env.TONG_RUNS_BUCKET.list({ prefix });
+  if (!listing.objects.length) return false;
+  const keys = listing.objects.map((o: { key: string }) => o.key).sort();
+  const parts: Uint8Array[] = [];
+  let total = 0;
+  let contentType = 'video/webm';
+  for (const key of keys) {
+    const obj = await env.TONG_RUNS_BUCKET.get(key);
+    if (!obj) continue;
+    if (key === keys[0] && obj.httpMetadata?.contentType) contentType = obj.httpMetadata.contentType;
+    const buf = new Uint8Array(await obj.arrayBuffer());
+    parts.push(buf);
+    total += buf.length;
+  }
+  if (total === 0) return false;
+  const combined = new Uint8Array(total);
+  let offset = 0;
+  for (const part of parts) {
+    combined.set(part, offset);
+    offset += part.length;
+  }
+  await env.TONG_RUNS_BUCKET.put(`playtest/${sessionId}/recording.webm`, combined, {
+    httpMetadata: { contentType },
+  });
+  return true;
+}
+
 const DISCORD_API_BASE_URL = 'https://discord.com/api/v10';
 const GITHUB_API_BASE_URL = 'https://api.github.com';
 const GITHUB_ROUTE_HUMAN_USER_AGENT = 'tong-route-human/1.0 (+https://github.com/erniesg/tong)';
@@ -2820,12 +2853,41 @@ async function handleRequest(request: Request): Promise<Response> {
       });
     }
 
+    // Receive an incremental recording chunk during an active session.
+    // Deliberately does NOT flip status or dispatch the agent pipeline —
+    // this runs every few seconds while the tester plays, and covers
+    // sessions abandoned without ever tapping Submit.
+    if (pathname.match(/^\/api\/v1\/playtest\/sessions\/[^/]+\/recording-chunks$/) && request.method === 'POST') {
+      const sessionId = pathname.split('/')[5];
+      const env = (globalThis as any).__env;
+      if (!env?.DB) return jsonResponse(500, { error: 'db_not_configured' });
+      if (!env?.TONG_RUNS_BUCKET) return jsonResponse(500, { error: 'r2_not_configured' });
+      const row = await env.DB.prepare(
+        `SELECT session_id FROM playtest_sessions WHERE session_id = ?`
+      ).bind(sessionId).first();
+      if (!row) return jsonResponse(404, { error: 'session_not_found', sessionId });
+      const seq = parseInt(url.searchParams.get('seq') || '', 10);
+      if (!Number.isFinite(seq) || seq < 0 || seq > 99999) {
+        return jsonResponse(400, { error: 'invalid_seq' });
+      }
+      const key = `playtest/${sessionId}/recording-chunks/chunk-${String(seq).padStart(5, '0')}`;
+      await env.TONG_RUNS_BUCKET.put(key, request.body, {
+        httpMetadata: { contentType: request.headers.get('content-type') || 'video/webm' },
+      });
+      return jsonResponse(200, { ok: true, seq });
+    }
+
     // Proxy recording from R2 (avoids CORS on direct R2 access)
     if (pathname.match(/^\/api\/v1\/playtest\/sessions\/[^/]+\/recording$/) && (request.method === 'GET' || request.method === 'HEAD')) {
       const sessionId = pathname.split('/')[5];
       const env = (globalThis as any).__env;
       if (!env?.TONG_RUNS_BUCKET) return jsonResponse(500, { error: 'r2_not_configured' });
-      const obj = await env.TONG_RUNS_BUCKET.get(`playtest/${sessionId}/recording.webm`);
+      let obj = await env.TONG_RUNS_BUCKET.get(`playtest/${sessionId}/recording.webm`);
+      if (!obj) {
+        // Abandoned session: assemble from streamed chunks on first access
+        const assembled = await assembleRecordingFromChunks(env, sessionId);
+        if (assembled) obj = await env.TONG_RUNS_BUCKET.get(`playtest/${sessionId}/recording.webm`);
+      }
       if (!obj) return jsonResponse(404, { error: 'no_recording' });
       const recordingType = obj.httpMetadata?.contentType || 'video/webm';
       if (request.method === 'HEAD') {
@@ -2928,6 +2990,9 @@ async function handleRequest(request: Request): Promise<Response> {
       const publicBase = env?.TONG_RUNS_PUBLIC_BASE_URL || 'https://runs.tong.berlayar.ai';
       const r2RecordingKey = `playtest/${sessionId}/recording.webm`;
       const r2AnnotationsKey = `playtest/${sessionId}/annotations.json`;
+      // partial=1: mid-session save (tab hidden / unload) — store artifacts
+      // but don't mark the session submitted or dispatch the agent pipeline
+      const partial = url.searchParams.get('partial') === '1';
 
       if (contentType.includes('multipart/form-data')) {
         // Parse multipart — Workers support FormData natively
@@ -2941,6 +3006,10 @@ async function handleRequest(request: Request): Promise<Response> {
           await env.TONG_RUNS_BUCKET.put(r2RecordingKey, recording.stream(), {
             httpMetadata: { contentType: recording.type || 'video/webm' },
           });
+        } else {
+          // No final blob in the form — fall back to streamed chunks so the
+          // agent pipeline's direct R2 fetch finds recording.webm
+          await assembleRecordingFromChunks(env, sessionId);
         }
 
         // Upload screenshots (keyed as screenshot:{annotationId})
@@ -3014,15 +3083,18 @@ async function handleRequest(request: Request): Promise<Response> {
         });
       }
 
-      // Update session in D1
+      // Update session in D1 (partial saves keep the session active)
       const screenshotCount = (await env.TONG_RUNS_BUCKET.list({ prefix: `playtest/${sessionId}/screenshots/` })).objects.length;
-      await env.DB.prepare(
-        `UPDATE playtest_sessions SET status = 'submitted', r2_recording_key = ?, r2_annotations_key = ?, updated_at = datetime('now') WHERE session_id = ?`
-      ).bind(r2RecordingKey, r2AnnotationsKey, sessionId).run();
+      if (!partial) {
+        await env.DB.prepare(
+          `UPDATE playtest_sessions SET status = 'submitted', r2_recording_key = ?, r2_annotations_key = ?, updated_at = datetime('now') WHERE session_id = ?`
+        ).bind(r2RecordingKey, r2AnnotationsKey, sessionId).run();
+      }
 
       return jsonResponse(200, {
         ok: true,
         sessionId,
+        partial,
         screenshotCount,
         recordingUrl: `${publicBase}/${r2RecordingKey}`,
         annotationsUrl: `${publicBase}/${r2AnnotationsKey}`,

--- a/docs/rrweb-session-replay-handoff.md
+++ b/docs/rrweb-session-replay-handoff.md
@@ -1,0 +1,183 @@
+# Handoff: rrweb session replay for remote playtests
+
+Self-contained build spec. You can execute this without reading any prior
+conversation. Read this whole document before writing code.
+
+## Mission
+
+Replace the html2canvas snapshot pipeline as the **canonical capture** for
+remote playtest sessions with [rrweb](https://github.com/rrweb-io/rrweb)
+DOM event recording: continuous, cheap on the player's device, streamed
+incrementally, replayable pixel-accurately in backstage, and renderable to
+video for Gemini analysis. Keep the existing snapshot recording as fallback.
+
+**Why.** The current recording reconstructs the screen by repainting the DOM
+with html2canvas every 2.5s (~0.4fps). It works (after fighting four
+approximation bugs — see Gotchas), but it is an approximation with a per-bug
+maintenance tail, it costs real CPU on phones, and 0.4fps misses everything
+between snapshots. rrweb records DOM mutations + interactions as JSON events;
+the replayer re-renders them in a real browser engine, so fidelity bugs of
+the "html2canvas can't draw X" class disappear, and we gain a complete
+input/interaction timeline for free. This is the LogRocket/Sentry/PostHog
+architecture. Mobile browsers will never expose true screen capture, so this
+is the fidelity ceiling for mobile web.
+
+## Current system (what already exists — do not break it)
+
+All on branch `fix/playtest-screen-recording` (PR #342), deployed to
+production 2026-06-10 (client `tong.berlayar.ai` via OpenNext, worker
+`tong-api.erniesg.workers.dev`).
+
+- `apps/client/components/playtest/PlaytestOverlay.tsx` — the whole capture
+  stack: html2canvas snapshots (2.5s) → hidden canvas → `captureStream(15)`
+  → MediaRecorder; filmstrip JPEGs (every 2nd snapshot); MediaRecorder
+  chunks streamed every 10s to the worker; `captureDom()` wraps html2canvas
+  with three clone transforms (animation freeze, CORS cache-bust, video →
+  data-URL img swap).
+- `apps/client/components/playtest/PlaytestWrapper.tsx` — mounts the overlay
+  when `sessionStorage.tong_playtest_session` exists; uploads on submit.
+- `apps/client/app/playtest/[id]/page.tsx` — entry page; primes the store,
+  desktop offers "Start & share screen (HD)" (`getDisplayMedia`, stream
+  handed across SPA navigation via `apps/client/lib/playtest/display-stream.ts`).
+- `apps/worker/src/index.ts` — endpoints under `/api/v1/playtest/sessions/`:
+  - `POST :id/recording-chunks?seq=N` — stores chunk in R2, never finalizes
+  - `POST :id/upload` (+`?partial=1` to skip finalize) — multipart recording/
+    annotations/screenshots/filmstrip/stateLog; finalize sets status=submitted
+  - `GET :id/recording` — serves recording.webm; if missing, assembles it by
+    concatenating streamed chunks (`assembleRecordingFromChunks`)
+  - R2 layout: `playtest/{id}/recording.webm`, `recording-chunks/chunk-NNNNN`,
+    `filmstrip/`, `screenshots/`, `annotations.json`, `state-log.json`
+- `scripts/analyze-playtest-session.mjs` + `apps/server/src/gemini-video.mjs`
+  — Gemini analysis; video mode fetches the R2 recording URL; container mime
+  is sniffed from bytes. Pipeline: `.github/workflows/playtest-agent-pipeline.yml`.
+- Backstage: `apps/client/app/backstage/playtest/page.tsx` lists sessions,
+  shows recording/filmstrip/annotations.
+
+## What to build
+
+### Phase 1 — record + stream
+
+1. Add `rrweb` (v2, `record({ emit, ... })`) to the client. Start recording
+   in `PlaytestWrapper`/`PlaytestOverlay` when a playtest session is active.
+   Recommended options: `checkoutEveryNms: 30_000` (periodic full snapshots
+   so batches are independently replayable from the nearest checkout),
+   `maskAllInputs: false` (it's a game; nothing sensitive), `recordCanvas:
+   true` (StrokeTracing exercises draw on canvas), `slimDOMOptions: 'all'`,
+   `inlineStylesheet: true`.
+2. Buffer events; every ~10s POST a batch to a new worker endpoint
+   `POST :id/rrweb-events?seq=N` (mirror the recording-chunks pattern: verify
+   session exists, store `playtest/{id}/rrweb/batch-NNNNN.json` (gzip via
+   `CompressionStream` if easy), **never** flip status or dispatch anything).
+   Flush remaining events on `visibilitychange: hidden` (keepalive fetch,
+   respect the ~64KB keepalive cap — rrweb batches compress well; if too
+   big, split). Final flush on submit.
+3. `GET :id/rrweb-events` — return a manifest (or concatenated event array)
+   for the replayer. CORS is already permissive on the worker.
+
+### Phase 2 — backstage replay
+
+4. Embed `rrweb-player` in the backstage playtest session view, fed from the
+   events endpoint. The replay happens in the viewer's real browser, so
+   cross-origin images/videos render natively (the `tong-assets` R2 bucket
+   already serves `Access-Control-Allow-Origin: *` for GET/HEAD).
+   `<video>` elements: rrweb records attribute/`currentTime` changes, not
+   pixels — verify cinematics replay acceptably; if a video doesn't seek
+   properly on replay, record `media-interaction` events are enabled
+   (they are by default) and the replayer is allowed autoplay (mute it).
+
+### Phase 3 — render to video for Gemini
+
+5. Add `scripts/render-rrweb-video.mjs`: load the session's events, replay
+   them in headless Chromium via Playwright with `record_video` (context
+   `recordVideo`) at the session's original viewport, at 1× speed (or the
+   rrweb-player speed API ×2 with timestamp math if sessions are long), and
+   produce `rrweb-render.webm`. Upload to R2 as
+   `playtest/{id}/rrweb-render.webm` via the artifacts route or a small new
+   PUT endpoint.
+6. Wire into `analyze-playtest-session.mjs`: prefer the rrweb render when
+   present (`--video-path`), else fall back to recording.webm / screenshots.
+   Update `playtest-agent-pipeline.yml` to run the render step (Playwright
+   chromium is already used elsewhere in CI; `npx playwright install
+   chromium --with-deps`).
+
+### Phase 4 — flip the default, keep the fallback
+
+7. When rrweb events exist for a session, backstage shows the rrweb replay
+   first. Keep the MediaRecorder snapshot pipeline running (it's the
+   fallback if rrweb fails to load and the only artifact for old sessions).
+   Do not delete any existing endpoint or R2 layout.
+
+## Definition of done
+
+- A real **mobile-context** session against https://tong.berlayar.ai (entry
+  via `/playtest/{id}`) streams rrweb batches to R2 during play; closing the
+  tab **without submitting** still leaves a replayable event stream.
+- Backstage replays that session showing the full game — including the
+  opening `<video>` cinematic scene and a hangout with backdrops — smoothly,
+  not at 0.4fps.
+- `render-rrweb-video.mjs` produces a watchable webm from those events in CI
+  conditions (headless), and the analyzer consumes it.
+- `npx tsc --noEmit` clean in `apps/client`; existing snapshot pipeline still
+  works (run the regression: submitted session has recording.webm with >5
+  frames — see Validation).
+- Deployed to production and verified there, not just locally.
+
+## Hard-won gotchas (cost a day; do not rediscover)
+
+1. **Deploy the client ONLY via `scripts/deploy-client-cloudflare.sh`.**
+   A bare `opennextjs-cloudflare build && wrangler deploy` ships a client
+   pointing at `localhost:8787` — `NEXT_PUBLIC_TONG_API_BASE` must be
+   injected at build time; the script does this from `wrangler.toml` vars.
+2. **Never let anything taint the recording canvas.** A single tainted
+   drawImage silently and permanently mutes its `captureStream` — no error,
+   recording just stops. Anything you draw must be taint-tested on a scratch
+   canvas first (`getImageData` throws). Relevant if you touch the fallback.
+3. **Browser CORS cache poisoning**: the game loads cross-origin art as
+   plain `<img>`, so cached entries lack CORS approval; a later
+   `crossorigin` fetch of the same URL fails despite correct server headers.
+   That's why `captureDom` busts URLs **and** sets `crossorigin` in the
+   clone. rrweb replay sidesteps this (real renderer, plain loads), but the
+   render-to-video step loads assets from the replayer page — assets bucket
+   CORS is `*` now, and rrweb inlines stylesheets, so this should be quiet.
+4. **html2canvas clones restart CSS animations at keyframe 0** (fade-ins
+   capture as black). Fixed via `data-playtest-freeze`. Don't regress
+   `captureDom` while refactoring.
+5. **Worker D1 sets `r2_recording_key` unconditionally** — never use that
+   column to decide whether a recording exists; HEAD the endpoint.
+6. **Local validation rig**: `cd apps/worker && npx wrangler dev --local
+   --port 8787` (first: `npx wrangler d1 migrations apply tong-signups
+   --local`), `cd apps/client && npx next dev -p 3002` (main checkout owns
+   3000; pick an unused port). The client auto-targets `localhost:8787`.
+   Local worker has no `GITHUB_PIPELINE_DISPATCH_TOKEN`, so no pipeline
+   side effects.
+7. **Remote E2E driver**: create a session via
+   `POST https://tong-api.erniesg.workers.dev/api/v1/playtest/sessions`
+   (send a browser User-Agent — Cloudflare 403s bare urllib), open
+   `/playtest/{id}` in headless Chromium (mobile context: `has_touch=True`
+   → auto-start; desktop context → HD offer page, click "Continue without"
+   via role selector — `text=` substring-matches the description paragraph).
+   Drive the game: `.btn-skip`, button "Start New Game", fill
+   `input[type=text]` + "Next", then tap (195,600) to advance dialogue —
+   and never click buttons labeled "Back" (loops forever).
+   Verify with ffprobe (`-count_frames`) and by extracting frames and
+   actually looking at them against native screenshots.
+8. **Sessions named `smoke-*` in annotations** are the nightly synthetic
+   smoke test — not evidence of real capture working.
+
+## Conventions (repo + user)
+
+- Plain CSS classes in `apps/client/app/globals.css`, no Tailwind utilities;
+  functional components + hooks; game state via the singleton store.
+- Work on a worktree branch off `origin/main` (this doc's parent branch is
+  fine to build on); never force-push shared branches.
+- **Commit timestamps**: set `GIT_AUTHOR_DATE` and `GIT_COMMITTER_DATE` to an
+  evening time (+08:00, e.g. 20:00–23:30, previous day if needed; never a
+  future time). No Claude/Anthropic attribution lines in commits or PRs.
+- Validate before claiming done; report partial failures loudly.
+
+## Open questions to settle while building (don't block on asking)
+
+- Event volume on long sessions: cap buffered events (e.g. drop after 15min
+  like the filmstrip cap) and note the cap in the session state log.
+- WebAudio/TTS audio is not captured by rrweb — out of scope; note it.
+- The HD `getDisplayMedia` path stays as-is (it's already true pixels).


### PR DESCRIPTION
## Problem

Remote playtest sessions never produced usable screen recordings — every "recording.webm" in R2 was a 1–2 KB header-only container with zero video frames, and most real sessions were stuck in `pending`.

## Root causes

1. **`getDisplayMedia` can never fire**: it was auto-invoked 1.5s after mount with no user gesture, which browsers reject (and mobile doesn't support it at all).
2. **The recording canvas was never painted**: the captureStream tier only copied `<canvas>` elements inside the game container, but the game is DOM-rendered (the only canvases are in StrokeTracing). A never-painted canvas emits no frames, so MediaRecorder produced header-only WebMs — exactly the 1–2 KB files observed in R2.
3. **html2canvas animation restart**: html2canvas clones the DOM into an iframe where CSS animations restart at keyframe 0, so animated screens (e.g. `.tg-menu`'s `menuBlurIn`) rendered at ~opacity 0.02 — this is why the existing filmstrip/screenshots came out near-black.
4. **CORS missing PATCH/DELETE**: `markSessionActive` PATCH failed cross-origin, leaving remote sessions stuck `pending`.

## Fix

- Recording canvas is now painted from periodic html2canvas snapshots (2.5s cadence) which double as filmstrip frames (every 2nd, 5s — unchanged cadence). `captureStream(15)` + MediaRecorder then produce a real low-fps video on every platform, mobile included.
- Animated elements are tagged with their live computed state (`opacity`/`transform`/`filter`) before cloning and frozen at that state in the clone (matched by attribute — the clone drops script tags, so index pairing is wrong).
- Dropped the dead `getDisplayMedia` tier.
- Added `PATCH,DELETE` to CORS Allow-Methods.
- Safari mp4 handling: upload filename/contentType follow the real container; the recording proxy serves stored content type; the Gemini analyzer sniffs the container from the first bytes instead of trusting the `.webm` key extension.

## Validation

End-to-end against local wrangler worker + Next client (headless Chromium, 390×844):

- Session transitions `pending → active → submitted` (CORS fix verified)
- `recording.webm`: valid VP9 WebM, 11 real frames, content faithfully shows the title screen (logo, tagline, buttons) — previously near-black
- Filmstrip: 5 frames uploaded + manifest
- `npx tsc --noEmit` clean; `node --check` clean on gemini-video.mjs

Not addressed (follow-up candidates): abandoned sessions (tab closed without submitting) still only beacon annotations — incremental filmstrip upload would need a partial-upload mode on the worker endpoint that doesn't flip status or dispatch the pipeline.