### PR TITLE
feat: rrweb session replay as canonical playtest capture

### DIFF
--- a/apps/client/app/backstage/playtest/page.tsx
+++ b/apps/client/app/backstage/playtest/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { RrwebReplay, type RrwebEventJson } from '@/components/playtest/RrwebReplay';
 
 /* ── Types ────────────────────────────────────────────────────────── */
 
@@ -81,7 +82,7 @@ interface StateLog {
   entries: StateLogEntry[];
 }
 
-type ViewerTab = 'filmstrip' | 'annotations' | 'gallery' | 'analysis' | 'statelog' | 'trace';
+type ViewerTab = 'replay' | 'filmstrip' | 'annotations' | 'gallery' | 'analysis' | 'statelog' | 'trace';
 
 /* ── API ──────────────────────────────────────────────────────────── */
 
@@ -185,6 +186,27 @@ async function fetchAgentTrace(sessionId: string): Promise<Record<string, unknow
   } catch { return null; }
 }
 
+// rrweb events stream in numbered batches; the manifest lists them in order
+async function fetchRrwebEvents(sessionId: string): Promise<RrwebEventJson[] | null> {
+  try {
+    const base = `${API_BASE}/api/v1/playtest/sessions/${sessionId}/rrweb-events`;
+    const res = await fetch(base);
+    if (!res.ok) return null;
+    const manifest = await res.json();
+    const batches: RrwebEventJson[][] = await Promise.all(
+      (manifest.batches || []).map((b: { name: string }) =>
+        fetch(`${base}/${b.name}`)
+          .then((r) => (r.ok ? r.json() : []))
+          .catch(() => []),
+      ),
+    );
+    const events = batches.flat();
+    return events.length >= 2 ? events : null;
+  } catch {
+    return null;
+  }
+}
+
 /* ── Helpers ──────────────────────────────────────────────────────── */
 
 const fmt = (s: number) =>
@@ -259,6 +281,7 @@ export default function PlaytestViewerPage() {
   const [filmstrip, setFilmstrip] = useState<{ ts: number; url: string }[]>([]);
   const [filmstripIdx, setFilmstripIdx] = useState(0);
   const [filmstripPlaying, setFilmstripPlaying] = useState(false);
+  const [rrwebEvents, setRrwebEvents] = useState<RrwebEventJson[] | null>(null);
   const [activeTab, setActiveTab] = useState<ViewerTab>('filmstrip');
   const [activeAnnotation, setActiveAnnotation] = useState<string | null>(null);
   const [screenshotPreview, setScreenshotPreview] = useState<string | null>(null);
@@ -299,11 +322,12 @@ export default function PlaytestViewerPage() {
     setStateLog(null);
     setAnalysis(null);
     setAgentTrace(null);
+    setRrwebEvents(null);
     setExpandedLogEntries(new Set());
     setActiveTab('filmstrip');
     setLoadingData(true);
 
-    const [anns, log, anal, trace, filmstripData] = await Promise.all([
+    const [anns, log, anal, trace, filmstripData, rrweb] = await Promise.all([
       fetchAnnotations(sessionId),
       fetchStateLog(sessionId),
       fetchAnalysis(sessionId),
@@ -311,6 +335,7 @@ export default function PlaytestViewerPage() {
       fetch(`${API_BASE}/api/v1/playtest/sessions/${sessionId}/filmstrip`)
         .then((r) => r.ok ? r.json() : [])
         .catch(() => []) as Promise<{ ts: number; url: string }[]>,
+      fetchRrwebEvents(sessionId),
     ]);
     setAnnotations(anns.sort((a, b) => a.timestamp - b.timestamp));
     setStateLog(log);
@@ -320,12 +345,16 @@ export default function PlaytestViewerPage() {
       ts: f.ts,
       url: `${API_BASE}/api/v1/playtest/sessions/${sessionId}/filmstrip/frame-${f.ts}.jpg`,
     })));
+    setRrwebEvents(rrweb);
     setFilmstripIdx(0);
     setFilmstripPlaying(false);
     setLoadingData(false);
 
-    // Default to annotations if no filmstrip
-    if ((!filmstripData || filmstripData.length === 0) && anns.length > 0) {
+    // rrweb replay is the canonical view when events exist;
+    // fall back to filmstrip, then annotations (old sessions)
+    if (rrweb) {
+      setActiveTab('replay');
+    } else if ((!filmstripData || filmstripData.length === 0) && anns.length > 0) {
       setActiveTab('annotations');
     }
   }, []);
@@ -538,6 +567,7 @@ export default function PlaytestViewerPage() {
               {/* Tab bar */}
               <div className="pv-tabs">
                 {([
+                  ['replay', `Replay${rrwebEvents ? '' : ' (none)'}`],
                   ['filmstrip', `Filmstrip${filmstrip.length ? ` (${filmstrip.length})` : ''}`],
                   ['annotations', `Annotations (${annotations.length})`],
                   ['gallery', `Screenshots (${screenshotAnnotations.length})`],
@@ -556,6 +586,20 @@ export default function PlaytestViewerPage() {
               </div>
 
               {loadingData && <p className="triage-muted" style={{ padding: 24 }}>Loading session data...</p>}
+
+              {/* ── Replay tab (rrweb) ───────────────────────── */}
+              {!loadingData && activeTab === 'replay' && (
+                <div>
+                  {rrwebEvents ? (
+                    <RrwebReplay events={rrwebEvents} />
+                  ) : (
+                    <div className="pv-empty-tab">
+                      No rrweb events for this session. Older sessions only have
+                      the snapshot filmstrip and recording.
+                    </div>
+                  )}
+                </div>
+              )}
 
               {/* ── Filmstrip tab ────────────────────────────── */}
               {!loadingData && activeTab === 'filmstrip' && (

--- a/apps/client/app/game/page.tsx
+++ b/apps/client/app/game/page.tsx
@@ -44,7 +44,7 @@ const TONG_TRANSPARENT_HEVC_URL = runtimeAssetUrl('app.tong.video.transparent.he
 const SEOUL_FOOD_STREET_BACKDROP_URL = runtimeAssetUrl('city.seoul.location.food-street.backdrop.default');
 
 const NPC_SPRITES: Record<string, { name: string; nameLocal: string; nameZh: string; src: string; idleVideo?: string; color: string }> = {
-  haeun: { name: 'Ha-eun', nameLocal: '하은', nameZh: '夏恩', src: runtimeAssetUrl('character.haeun.portrait.default'), idleVideo: '/assets/characters/haeun/haeun_idle_loop.mp4', color: '#e8485c' },
+  haeun: { name: 'Ha-eun', nameLocal: '하은', nameZh: '夏恩', src: runtimeAssetUrl('character.haeun.portrait.default'), idleVideo: resolveRuntimeAssetUrl('/assets/characters/haeun/haeun_idle_loop.mp4'), color: '#e8485c' },
   jin: { name: 'Jin', nameLocal: '진', nameZh: '珍', src: runtimeAssetUrl('character.jin.portrait.default'), color: '#4a90d9' },
 };
 

--- a/apps/client/app/globals.css
+++ b/apps/client/app/globals.css
@@ -9495,6 +9495,29 @@ body:has(.playtest-pill-expanded) {
   justify-content: center;
 }
 
+/* rrweb replay — Replayer iframe scaled into a phone-shaped stage */
+.pv-rrweb-player {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 16px 0;
+}
+
+.pv-rrweb-stage {
+  position: relative;
+  overflow: hidden;
+  border-radius: 8px;
+  border: 1px solid var(--line);
+  background: #000;
+}
+
+.pv-rrweb-stage iframe {
+  border: none;
+  background: #fff;
+  pointer-events: none;
+}
+
 /* Filmstrip — compact, phone-shaped */
 .pv-filmstrip {
   border-radius: 8px;

--- a/apps/client/components/playtest/PlaytestOverlay.tsx
+++ b/apps/client/components/playtest/PlaytestOverlay.tsx
@@ -5,6 +5,7 @@ import html2canvas from 'html2canvas';
 import { sessionLogger } from '@/lib/debug/session-logger';
 import { getPublicApiBase } from '@/lib/public-api-base';
 import { takeDisplayStream } from '@/lib/playtest/display-stream';
+import { startRrwebRecording, type RrwebRecorderHandle } from '@/lib/playtest/rrweb-recorder';
 
 /* ── Types ────────────────────────────────────────────────────────── */
 
@@ -256,6 +257,10 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
   const chunkSeqRef = useRef(0);
   const chunkFlushBusyRef = useRef(false);
 
+  // rrweb DOM event recording — the canonical capture; the snapshot/
+  // MediaRecorder pipeline above stays as fallback
+  const rrwebRef = useRef<RrwebRecorderHandle | null>(null);
+
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const isDrawing = useRef(false);
   const currentPath = useRef<string[]>([]);
@@ -283,6 +288,9 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
       fc.width = Math.max(2, Math.floor(window.innerWidth / 2) & ~1);
       fc.height = Math.max(2, Math.floor(window.innerHeight / 2) & ~1);
       fc.style.display = 'none';
+      // rr-block: keep rrweb from recording this canvas — every 2.5s paint
+      // would otherwise land in the event stream as a ~1.4MB canvas mutation
+      fc.className = 'rr-block';
       document.body.appendChild(fc);
       const ctx = fc.getContext('2d');
       if (ctx) {
@@ -403,6 +411,9 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
 
   const stopAndSubmit = useCallback(() => {
     if (timerRef.current) clearInterval(timerRef.current);
+    // Final rrweb flush — async, doesn't gate the snapshot upload
+    void rrwebRef.current?.stop();
+    rrwebRef.current = null;
     // Snapshot final state before submitting
     if (typeof window !== 'undefined' && // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (window as any).__TONG_QA__) {
@@ -444,7 +455,20 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
     });
 
     const timer = setTimeout(() => startRecording(), 1500);
-    return () => clearTimeout(timer);
+
+    // rrweb starts immediately — its full snapshot captures the initial DOM
+    let cancelled = false;
+    void startRrwebRecording(sessionId).then((handle) => {
+      if (cancelled) { void handle?.stop(); return; }
+      rrwebRef.current = handle;
+    });
+
+    return () => {
+      clearTimeout(timer);
+      cancelled = true;
+      void rrwebRef.current?.stop();
+      rrwebRef.current = null;
+    };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [startRecording]);
 
@@ -789,6 +813,7 @@ export function PlaytestOverlay({ targetRef, sessionId, onSubmit, onRequestClari
     // tab or navigating away must not mark it submitted or trigger analysis
     const savePartial = () => {
       void flushChunks(true);
+      void rrwebRef.current?.flush(true);
       if (annotations.length > 0) {
         const formData = new FormData();
         formData.append('annotations', JSON.stringify(annotations));

--- a/apps/client/components/playtest/RrwebReplay.tsx
+++ b/apps/client/components/playtest/RrwebReplay.tsx
@@ -1,0 +1,165 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import 'rrweb/dist/style.css';
+
+export type RrwebEventJson = { type: number; data: unknown; timestamp: number };
+
+/* Minimal Replayer surface — rrweb-player 2.0.1 ships a broken dist (its
+   compiled Player never constructs a Replayer), so we drive rrweb's
+   Replayer directly with our own controls. */
+interface ReplayerLike {
+  play: (timeOffset?: number) => void;
+  pause: (timeOffset?: number) => void;
+  getCurrentTime: () => number;
+  getMetaData: () => { startTime: number; endTime: number; totalTime: number };
+  setConfig: (config: { speed?: number }) => void;
+  on: (event: string, handler: () => void) => void;
+  destroy?: () => void;
+}
+
+/* The session's true viewport comes from rrweb's Meta event (type 4) */
+const metaDimensions = (events: RrwebEventJson[]): { width: number; height: number } => {
+  const meta = events.find((e) => e.type === 4) as
+    | { data: { width?: number; height?: number } }
+    | undefined;
+  return {
+    width: meta?.data?.width || 390,
+    height: meta?.data?.height || 844,
+  };
+};
+
+const fmtMs = (ms: number) => {
+  const s = Math.max(0, Math.floor(ms / 1000));
+  return `${String(Math.floor(s / 60)).padStart(2, '0')}:${String(s % 60).padStart(2, '0')}`;
+};
+
+interface Props {
+  events: RrwebEventJson[];
+  maxWidth?: number;
+  maxHeight?: number;
+}
+
+/**
+ * Replays an rrweb event stream. The replay runs in the viewer's real
+ * browser engine, so cross-origin art and videos render natively — no
+ * html2canvas approximation.
+ */
+export function RrwebReplay({ events, maxWidth = 480, maxHeight = 600 }: Props) {
+  const stageRef = useRef<HTMLDivElement>(null);
+  const replayerRef = useRef<ReplayerLike | null>(null);
+  const rafRef = useRef<number>();
+  const [ready, setReady] = useState(false);
+  const [playing, setPlaying] = useState(false);
+  const [currentMs, setCurrentMs] = useState(0);
+  const [totalMs, setTotalMs] = useState(0);
+  const [speed, setSpeed] = useState(1);
+
+  useEffect(() => {
+    const el = stageRef.current;
+    if (!el || events.length < 2) return;
+    let replayer: ReplayerLike | null = null;
+    let cancelled = false;
+
+    void import('rrweb').then(({ Replayer }) => {
+      if (cancelled || !stageRef.current) return;
+      replayer = new Replayer(events as unknown as ConstructorParameters<typeof Replayer>[0], {
+        root: el,
+        UNSAFE_replayCanvas: true, // StrokeTracing exercises record canvas
+        showWarning: false,
+      }) as unknown as ReplayerLike;
+      replayerRef.current = replayer;
+      setTotalMs(replayer.getMetaData().totalTime);
+
+      // Scale the native-viewport iframe into the stage box
+      const native = metaDimensions(events);
+      const scale = Math.min(maxWidth / native.width, maxHeight / native.height, 1);
+      el.style.width = `${Math.round(native.width * scale)}px`;
+      el.style.height = `${Math.round(native.height * scale)}px`;
+      const wrapper = el.querySelector('.replayer-wrapper') as HTMLElement | null;
+      if (wrapper) {
+        wrapper.style.transform = `scale(${scale})`;
+        wrapper.style.transformOrigin = 'top left';
+      }
+
+      replayer.on('finish', () => setPlaying(false));
+      replayer.pause(0); // render the first frame
+      setReady(true);
+    });
+
+    return () => {
+      cancelled = true;
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      try { replayer?.pause(); } catch { /* not started */ }
+      try { replayer?.destroy?.(); } catch { /* already gone */ }
+      replayerRef.current = null;
+      el.innerHTML = '';
+      setReady(false);
+      setPlaying(false);
+      setCurrentMs(0);
+    };
+  }, [events, maxWidth, maxHeight]);
+
+  // Progress readout while playing
+  useEffect(() => {
+    if (!playing) return;
+    const tick = () => {
+      const r = replayerRef.current;
+      if (r) setCurrentMs(Math.min(r.getCurrentTime(), totalMs));
+      rafRef.current = requestAnimationFrame(tick);
+    };
+    rafRef.current = requestAnimationFrame(tick);
+    return () => { if (rafRef.current) cancelAnimationFrame(rafRef.current); };
+  }, [playing, totalMs]);
+
+  const togglePlay = useCallback(() => {
+    const r = replayerRef.current;
+    if (!r) return;
+    if (playing) {
+      r.pause(r.getCurrentTime());
+      setPlaying(false);
+    } else {
+      r.play(currentMs >= totalMs ? 0 : currentMs);
+      setPlaying(true);
+    }
+  }, [playing, currentMs, totalMs]);
+
+  const seek = useCallback((ms: number) => {
+    const r = replayerRef.current;
+    if (!r) return;
+    if (playing) r.play(ms);
+    else r.pause(ms);
+    setCurrentMs(ms);
+  }, [playing]);
+
+  const cycleSpeed = useCallback(() => {
+    const next = speed === 1 ? 2 : speed === 2 ? 4 : 1;
+    replayerRef.current?.setConfig({ speed: next });
+    setSpeed(next);
+  }, [speed]);
+
+  return (
+    <div className="pv-rrweb-player">
+      <div ref={stageRef} className="pv-rrweb-stage" />
+      <div className="pv-filmstrip-controls">
+        <button onClick={togglePlay} disabled={!ready}>
+          {playing ? '⏸' : '▶'}
+        </button>
+        <span className="pv-filmstrip-time">{fmtMs(currentMs)}</span>
+        <input
+          type="range"
+          min={0}
+          max={Math.max(1, totalMs)}
+          value={Math.min(currentMs, totalMs)}
+          onChange={(e) => seek(Number(e.target.value))}
+          className="pv-filmstrip-scrubber"
+          disabled={!ready}
+        />
+        <span className="pv-filmstrip-time">{fmtMs(totalMs)}</span>
+        <button onClick={cycleSpeed} disabled={!ready} title="Playback speed">
+          {speed}x
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/client/components/scene/CharacterSprite.tsx
+++ b/apps/client/components/scene/CharacterSprite.tsx
@@ -74,7 +74,9 @@ export function CharacterSprite({
       className={cn(
         'absolute inset-0',
         'transition-all duration-500 ease-out',
-        active && showVideo ? 'opacity-100 scale-100' : active && !idleVideoUrl ? 'opacity-100 scale-100' : !active ? 'opacity-40 scale-90 brightness-50' : 'opacity-0',
+        // !videoAvailable (not !idleVideoUrl): when every video candidate
+        // errors the static sprite takes over — it must not stay hidden
+        active && showVideo ? 'opacity-100 scale-100' : active && !videoAvailable ? 'opacity-100 scale-100' : !active ? 'opacity-40 scale-90 brightness-50' : 'opacity-0',
         position === 'left' && 'slide-in-left',
         position === 'right' && 'slide-in-right',
       )}

--- a/apps/client/design-system.html
+++ b/apps/client/design-system.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Tong Design System</title>
-<!-- Design system snapshot | 121 variables, 994 classes, 55 keyframes -->
+<!-- Design system snapshot | 121 variables, 996 classes, 55 keyframes -->
 <style>
 /* ══════════════════════════════════════════════════════════════
    BLOCK 1: globals.css — verbatim embed (single source of truth)
@@ -9504,6 +9504,29 @@ body:has(.playtest-pill-expanded) {
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+/* rrweb replay — Replayer iframe scaled into a phone-shaped stage */
+.pv-rrweb-player {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 16px 0;
+}
+
+.pv-rrweb-stage {
+  position: relative;
+  overflow: hidden;
+  border-radius: 8px;
+  border: 1px solid var(--line);
+  background: #000;
+}
+
+.pv-rrweb-stage iframe {
+  border: none;
+  background: #fff;
+  pointer-events: none;
 }
 
 /* Filmstrip — compact, phone-shaped */

--- a/apps/client/lib/playtest/rrweb-recorder.ts
+++ b/apps/client/lib/playtest/rrweb-recorder.ts
@@ -1,0 +1,231 @@
+/**
+ * rrweb DOM event recording for playtest sessions. Events are buffered and
+ * streamed to the worker as numbered JSON batches (mirroring the
+ * recording-chunks pattern), so a session that never reaches Submit still
+ * leaves a replayable stream behind.
+ */
+import { getPublicApiBase } from '@/lib/public-api-base';
+import { sessionLogger } from '@/lib/debug/session-logger';
+
+type RrwebEvent = { type: number; data: unknown; timestamp: number };
+
+const FLUSH_INTERVAL_MS = 10_000;
+// keepalive request bodies share a ~64KB in-flight budget per page
+const KEEPALIVE_BODY_CAP = 60_000;
+// Memory bound for sessions that stream-fail for a long stretch (~15 min of
+// dialogue play stays well under this; a runaway mutation loop won't OOM us)
+const MAX_BUFFERED_EVENTS = 50_000;
+
+export interface RrwebRecorderHandle {
+  flush: (keepalive?: boolean) => Promise<void>;
+  stop: () => Promise<void>;
+}
+
+/* ── html2canvas clone-iframe filter ─────────────────────────────────
+   The snapshot fallback clones the document into an iframe every 2.5s.
+   blockSelector stops rrweb serializing the iframe element, but rrweb's
+   iframe-load hook still attaches to its contentDocument (upstream bug),
+   emitting ~280KB of clone-document events per capture. The game has no
+   same-origin iframes of its own, so drop attach events for blocked
+   html2canvas iframes plus any later events targeting their nodes. */
+
+type RrwebNode = {
+  id?: number;
+  tagName?: string;
+  attributes?: Record<string, unknown>;
+  childNodes?: RrwebNode[];
+};
+
+type MutationData = {
+  source?: number;
+  id?: number;
+  isAttachIframe?: boolean;
+  adds?: { parentId?: number; node?: RrwebNode }[];
+  removes?: { parentId?: number; id?: number }[];
+  texts?: { id: number }[];
+  attributes?: { id: number }[];
+};
+
+const isCloneIframe = (n: RrwebNode): boolean =>
+  n.tagName === 'iframe' &&
+  typeof n.attributes?.class === 'string' &&
+  (n.attributes.class as string).includes('html2canvas-container');
+
+const subtreeIds = (n: RrwebNode, acc: number[]): number[] => {
+  if (typeof n.id === 'number') acc.push(n.id);
+  n.childNodes?.forEach((c) => subtreeIds(c, acc));
+  return acc;
+};
+
+const createCloneIframeFilter = () => {
+  let blockedIframeIds = new Set<number>();
+  let droppedRanges: [number, number][] = [];
+
+  const inDropped = (id: number): boolean =>
+    blockedIframeIds.has(id) || droppedRanges.some(([lo, hi]) => id >= lo && id <= hi);
+
+  const scan = (n: RrwebNode): void => {
+    if (isCloneIframe(n) && typeof n.id === 'number') blockedIframeIds.add(n.id);
+    n.childNodes?.forEach(scan);
+  };
+
+  return (event: RrwebEvent): boolean => {
+    if (event.type === 2) {
+      // Checkout: new id space — reset and rescan the snapshot tree
+      blockedIframeIds = new Set();
+      droppedRanges = [];
+      const node = (event.data as { node?: RrwebNode }).node;
+      if (node) scan(node);
+      return false;
+    }
+    if (event.type !== 3) return false;
+    const data = event.data as MutationData;
+    if (data.source !== 0) {
+      // Non-mutation incrementals (canvas, scroll, media…) carry a single
+      // target id — drop those aimed inside a dropped clone document
+      return typeof data.id === 'number' && inDropped(data.id);
+    }
+    data.adds?.forEach((a) => { if (a.node) scan(a.node); });
+    if (data.isAttachIframe) {
+      const parentId = data.adds?.[0]?.parentId;
+      if (typeof parentId === 'number' && blockedIframeIds.has(parentId) && data.adds?.[0]?.node) {
+        const ids = subtreeIds(data.adds[0].node, []);
+        if (ids.length) {
+          droppedRanges.push([
+            ids.reduce((a, b) => Math.min(a, b)),
+            ids.reduce((a, b) => Math.max(a, b)),
+          ]);
+        }
+        return true;
+      }
+      return false;
+    }
+    const ids: number[] = [];
+    data.adds?.forEach((a) => { if (typeof a.parentId === 'number') ids.push(a.parentId); });
+    data.removes?.forEach((r) => {
+      if (typeof r.id === 'number') ids.push(r.id);
+      if (typeof r.parentId === 'number') ids.push(r.parentId);
+    });
+    data.texts?.forEach((t) => ids.push(t.id));
+    data.attributes?.forEach((a) => ids.push(a.id));
+    return ids.length > 0 && ids.every(inDropped);
+  };
+};
+
+const gzip = async (text: string): Promise<Blob | null> => {
+  if (typeof CompressionStream !== 'function') return null;
+  try {
+    const stream = new Blob([text]).stream().pipeThrough(new CompressionStream('gzip'));
+    return await new Response(stream).blob();
+  } catch {
+    return null;
+  }
+};
+
+export async function startRrwebRecording(sessionId: string): Promise<RrwebRecorderHandle | null> {
+  if (typeof window === 'undefined') return null;
+  let record: typeof import('rrweb').record;
+  try {
+    ({ record } = await import('rrweb'));
+  } catch {
+    return null; // bundle failed to load — snapshot pipeline remains the capture
+  }
+
+  const buffer: RrwebEvent[] = [];
+  let seq = 0;
+  let dropped = 0;
+  let flushBusy = false;
+  let stopped = false;
+
+  const endpoint = (gz: boolean) =>
+    `${getPublicApiBase()}/api/v1/playtest/sessions/${sessionId}/rrweb-events?seq=${seq}${gz ? '&gz=1' : ''}`;
+
+  const postBatch = async (events: RrwebEvent[], keepalive: boolean): Promise<boolean> => {
+    const json = JSON.stringify(events);
+    const gzBody = await gzip(json);
+    const body: BodyInit = gzBody ?? json;
+    const size = gzBody ? gzBody.size : json.length;
+    if (keepalive && size > KEEPALIVE_BODY_CAP) {
+      // Too big for the keepalive budget — split and send halves separately;
+      // a single oversized event is dropped (next checkout re-snapshots).
+      if (events.length < 2) return false;
+      const mid = Math.ceil(events.length / 2);
+      const first = await postBatch(events.slice(0, mid), keepalive);
+      if (!first) return false;
+      return postBatch(events.slice(mid), keepalive);
+    }
+    try {
+      const res = await fetch(endpoint(Boolean(gzBody)), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body,
+        keepalive,
+      });
+      if (res.ok) {
+        seq += 1;
+        return true;
+      }
+      return false;
+    } catch {
+      return false;
+    }
+  };
+
+  const flush = async (keepalive = false): Promise<void> => {
+    if (flushBusy || buffer.length === 0) return;
+    flushBusy = true;
+    const pending = buffer.splice(0, buffer.length);
+    try {
+      const ok = await postBatch(pending, keepalive);
+      if (!ok) buffer.unshift(...pending); // retry on the next flush
+    } finally {
+      flushBusy = false;
+    }
+  };
+
+  const shouldDropCloneEvent = createCloneIframeFilter();
+
+  const stopRecordFn = record({
+    emit(event: RrwebEvent) {
+      if (shouldDropCloneEvent(event)) return;
+      buffer.push(event);
+      if (buffer.length > MAX_BUFFERED_EVENTS) {
+        buffer.shift();
+        dropped += 1;
+      }
+    },
+    // Periodic full snapshots keep batches independently replayable
+    checkoutEveryNms: 30_000,
+    maskAllInputs: false, // it's a game; nothing sensitive is typed
+    recordCanvas: true, // StrokeTracing exercises draw on canvas
+    slimDOMOptions: 'all',
+    inlineStylesheet: true,
+    // The html2canvas fallback clones the document into this iframe every
+    // 2.5s — without blocking it, every clone lands in the event stream
+    // as a ~280KB mutation
+    blockSelector: 'iframe.html2canvas-container',
+  });
+
+  if (!stopRecordFn) return null;
+
+  sessionLogger.logTrace('rrweb_recording_start', {
+    sessionId,
+    checkoutEveryNms: 30_000,
+    maxBufferedEvents: MAX_BUFFERED_EVENTS,
+  });
+
+  const interval = setInterval(() => { void flush(); }, FLUSH_INTERVAL_MS);
+
+  const stop = async (): Promise<void> => {
+    if (stopped) return;
+    stopped = true;
+    clearInterval(interval);
+    try { stopRecordFn(); } catch { /* already stopped */ }
+    if (dropped > 0) {
+      sessionLogger.logTrace('rrweb_events_dropped', { sessionId, dropped });
+    }
+    await flush();
+  };
+
+  return { flush, stop };
+}

--- a/apps/client/lib/playtest/rrweb-recorder.ts
+++ b/apps/client/lib/playtest/rrweb-recorder.ts
@@ -140,7 +140,7 @@ export async function startRrwebRecording(sessionId: string): Promise<RrwebRecor
   const endpoint = (gz: boolean) =>
     `${getPublicApiBase()}/api/v1/playtest/sessions/${sessionId}/rrweb-events?seq=${seq}${gz ? '&gz=1' : ''}`;
 
-  const postBatch = async (events: RrwebEvent[], keepalive: boolean): Promise<boolean> => {
+  const postBatch = async (events: RrwebEvent[], keepalive: boolean): Promise<RrwebEvent[]> => {
     const json = JSON.stringify(events);
     const gzBody = await gzip(json);
     const body: BodyInit = gzBody ?? json;
@@ -148,11 +148,13 @@ export async function startRrwebRecording(sessionId: string): Promise<RrwebRecor
     if (keepalive && size > KEEPALIVE_BODY_CAP) {
       // Too big for the keepalive budget — split and send halves separately;
       // a single oversized event is dropped (next checkout re-snapshots).
-      if (events.length < 2) return false;
+      if (events.length < 2) return [];
       const mid = Math.ceil(events.length / 2);
-      const first = await postBatch(events.slice(0, mid), keepalive);
-      if (!first) return false;
-      return postBatch(events.slice(mid), keepalive);
+      const firstHalf = events.slice(0, mid);
+      const secondHalf = events.slice(mid);
+      const firstUnsent = await postBatch(firstHalf, keepalive);
+      if (firstUnsent.length > 0) return [...firstUnsent, ...secondHalf];
+      return postBatch(secondHalf, keepalive);
     }
     try {
       const res = await fetch(endpoint(Boolean(gzBody)), {
@@ -163,11 +165,11 @@ export async function startRrwebRecording(sessionId: string): Promise<RrwebRecor
       });
       if (res.ok) {
         seq += 1;
-        return true;
+        return [];
       }
-      return false;
+      return events;
     } catch {
-      return false;
+      return events;
     }
   };
 
@@ -176,8 +178,8 @@ export async function startRrwebRecording(sessionId: string): Promise<RrwebRecor
     flushBusy = true;
     const pending = buffer.splice(0, buffer.length);
     try {
-      const ok = await postBatch(pending, keepalive);
-      if (!ok) buffer.unshift(...pending); // retry on the next flush
+      const unsent = await postBatch(pending, keepalive);
+      if (unsent.length > 0) buffer.unshift(...unsent); // retry on the next flush
     } finally {
       flushBusy = false;
     }

--- a/apps/client/package-lock.json
+++ b/apps/client/package-lock.json
@@ -16,6 +16,7 @@
         "next": "^14.2.35",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "rrweb": "^2.0.1",
         "zod": "^3.24.0"
       },
       "devDependencies": {
@@ -9961,6 +9962,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@rrweb/types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rrweb/types/-/types-2.0.1.tgz",
+      "integrity": "sha512-x8cNaKFxdvS0/5IfKOj1xG8Htnw1fUwqoPqgP61bOaWqZL6t9UtRPpO9ZlMB2z+FiTxg9zlFFL+Da4ZpFuhoiA==",
+      "license": "MIT"
+    },
+    "node_modules/@rrweb/utils": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rrweb/utils/-/utils-2.0.1.tgz",
+      "integrity": "sha512-t+b+4rB23/e4EpoGMdPUr6cKtDsFuOb3LxA9IHE8e3A/Xo0nMUfH0bkwqdpUNa/VGDOdiGeG3bhHjuO9zWX54g==",
+      "license": "MIT"
+    },
     "node_modules/@sindresorhus/is": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
@@ -11813,6 +11826,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/css-font-loading-module": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.7.tgz",
+      "integrity": "sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==",
+      "license": "MIT"
+    },
     "node_modules/@types/diff-match-patch": {
       "version": "1.0.36",
       "resolved": "https://registry.npmjs.org/@types/diff-match-patch/-/diff-match-patch-1.0.36.tgz",
@@ -11867,6 +11886,12 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@xstate/fsm": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@xstate/fsm/-/fsm-1.6.5.tgz",
+      "integrity": "sha512-b5o1I6aLNeYlU/3CPlj/Z91ybk1gUsKT+5NAJI+2W4UjvS5KLG28K9v5UvNoFVjHV8PajVZ00RH3vnjyQO7ZAw==",
+      "license": "MIT"
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -13754,6 +13779,12 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
     "node_modules/mkdirp": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -13785,9 +13816,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -14198,6 +14229,68 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/rrdom": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rrdom/-/rrdom-2.0.1.tgz",
+      "integrity": "sha512-z8GdQWFmVfa8GpcGkAqfBXseb89z0ciTPSBkID0qr0i6KHCye1MdQ4VoXFf0Ejp3ELe/c7AObu4zsbSbMT+hiw==",
+      "license": "MIT",
+      "dependencies": {
+        "rrweb-snapshot": "^2.0.1"
+      }
+    },
+    "node_modules/rrweb": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rrweb/-/rrweb-2.0.1.tgz",
+      "integrity": "sha512-MQYzOtI7aZft9ffDMT6rmRSAj6hO4W6T7iA4eB9Mtcuiv3M7DbnnxDMrcPW0sQXepgYN46YhfSKe75d/mlUHrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rrweb/types": "^2.0.1",
+        "@rrweb/utils": "^2.0.1",
+        "@types/css-font-loading-module": "0.0.7",
+        "@xstate/fsm": "^1.4.0",
+        "base64-arraybuffer": "^1.0.1",
+        "mitt": "^3.0.0",
+        "rrdom": "^2.0.1",
+        "rrweb-snapshot": "^2.0.1"
+      }
+    },
+    "node_modules/rrweb-snapshot": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rrweb-snapshot/-/rrweb-snapshot-2.0.1.tgz",
+      "integrity": "sha512-H8TA29ct2tpYtr5oaB0N+ksRY9bhEErfAYcKbce4+w8lqEUQChpKZd41HpBJLkp04b5QUfWUg4v6r9Okf8r7vA==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss": "^8.4.38"
+      }
+    },
+    "node_modules/rrweb-snapshot/node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/safer-buffer": {

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -22,6 +22,7 @@
     "next": "^14.2.35",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "rrweb": "^2.0.1",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/apps/server/src/gemini-video.mjs
+++ b/apps/server/src/gemini-video.mjs
@@ -603,8 +603,11 @@ export async function analyzePlaytestSession(args) {
     contextParts.push(`User comments (with AI clarifications):\n${args.commentsJson}`);
   }
 
-  // If we have a video file, upload it first
+  // If we have a video file, upload it first. The sniffed container type
+  // must travel with the fileUri — Gemini 400s when the declared mime
+  // (analyzeVideo defaults to video/mp4) mismatches the uploaded bytes.
   let fileUri = args.fileUri;
+  let mimeType = args.mimeType;
   if (!fileUri && args.videoPath) {
     const uploaded = await uploadVideo({
       filePath: args.videoPath,
@@ -612,6 +615,7 @@ export async function analyzePlaytestSession(args) {
       mimeType: args.videoPath.endsWith('.mp4') ? 'video/mp4' : 'video/webm',
     });
     fileUri = uploaded.fileUri;
+    mimeType = uploaded.mimeType;
   }
   if (!fileUri && args.videoUrl) {
     const uploaded = await uploadVideo({
@@ -620,6 +624,7 @@ export async function analyzePlaytestSession(args) {
       mimeType: args.videoUrl.endsWith('.mp4') ? 'video/mp4' : 'video/webm',
     });
     fileUri = uploaded.fileUri;
+    mimeType = uploaded.mimeType;
   }
 
   if (!fileUri) {
@@ -628,6 +633,7 @@ export async function analyzePlaytestSession(args) {
 
   return analyzeVideo({
     fileUri,
+    mimeType,
     prompt,
     model: args.model || (preset === ANALYSIS_PRESETS.ux_friction ? 'pro' : 'flash'),
     mediaResolution: args.mediaResolution || 'low',

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -2877,6 +2877,109 @@ async function handleRequest(request: Request): Promise<Response> {
       return jsonResponse(200, { ok: true, seq });
     }
 
+    // Receive an rrweb event batch during an active session. Mirrors the
+    // recording-chunks contract: stores the batch, never flips status or
+    // dispatches anything. ?gz=1 marks a CompressionStream-gzipped body.
+    if (pathname.match(/^\/api\/v1\/playtest\/sessions\/[^/]+\/rrweb-events$/) && request.method === 'POST') {
+      const sessionId = pathname.split('/')[5];
+      const env = (globalThis as any).__env;
+      if (!env?.DB) return jsonResponse(500, { error: 'db_not_configured' });
+      if (!env?.TONG_RUNS_BUCKET) return jsonResponse(500, { error: 'r2_not_configured' });
+      const row = await env.DB.prepare(
+        `SELECT session_id FROM playtest_sessions WHERE session_id = ?`
+      ).bind(sessionId).first();
+      if (!row) return jsonResponse(404, { error: 'session_not_found', sessionId });
+      const seq = parseInt(url.searchParams.get('seq') || '', 10);
+      if (!Number.isFinite(seq) || seq < 0 || seq > 99999) {
+        return jsonResponse(400, { error: 'invalid_seq' });
+      }
+      const gzipped = url.searchParams.get('gz') === '1';
+      const key = `playtest/${sessionId}/rrweb/batch-${String(seq).padStart(5, '0')}.json`;
+      await env.TONG_RUNS_BUCKET.put(key, request.body, {
+        httpMetadata: {
+          contentType: 'application/json',
+          ...(gzipped ? { contentEncoding: 'gzip' } : {}),
+        },
+      });
+      return jsonResponse(200, { ok: true, seq });
+    }
+
+    // rrweb batch manifest — the replayer fetches batches individually
+    if (pathname.match(/^\/api\/v1\/playtest\/sessions\/[^/]+\/rrweb-events$/) && request.method === 'GET') {
+      const sessionId = pathname.split('/')[5];
+      const env = (globalThis as any).__env;
+      if (!env?.TONG_RUNS_BUCKET) return jsonResponse(500, { error: 'r2_not_configured' });
+      const listing = await env.TONG_RUNS_BUCKET.list({ prefix: `playtest/${sessionId}/rrweb/` });
+      if (!listing.objects.length) return jsonResponse(404, { error: 'no_rrweb_events' });
+      const batches = listing.objects
+        .map((o: { key: string; size: number }) => ({
+          name: o.key.split('/').pop()!,
+          size: o.size,
+        }))
+        .sort((a: { name: string }, b: { name: string }) => a.name.localeCompare(b.name));
+      return jsonResponse(200, { sessionId, count: batches.length, batches });
+    }
+
+    // Serve a single rrweb batch, decompressed (stored gzip-encoded batches
+    // are piped through DecompressionStream so consumers always see JSON)
+    if (pathname.match(/^\/api\/v1\/playtest\/sessions\/[^/]+\/rrweb-events\/batch-\d{5}\.json$/) && request.method === 'GET') {
+      const parts = pathname.split('/');
+      const sessionId = parts[5];
+      const filename = parts[7];
+      const env = (globalThis as any).__env;
+      if (!env?.TONG_RUNS_BUCKET) return jsonResponse(500, { error: 'r2_not_configured' });
+      const obj = await env.TONG_RUNS_BUCKET.get(`playtest/${sessionId}/rrweb/${filename}`);
+      if (!obj) return jsonResponse(404, { error: 'not_found' });
+      const body = obj.httpMetadata?.contentEncoding === 'gzip'
+        ? obj.body.pipeThrough(new DecompressionStream('gzip'))
+        : obj.body;
+      return new Response(body, {
+        headers: {
+          'Content-Type': 'application/json',
+          'Access-Control-Allow-Origin': '*',
+          'Cache-Control': 'max-age=300',
+        },
+      });
+    }
+
+    // Store the headless rrweb render (Phase 3 of the rrweb pipeline)
+    if (pathname.match(/^\/api\/v1\/playtest\/sessions\/[^/]+\/rrweb-render$/) && request.method === 'PUT') {
+      const sessionId = pathname.split('/')[5];
+      const env = (globalThis as any).__env;
+      if (!env?.TONG_RUNS_BUCKET) return jsonResponse(500, { error: 'r2_not_configured' });
+      const key = `playtest/${sessionId}/rrweb-render.webm`;
+      await env.TONG_RUNS_BUCKET.put(key, request.body, {
+        httpMetadata: { contentType: request.headers.get('content-type') || 'video/webm' },
+      });
+      const publicBase = env?.TONG_RUNS_PUBLIC_BASE_URL || 'https://runs.tong.berlayar.ai';
+      return jsonResponse(200, { ok: true, key, url: `${publicBase}/${key}` });
+    }
+
+    if (pathname.match(/^\/api\/v1\/playtest\/sessions\/[^/]+\/rrweb-render$/) && (request.method === 'GET' || request.method === 'HEAD')) {
+      const sessionId = pathname.split('/')[5];
+      const env = (globalThis as any).__env;
+      if (!env?.TONG_RUNS_BUCKET) return jsonResponse(500, { error: 'r2_not_configured' });
+      const obj = await env.TONG_RUNS_BUCKET.get(`playtest/${sessionId}/rrweb-render.webm`);
+      if (!obj) return jsonResponse(404, { error: 'no_rrweb_render' });
+      const renderType = obj.httpMetadata?.contentType || 'video/webm';
+      if (request.method === 'HEAD') {
+        return new Response(null, {
+          headers: {
+            'Content-Type': renderType,
+            'Content-Length': String(obj.size),
+            'Access-Control-Allow-Origin': '*',
+          },
+        });
+      }
+      return new Response(obj.body, {
+        headers: {
+          'Content-Type': renderType,
+          'Access-Control-Allow-Origin': '*',
+          'Cache-Control': 'max-age=300',
+        },
+      });
+    }
+
     // Proxy recording from R2 (avoids CORS on direct R2 access)
     if (pathname.match(/^\/api\/v1\/playtest\/sessions\/[^/]+\/recording$/) && (request.method === 'GET' || request.method === 'HEAD')) {
       const sessionId = pathname.split('/')[5];

--- a/docs/rrweb-session-replay-handoff.md
+++ b/docs/rrweb-session-replay-handoff.md
@@ -181,3 +181,34 @@ production 2026-06-10 (client `tong.berlayar.ai` via OpenNext, worker
   like the filmstrip cap) and note the cap in the session state log.
 - WebAudio/TTS audio is not captured by rrweb — out of scope; note it.
 - The HD `getDisplayMedia` path stays as-is (it's already true pixels).
+
+## Implementation notes (built 2026-06-10, branch `feat/rrweb-session-replay`)
+
+All four phases shipped. Gotchas discovered while building:
+
+1. **`rrweb-player` 2.0.1 has a broken published dist** — its compiled
+   Player component never constructs a Replayer (no `new Replayer` in any
+   dist format), so it mounts an empty white frame, silently. Both the
+   backstage replay (`components/playtest/RrwebReplay.tsx`) and the render
+   script drive `rrweb`'s `Replayer` class directly instead, with our own
+   minimal controls.
+2. **rrweb records the snapshot fallback's own machinery.** The hidden
+   recording canvas gets `class="rr-block"`, and `blockSelector:
+   'iframe.html2canvas-container'` blocks the html2canvas clone iframe —
+   but rrweb's iframe-load hook attaches to a *blocked* iframe's
+   contentDocument anyway (upstream bug), emitting ~280KB of clone-document
+   events per 2.5s capture. `rrweb-recorder.ts` carries a filter that drops
+   attach events for blocked html2canvas iframes plus later events whose
+   target ids fall inside the dropped documents. Steady-state wire cost
+   after filtering: <1KB gzipped per 10s batch (vs ~320KB before).
+3. **Batches are stored with `contentEncoding: gzip` R2 metadata**; the
+   worker GET pipes them through `DecompressionStream`, so consumers always
+   see plain JSON.
+4. `.github/workflows/playtest-agent-pipeline.yml` does not exist on this
+   branch's lineage (it lives on unmerged branches) — the render step is
+   CLI-only for now: `node scripts/render-rrweb-video.mjs --session-id <id>
+   --upload` (needs root `npm install` + `npx playwright install chromium`).
+   Wire it into the pipeline when that workflow lands.
+5. The analyzer (`scripts/analyze-playtest-session.mjs`) HEADs
+   `playtest/{id}/rrweb-render.webm` on the public R2 base and prefers it
+   over `recording.webm` when present.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,62 @@
+{
+  "name": "tong",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "tong",
+      "version": "0.1.0",
+      "devDependencies": {
+        "playwright": "^1.49.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -46,6 +46,10 @@
     "launch:agents": "./scripts/launch-parallel-agents.sh",
     "test:kg-contract-schema": "node scripts/kg_contract_schema_check.mjs",
     "dev:remotion": "npm --prefix packages/remotion run preview",
-    "dev:sam2": "SAM2_MOCK=1 python3 -m uvicorn server:app --port 8100 --app-dir packages/sam2"
+    "dev:sam2": "SAM2_MOCK=1 python3 -m uvicorn server:app --port 8100 --app-dir packages/sam2",
+    "render:rrweb": "node scripts/render-rrweb-video.mjs"
+  },
+  "devDependencies": {
+    "playwright": "^1.49.0"
   }
 }

--- a/scripts/analyze-playtest-session.mjs
+++ b/scripts/analyze-playtest-session.mjs
@@ -183,9 +183,25 @@ console.error(`[analyze] Mode: ${mode}${mode === 'screenshots' ? ` (${screenshot
 
 // ── Build video source (for video mode) ─────────────────────────────
 
-const videoUrl = args['video-path']
+// Prefer the headless rrweb render (full-fidelity, smooth) over the
+// low-fps html2canvas recording when one has been produced for the session
+let videoUrl = args['video-path']
   ? undefined
   : `${r2Base}/playtest/${sessionId}/recording.webm`;
+
+if (mode === 'video' && !args['video-path']) {
+  const rrwebRenderUrl = `${r2Base}/playtest/${sessionId}/rrweb-render.webm`;
+  try {
+    const head = await fetch(rrwebRenderUrl, {
+      method: 'HEAD',
+      headers: { 'User-Agent': 'Mozilla/5.0 (tong-pipeline)' },
+    });
+    if (head.ok) {
+      videoUrl = rrwebRenderUrl;
+      console.error('[analyze] Using rrweb render as video source');
+    }
+  } catch { /* fall back to recording.webm */ }
+}
 
 const videoPath = args['video-path'] || undefined;
 

--- a/scripts/render-rrweb-video.mjs
+++ b/scripts/render-rrweb-video.mjs
@@ -1,0 +1,225 @@
+#!/usr/bin/env node
+/**
+ * Render a playtest session's rrweb event stream to video.
+ *
+ * Replays the events in headless Chromium (real browser engine — full
+ * fidelity, smooth motion) and captures the replay with Playwright's
+ * recordVideo. The result is what Gemini analyzes instead of the low-fps
+ * html2canvas recording.
+ *
+ * Usage:
+ *   node scripts/render-rrweb-video.mjs --session-id <id> [options]
+ *
+ * Options:
+ *   --session-id   Playtest session ID (required)
+ *   --api-base     Worker API base (default: https://tong-api.erniesg.workers.dev)
+ *   --output       Output webm path (default: rrweb-render-<id>.webm)
+ *   --speed        Replay speed multiplier (default: 1)
+ *   --upload       PUT the render to the worker (playtest/<id>/rrweb-render.webm)
+ *   --events       Local events JSON path (array of rrweb events; skips fetch)
+ *
+ * Requires the `playwright` npm package plus a chromium install
+ * (`npm install -D playwright && npx playwright install chromium --with-deps`).
+ *
+ * Exit codes: 0 rendered OK, 1 error, 2 session has no rrweb events.
+ */
+
+import { parseArgs } from 'node:util';
+import { readFileSync, mkdtempSync, rmSync, statSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+const USER_AGENT = 'Mozilla/5.0 (tong-pipeline)';
+
+const { values: args } = parseArgs({
+  options: {
+    'session-id': { type: 'string' },
+    'api-base': { type: 'string', default: 'https://tong-api.erniesg.workers.dev' },
+    output: { type: 'string' },
+    speed: { type: 'string', default: '1' },
+    upload: { type: 'boolean', default: false },
+    events: { type: 'string' },
+    help: { type: 'boolean', default: false },
+  },
+  strict: false,
+});
+
+if (args.help || !args['session-id']) {
+  console.error('Usage: node scripts/render-rrweb-video.mjs --session-id <id> [--api-base url] [--output path] [--speed N] [--upload] [--events path]');
+  process.exit(args.help ? 0 : 1);
+}
+
+const sessionId = args['session-id'];
+const apiBase = args['api-base'];
+const speed = Math.max(0.5, Number(args.speed) || 1);
+const outPath = resolve(args.output || `rrweb-render-${sessionId}.webm`);
+
+// ── Resolve dependencies (playwright at root, rrweb-player via client) ──
+
+function resolveModule(name) {
+  for (const base of [ROOT, join(ROOT, 'apps', 'client')]) {
+    try {
+      return createRequire(join(base, 'package.json')).resolve(name);
+    } catch { /* try next */ }
+  }
+  return null;
+}
+
+const playwrightPath = resolveModule('playwright');
+if (!playwrightPath) {
+  console.error('[render] playwright is not installed. Run: npm install -D playwright && npx playwright install chromium --with-deps');
+  process.exit(1);
+}
+const playwrightMod = await import(pathToFileURL(playwrightPath).href);
+const chromium = playwrightMod.chromium || playwrightMod.default?.chromium;
+
+// rrweb's Replayer is driven directly (rrweb-player 2.0.1 ships a broken
+// dist). The exports map hides the UMD build — resolve the main entry and
+// take the sibling files from its dist directory.
+const rrwebMain = resolveModule('rrweb');
+if (!rrwebMain) {
+  console.error('[render] rrweb not found. Run: npm --prefix apps/client ci');
+  process.exit(1);
+}
+const rrwebDist = dirname(rrwebMain);
+const playerJsPath = join(rrwebDist, 'rrweb.umd.min.cjs');
+const playerCssPath = join(rrwebDist, 'style.css');
+
+// ── Load events ─────────────────────────────────────────────────────
+
+async function fetchJson(url) {
+  const res = await fetch(url, { headers: { 'User-Agent': USER_AGENT } });
+  if (!res.ok) throw new Error(`${url} returned ${res.status}`);
+  return res.json();
+}
+
+let events;
+if (args.events) {
+  events = JSON.parse(readFileSync(args.events, 'utf8'));
+} else {
+  const base = `${apiBase}/api/v1/playtest/sessions/${sessionId}/rrweb-events`;
+  let manifest;
+  try {
+    manifest = await fetchJson(base);
+  } catch (err) {
+    console.error(`[render] No rrweb events for session ${sessionId}: ${err.message}`);
+    process.exit(2);
+  }
+  console.error(`[render] Fetching ${manifest.count} event batches...`);
+  events = [];
+  for (const batch of manifest.batches) {
+    events.push(...await fetchJson(`${base}/${batch.name}`));
+  }
+}
+
+if (!Array.isArray(events) || events.length < 2) {
+  console.error('[render] Not enough events to replay');
+  process.exit(2);
+}
+
+// Session viewport comes from rrweb's Meta event (type 4)
+const meta = events.find((e) => e.type === 4);
+const width = Math.max(2, Math.round((meta?.data?.width || 390) / 2) * 2);
+const height = Math.max(2, Math.round((meta?.data?.height || 844) / 2) * 2);
+const durationMs = events[events.length - 1].timestamp - events[0].timestamp;
+console.error(`[render] ${events.length} events, ${Math.round(durationMs / 1000)}s session, ${width}x${height}, speed ${speed}x`);
+
+// ── Replay in headless Chromium with video recording ────────────────
+
+const playerJs = readFileSync(playerJsPath, 'utf8');
+const playerCss = readFileSync(playerCssPath, 'utf8');
+
+const html = `<!doctype html>
+<html><head><meta charset="utf-8">
+<style>${playerCss}</style>
+<style>
+  html, body { margin: 0; padding: 0; background: #0d0d1a; overflow: hidden; }
+  .replayer-wrapper { position: relative; }
+  .replayer-wrapper iframe { border: none; background: #fff; }
+</style>
+</head><body></body></html>`;
+
+const videoDir = mkdtempSync(join(tmpdir(), 'rrweb-render-'));
+const browser = await chromium.launch({
+  args: ['--autoplay-policy=no-user-gesture-required'],
+});
+
+try {
+  const context = await browser.newContext({
+    viewport: { width, height },
+    recordVideo: { dir: videoDir, size: { width, height } },
+    userAgent: USER_AGENT,
+  });
+  const page = await context.newPage();
+  page.on('pageerror', (err) => console.error(`[render] page error: ${err.message}`));
+  await page.setContent(html, { waitUntil: 'load' });
+  await page.addScriptTag({ content: playerJs });
+
+  await page.evaluate(
+    ({ events, speed, durationMs }) => {
+      window.__rrwebDone = false;
+      const replayer = new window.rrweb.Replayer(events, {
+        root: document.body,
+        speed,
+        UNSAFE_replayCanvas: true,
+        showWarning: false,
+      });
+      replayer.on('finish', () => { window.__rrwebDone = true; });
+      replayer.play(0);
+      // Backstop in case 'finish' never fires (e.g. trailing incremental
+      // events the replayer skips)
+      setTimeout(() => { window.__rrwebDone = true; }, Math.round(durationMs / speed) + 10_000);
+    },
+    { events, speed, durationMs },
+  );
+
+  const timeoutMs = Math.round(durationMs / speed) + 60_000;
+  console.error(`[render] Replaying (timeout ${Math.round(timeoutMs / 1000)}s)...`);
+  await page.waitForFunction(() => window.__rrwebDone, null, {
+    timeout: timeoutMs,
+    polling: 1000,
+  });
+  await page.waitForTimeout(1000); // trailing frames
+
+  const video = page.video();
+  await context.close(); // finalizes the recording
+  await video.saveAs(outPath);
+} finally {
+  await browser.close();
+  rmSync(videoDir, { recursive: true, force: true });
+}
+
+const sizeBytes = statSync(outPath).size;
+console.error(`[render] Wrote ${outPath} (${Math.round(sizeBytes / 1024)} KB)`);
+
+// ── Optional upload to R2 via the worker ────────────────────────────
+
+if (args.upload) {
+  const res = await fetch(`${apiBase}/api/v1/playtest/sessions/${sessionId}/rrweb-render`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'video/webm', 'User-Agent': USER_AGENT },
+    body: readFileSync(outPath),
+  });
+  if (!res.ok) {
+    console.error(`[render] Upload failed: ${res.status}`);
+    process.exit(1);
+  }
+  const data = await res.json();
+  console.error(`[render] Uploaded: ${data.url}`);
+}
+
+console.log(JSON.stringify({
+  sessionId,
+  output: outPath,
+  bytes: sizeBytes,
+  width,
+  height,
+  durationMs,
+  speed,
+  events: events.length,
+  uploaded: Boolean(args.upload),
+}, null, 2));

--- a/scripts/rrweb_recorder_keepalive_check.mjs
+++ b/scripts/rrweb_recorder_keepalive_check.mjs
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import vm from 'node:vm';
+import { readFileSync } from 'node:fs';
+
+const repoRoot = process.cwd();
+const clientRequire = createRequire(path.join(repoRoot, 'apps/client/package.json'));
+const ts = clientRequire('typescript');
+
+const sourcePath = path.join(repoRoot, 'apps/client/lib/playtest/rrweb-recorder.ts');
+const source = readFileSync(sourcePath, 'utf8');
+const compiled = ts.transpileModule(source, {
+  compilerOptions: {
+    module: ts.ModuleKind.CommonJS,
+    target: ts.ScriptTarget.ES2022,
+    esModuleInterop: true,
+  },
+}).outputText;
+
+const posts = [];
+const fetchResults = [true, false, true];
+let emitEvent;
+let stopped = false;
+
+const sandboxRequire = (specifier) => {
+  if (specifier === '@/lib/public-api-base') {
+    return { getPublicApiBase: () => 'https://api.example.test' };
+  }
+  if (specifier === '@/lib/debug/session-logger') {
+    return { sessionLogger: { logTrace() {} } };
+  }
+  if (specifier === 'rrweb') {
+    return {
+      record(options) {
+        emitEvent = options.emit;
+        return () => { stopped = true; };
+      },
+    };
+  }
+  return clientRequire(specifier);
+};
+
+const context = vm.createContext({
+  Blob,
+  CompressionStream: undefined,
+  console,
+  exports: {},
+  fetch: async (url, init) => {
+    posts.push({
+      url,
+      keepalive: Boolean(init?.keepalive),
+      events: JSON.parse(String(init?.body || '[]')).map((event) => event.data.id),
+    });
+    return { ok: fetchResults.shift() ?? true };
+  },
+  module: { exports: {} },
+  require: sandboxRequire,
+  Response,
+  setInterval,
+  clearInterval,
+  window: {},
+});
+context.exports = context.module.exports;
+
+vm.runInContext(compiled, context, { filename: sourcePath });
+
+const { startRrwebRecording } = context.module.exports;
+assert.equal(typeof startRrwebRecording, 'function');
+
+const recorder = await startRrwebRecording('session-a');
+assert.ok(recorder, 'recorder should start with mocked rrweb');
+assert.equal(typeof emitEvent, 'function');
+
+for (let id = 0; id < 4; id += 1) {
+  emitEvent({
+    type: 3,
+    data: { id, payload: 'x'.repeat(20_000) },
+    timestamp: id,
+  });
+}
+
+await recorder.flush(true);
+assert.deepEqual(posts.map((post) => post.events), [[0, 1], [2, 3]]);
+
+await recorder.flush(false);
+assert.deepEqual(
+  posts.map((post) => post.events),
+  [[0, 1], [2, 3], [2, 3]],
+  'only the failed second keepalive split should be retried',
+);
+
+await recorder.stop();
+assert.equal(stopped, true);


### PR DESCRIPTION
Executes `docs/rrweb-session-replay-handoff.md` — rrweb DOM event recording becomes the canonical capture for remote playtest sessions; the html2canvas snapshot pipeline stays as fallback. Stacked on #342.

## What's here

- **Record + stream**: rrweb recording starts with the playtest overlay; events are gzipped and streamed every 10s to `POST :id/rrweb-events?seq=N` (stored as `playtest/{id}/rrweb/batch-NNNNN.json` with `contentEncoding: gzip`, served back decompressed via a manifest). Abandoned sessions keep their stream — same contract as recording-chunks: never flips status, never dispatches.
- **Backstage Replay tab**: default view when events exist; drives rrweb's `Replayer` directly with play/seek/speed controls. rrweb-player 2.0.1 ships a broken dist (its Player never constructs a Replayer — mounts an empty white frame), so it isn't used.
- **Render to video**: `scripts/render-rrweb-video.mjs` replays events in headless Chromium with Playwright `recordVideo` (~25–34fps vs 0.4fps) and `--upload`s to R2; the analyzer HEADs `rrweb-render.webm` and prefers it over `recording.webm`.
- **Recording hygiene**: the fallback's hidden canvas is `rr-block`'d and a recorder-side filter drops the html2canvas clone-iframe events rrweb emits even for blocked iframes (upstream bug). Steady-state wire cost: **<1KB gzipped per 10s batch** (was ~320KB).
- **Bonus fix**: `analyzePlaytestSession` never forwarded the sniffed container mime to `generateContent`, which defaults to `video/mp4` — Gemini 400s every webm recording (old ones included; bisected via the Files API). One-line carry-through fixes video analysis for both pipelines.

## Verified on production (deployed 2026-06-10)

- Mobile-context session against tong.berlayar.ai streamed 15 batches during play; closed without submitting → replayable stream (`haRNLnPjhWUM`).
- Prod backstage replays the full game: opening `<video>` cinematic plays with its typewriter caption, hangout scene renders its pojangmacha backdrop natively.
- Headless render of the prod session: 2305 frames / 90s, cinematic included; Gemini consumed it end-to-end (score 7/10, 1 issue — a text-pacing observation only visible at full framerate).
- Regression: snapshot pipeline untouched; assembled recording from streamed chunks plays with 23 frames (>5). `npx tsc --noEmit` clean.

## Notes

- `playtest-agent-pipeline.yml` doesn't exist on this lineage — render step is CLI-only until that workflow lands (root `npm install` + `npx playwright install chromium`; see handoff doc implementation notes).
- WebAudio/TTS audio is not captured by rrweb (known, out of scope). HD `getDisplayMedia` path unchanged.

## Update: first real bug caught by the replay

Reviewing a hangout-session replay surfaced that **Ha-eun never appeared** — her `<video>` element was recorded frozen at `paused / 0:00`. Root cause (commit `48196cf`):
- `NPC_SPRITES.haeun.idleVideo` was a page-relative path → 404 on production (the mp4 only exists on `assets.tong.berlayar.ai`)
- when every video candidate errored, `CharacterSprite`'s visibility check (keyed off the original prop) kept even the static-portrait fallback at `opacity-0`, hiding the character entirely

Both fixed and verified on production: fresh session `Lalo8rAB1wBB` records her idle loop playing (`paused: false`, currentTime advancing), and the headless render reproduces it — https://runs.tong.berlayar.ai/playtest/Lalo8rAB1wBB/rrweb-render.webm
