### PR TITLE
fix(qa): honor blocked issue routing labels

### DIFF
--- a/.agents/skills/_functional-qa/config/codex-cloud.json
+++ b/.agents/skills/_functional-qa/config/codex-cloud.json
@@ -64,15 +64,6 @@
       ]
     },
     {
-      "id": "batch-parallel",
-      "description": "Independent remote-first tooling and asset-foundation work that can run in parallel with the client-shell priority wave.",
-      "issues": [
-        "#35",
-        "#36",
-        "#34"
-      ]
-    },
-    {
       "id": "batch-2",
       "description": "Second cloud wave: follow-up onboarding, HUD, Block Crush guidance, and tap-flow fixes after the priority wave settles.",
       "issues": [

--- a/.agents/skills/_functional-qa/config/repo-adapter.json
+++ b/.agents/skills/_functional-qa/config/repo-adapter.json
@@ -131,6 +131,14 @@
         "Treat the API half of scenario-seed mounts as a server-state verification issue, not a reviewer-proof visual transition.",
         "Prefer strict API replay with contract assertions and console-state traces over screenshot gates."
       ]
+    },
+    {
+      "match": "#359",
+      "issue_class_override": "functional-logic",
+      "notes": [
+        "Treat this as archival and queue-control work, not as an API or fixture implementation issue.",
+        "The blocked-on-human and lane:qa-platform labels remain authoritative until consolidation is reviewed."
+      ]
     }
   ],
   "issue_playbooks": [

--- a/.agents/skills/_functional-qa/config/repo-adapter.json
+++ b/.agents/skills/_functional-qa/config/repo-adapter.json
@@ -135,6 +135,12 @@
     {
       "match": "#359",
       "issue_class_override": "functional-logic",
+      "fallback_labels": [
+        "blocked-on-human",
+        "lane:qa-platform",
+        "needs-consolidation",
+        "rucksack-blocked"
+      ],
       "notes": [
         "Treat this as archival and queue-control work, not as an API or fixture implementation issue.",
         "The blocked-on-human and lane:qa-platform labels remain authoritative until consolidation is reviewed."

--- a/.agents/skills/_functional-qa/scripts/dispatch_issue_queue.py
+++ b/.agents/skills/_functional-qa/scripts/dispatch_issue_queue.py
@@ -177,16 +177,16 @@ def build_dispatch_summary(
                     }
                 )
                 continue
+            ready, ready_reason = adapter.dispatch_eligibility(issue)
+            if not ready:
+                skipped.append({"issue_ref": ref, "provider": provider_id, "reason": ready_reason})
+                continue
             if issue.get("batch_id") == "unassigned":
                 skipped.append({"issue_ref": ref, "provider": provider_id, "reason": "issue is not in an execution batch"})
                 continue
             deps_ok, deps_reason = dependencies_satisfied(issue)
             if not deps_ok:
                 skipped.append({"issue_ref": ref, "provider": provider_id, "reason": deps_reason})
-                continue
-            ready, ready_reason = adapter.dispatch_eligibility(issue)
-            if not ready:
-                skipped.append({"issue_ref": ref, "provider": provider_id, "reason": ready_reason})
                 continue
             existing_pr = open_prs.get(issue["branch_name"])
             if existing_pr:

--- a/.agents/skills/_functional-qa/scripts/issue_router.py
+++ b/.agents/skills/_functional-qa/scripts/issue_router.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from qa_runtime import (
     apply_execution_mode_override,
+    apply_issue_label_gates,
     CONFIG_ROOT,
     REPO_ROOT,
     artifact_root,
@@ -154,6 +155,17 @@ def score_worktree(worktree: dict[str, Any], lowered_text: str, labels_text: str
     return (score, reasons, explicit_matches)
 
 
+def preferred_lane_from_labels(labels: list[str]) -> str | None:
+    valid_lanes = {worktree["id"] for worktree in ROUTING_CONFIG["worktrees"]}
+    requested = {
+        label.split(":", 1)[1].strip().lower()
+        for label in labels
+        if label.lower().startswith("lane:") and ":" in label
+    }
+    valid_requested = requested & valid_lanes
+    return next(iter(valid_requested)) if len(valid_requested) == 1 else None
+
+
 def route_worktree(issue: dict[str, Any], issue_class: str, explicit_paths: list[str]) -> tuple[dict[str, Any], list[str], bool, list[str]]:
     lowered_text = f"{issue['title']}\n{issue['body']}".lower()
     labels_text = " ".join(label.lower() for label in issue.get("labels", []))
@@ -161,7 +173,9 @@ def route_worktree(issue: dict[str, Any], issue_class: str, explicit_paths: list
     explicit_candidates: set[str] = set()
     project_fields = issue.get("project_fields", {})
     lane_field = project_control_plane().get("lane_field") if project_control_plane() else None
-    preferred_lane = project_fields.get(lane_field) if lane_field else None
+    project_lane = project_fields.get(lane_field) if lane_field else None
+    label_lane = preferred_lane_from_labels(issue.get("labels", [])) if not project_lane else None
+    preferred_lane = project_lane or label_lane
 
     for worktree in ROUTING_CONFIG["worktrees"]:
         score, reasons, explicit_matches = score_worktree(worktree, lowered_text, labels_text, explicit_paths, issue_class)
@@ -173,7 +187,10 @@ def route_worktree(issue: dict[str, Any], issue_class: str, explicit_paths: list
         preferred = next((item for item in ROUTING_CONFIG["worktrees"] if item["id"] == preferred_lane), None)
         if preferred:
             spans_multiple = len(explicit_candidates) > 1
-            reasons = [f"project field `{lane_field}` pinned worktree to `{preferred_lane}`"]
+            if project_lane:
+                reasons = [f"project field `{lane_field}` pinned worktree to `{preferred_lane}`"]
+            else:
+                reasons = [f"label `lane:{preferred_lane}` pinned worktree to `{preferred_lane}`"]
             if spans_multiple:
                 reasons.append("explicit file references span multiple worktrees; keep execution serialized")
             return (preferred, reasons, spans_multiple, sorted(explicit_candidates))
@@ -255,6 +272,7 @@ def build_issue_entry(issue: dict[str, Any]) -> dict[str, Any]:
     execution_mode_field = project_control_plane().get("execution_mode_field") if project_control_plane() else None
     if execution_mode_field and project_fields.get(execution_mode_field):
         validation_policy = apply_execution_mode_override(validation_policy, project_fields[execution_mode_field])
+    validation_policy = apply_issue_label_gates(validation_policy, issue.get("labels", []))
     portability = portability_preflight(
         issue,
         project_fields=project_fields,

--- a/.agents/skills/_functional-qa/scripts/issue_router.py
+++ b/.agents/skills/_functional-qa/scripts/issue_router.py
@@ -13,6 +13,7 @@ from typing import Any
 from qa_runtime import (
     apply_execution_mode_override,
     apply_issue_label_gates,
+    apply_issue_metadata_gate,
     CONFIG_ROOT,
     REPO_ROOT,
     artifact_root,
@@ -59,6 +60,7 @@ def normalize_issue(payload: dict[str, Any]) -> dict[str, Any]:
         "url": payload.get("url") or payload.get("html_url", ""),
         "labels": [label for label in normalized_labels if label],
         "issue_ref": payload.get("issue_ref"),
+        "metadata_resolution": payload.get("metadata_resolution"),
     }
 
 
@@ -281,6 +283,7 @@ def build_issue_entry(issue: dict[str, Any]) -> dict[str, Any]:
     if execution_mode_field and project_fields.get(execution_mode_field):
         validation_policy = apply_execution_mode_override(validation_policy, project_fields[execution_mode_field])
     validation_policy = apply_issue_label_gates(validation_policy, issue.get("labels", []))
+    validation_policy = apply_issue_metadata_gate(validation_policy, issue.get("metadata_resolution"))
     portability = portability_preflight(
         issue,
         project_fields=project_fields,
@@ -301,6 +304,7 @@ def build_issue_entry(issue: dict[str, Any]) -> dict[str, Any]:
         "issue_ref": issue_ref,
         "url": issue.get("url", ""),
         "labels": issue.get("labels", []),
+        "metadata_resolution": issue.get("metadata_resolution"),
         "project_fields": project_fields,
         "classification": classification,
         "evidence_plan": evidence_plan,

--- a/.agents/skills/_functional-qa/scripts/issue_router.py
+++ b/.agents/skills/_functional-qa/scripts/issue_router.py
@@ -183,15 +183,19 @@ def route_worktree(issue: dict[str, Any], issue_class: str, explicit_paths: list
             explicit_candidates.add(worktree["id"])
         scored.append((score, reasons, explicit_matches, worktree))
 
+    label_conflicts_with_paths = bool(label_lane and explicit_candidates and label_lane not in explicit_candidates)
+    project_conflicts_with_paths = bool(project_lane and explicit_candidates and project_lane not in explicit_candidates)
     if preferred_lane:
         preferred = next((item for item in ROUTING_CONFIG["worktrees"] if item["id"] == preferred_lane), None)
-        if preferred:
-            spans_multiple = len(explicit_candidates) > 1
+        if preferred and (project_lane or not label_conflicts_with_paths):
+            spans_multiple = len(explicit_candidates) > 1 or project_conflicts_with_paths
             if project_lane:
                 reasons = [f"project field `{lane_field}` pinned worktree to `{preferred_lane}`"]
             else:
                 reasons = [f"label `lane:{preferred_lane}` pinned worktree to `{preferred_lane}`"]
-            if spans_multiple:
+            if project_conflicts_with_paths:
+                reasons.append("project lane conflicts with explicit path ownership; keep execution serialized")
+            if len(explicit_candidates) > 1:
                 reasons.append("explicit file references span multiple worktrees; keep execution serialized")
             return (preferred, reasons, spans_multiple, sorted(explicit_candidates))
 
@@ -203,8 +207,10 @@ def route_worktree(issue: dict[str, Any], issue_class: str, explicit_paths: list
         worktree = next(item for item in ROUTING_CONFIG["worktrees"] if item["id"] == fallback_id)
         reasons = [f"no path or keyword hit; fell back to `{fallback_id}` for `{issue_class}`"]
 
-    spans_multiple = len(explicit_candidates) > 1
-    if spans_multiple:
+    spans_multiple = len(explicit_candidates) > 1 or label_conflicts_with_paths
+    if label_conflicts_with_paths:
+        reasons.append("lane label conflicts with explicit path ownership; keep execution serialized")
+    if len(explicit_candidates) > 1:
         reasons.append("explicit file references span multiple worktrees; keep execution serialized")
 
     return (worktree, reasons, spans_multiple, sorted(explicit_candidates))

--- a/.agents/skills/_functional-qa/scripts/issue_router.py
+++ b/.agents/skills/_functional-qa/scripts/issue_router.py
@@ -41,6 +41,7 @@ from qa_runtime import (
 
 ROUTING_CONFIG = load_json(CONFIG_ROOT / "worktree-routing.json")
 PATH_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9._-])"
     r"(?P<path>(?:\.[A-Za-z0-9_-]+|apps|packages|scripts|docs|infra|assets)/[A-Za-z0-9._/-]+)"
 )
 

--- a/.agents/skills/_functional-qa/scripts/issue_router.py
+++ b/.agents/skills/_functional-qa/scripts/issue_router.py
@@ -39,7 +39,9 @@ from qa_runtime import (
 
 
 ROUTING_CONFIG = load_json(CONFIG_ROOT / "worktree-routing.json")
-PATH_PATTERN = re.compile(r"(?P<path>(?:apps|packages|scripts|docs|infra|assets|\\.github)/[A-Za-z0-9._/-]+)")
+PATH_PATTERN = re.compile(
+    r"(?P<path>(?:\.[A-Za-z0-9_-]+|apps|packages|scripts|docs|infra|assets)/[A-Za-z0-9._/-]+)"
+)
 
 
 def normalize_issue(payload: dict[str, Any]) -> dict[str, Any]:

--- a/.agents/skills/_functional-qa/scripts/qa_runtime.py
+++ b/.agents/skills/_functional-qa/scripts/qa_runtime.py
@@ -339,15 +339,18 @@ def fetch_issue(target: str) -> dict[str, Any] | None:
     if parsed["kind"] != "github":
         return None
 
-    result = run_command(
-        [
-            "gh",
-            "api",
-            f"repos/{parsed['repo']}/issues/{parsed['number']}",
-        ],
-        allow_failure=True,
-    )
-    if result.returncode != 0:
+    try:
+        result = run_command(
+            [
+                "gh",
+                "api",
+                f"repos/{parsed['repo']}/issues/{parsed['number']}",
+            ],
+            allow_failure=True,
+        )
+    except FileNotFoundError:
+        result = None
+    if result is None or result.returncode != 0:
         fallback_labels = issue_fallback_labels(parsed["issue_ref"])
         return {
             "repo": parsed["repo"],

--- a/.agents/skills/_functional-qa/scripts/qa_runtime.py
+++ b/.agents/skills/_functional-qa/scripts/qa_runtime.py
@@ -1146,7 +1146,7 @@ def validation_gate_failures(run: dict[str, Any], evidence: dict[str, Any], *, f
     if policy.get("requires_live_model_for_fixed") and not validation.get("live_model_confirmed", False):
         failures.append("live-model validation is not confirmed")
 
-    if policy.get("human_review_required") and not validation.get("human_review_completed", False):
+    if for_fixed_claim and policy.get("human_review_required") and not validation.get("human_review_completed", False):
         failures.append("human review is not marked complete")
 
     for item in validation.get("missing_requirements", []):

--- a/.agents/skills/_functional-qa/scripts/qa_runtime.py
+++ b/.agents/skills/_functional-qa/scripts/qa_runtime.py
@@ -31,6 +31,10 @@ QUEUE_BLOCKING_LABELS = {
     "blocked-on-human",
     "do-not-merge",
     "pm:portability-gap",
+    "rucksack-blocked",
+    "rucksack-needs-decision",
+    "rucksack-needs-human",
+    "rucksack-provider-limited",
     "self-heal:exhausted",
 }
 
@@ -344,6 +348,7 @@ def fetch_issue(target: str) -> dict[str, Any] | None:
         allow_failure=True,
     )
     if result.returncode != 0:
+        fallback_labels = issue_fallback_labels(parsed["issue_ref"])
         return {
             "repo": parsed["repo"],
             "number": parsed["number"],
@@ -351,10 +356,10 @@ def fetch_issue(target: str) -> dict[str, Any] | None:
             "title": target if target != parsed["issue_ref"] else parsed["issue_ref"],
             "body": "",
             "html_url": f"https://github.com/{parsed['repo']}/issues/{parsed['number']}",
-            "labels": [],
+            "labels": fallback_labels,
             "created_at": None,
             "updated_at": None,
-            "metadata_resolution": "fallback-no-gh",
+            "metadata_resolution": "repo-adapter-fallback" if fallback_labels else "fallback-no-gh",
         }
 
     payload = json.loads(result.stdout)
@@ -368,6 +373,7 @@ def fetch_issue(target: str) -> dict[str, Any] | None:
         "labels": [label["name"] for label in payload.get("labels", [])],
         "created_at": payload.get("created_at"),
         "updated_at": payload.get("updated_at"),
+        "metadata_resolution": "github",
     }
 
 
@@ -510,6 +516,16 @@ def collect_issue_notes(issue_ref: str | None) -> list[str]:
     return notes
 
 
+def issue_fallback_labels(issue_ref: str | None) -> list[str]:
+    if not issue_ref:
+        return []
+    labels: list[str] = []
+    for item in REPO_ADAPTER.get("issue_notes", []):
+        if item["match"] in issue_ref:
+            labels.extend(str(label) for label in item.get("fallback_labels", []))
+    return unique_lines(labels)
+
+
 def issue_playbook(issue_ref: str | None) -> dict[str, Any] | None:
     if not issue_ref:
         return None
@@ -599,6 +615,26 @@ def apply_issue_label_gates(
     updated["stop_conditions"] = unique_lines(
         list(updated.get("stop_conditions", []))
         + [f"issue label `{label}` requires human resolution before fix or dispatch" for label in blocking]
+    )
+    return updated
+
+
+def apply_issue_metadata_gate(
+    validation_policy: dict[str, Any],
+    metadata_resolution: str | None,
+) -> dict[str, Any]:
+    if metadata_resolution != "fallback-no-gh":
+        return dict(validation_policy)
+
+    if validation_policy.get("execution_mode") in {"validate-and-propose-only", "needs-human-design-review"}:
+        updated = dict(validation_policy)
+    else:
+        updated = apply_execution_mode_override(validation_policy, "validate-and-propose-only")
+    updated["fix_allowed"] = False
+    updated["human_review_required"] = True
+    updated["stop_conditions"] = unique_lines(
+        list(updated.get("stop_conditions", []))
+        + ["GitHub issue metadata is unavailable and no repository fallback labels are configured; remote dispatch is blocked"]
     )
     return updated
 
@@ -1456,6 +1492,10 @@ def init_run(args: argparse.Namespace) -> int:
     validation_policy = apply_issue_label_gates(
         validation_policy,
         issue_payload.get("labels", []) if issue_payload else [],
+    )
+    validation_policy = apply_issue_metadata_gate(
+        validation_policy,
+        issue_payload.get("metadata_resolution") if issue_payload else None,
     )
     portability = portability_preflight(
         issue_payload or {"title": args.target, "body": ""},

--- a/.agents/skills/_functional-qa/scripts/qa_runtime.py
+++ b/.agents/skills/_functional-qa/scripts/qa_runtime.py
@@ -27,6 +27,12 @@ FIX_STATUSES = {"not-checked", "fixed", "still-reproduces", "inconclusive"}
 ISSUE_ACCURACY = {"accurate", "stale", "misdescribed", "n/a"}
 FIX_ALLOWED_EXECUTION_MODES = {"safe-unattended", "requires-live-model"}
 REVIEWER_PROOF_REQUIRED_CLASSES = {"interaction-input", "animation-transition", "async-streaming-state"}
+QUEUE_BLOCKING_LABELS = {
+    "blocked-on-human",
+    "do-not-merge",
+    "pm:portability-gap",
+    "self-heal:exhausted",
+}
 
 
 def load_json(path: Path) -> Any:
@@ -572,6 +578,28 @@ def apply_execution_mode_override(validation_policy: dict[str, Any], execution_m
     updated["execution_mode"] = execution_mode
     updated["fix_allowed"] = execution_mode in FIX_ALLOWED_EXECUTION_MODES
     updated["human_review_required"] = updated.get("human_review_required", False) or execution_mode == "needs-human-design-review"
+    return updated
+
+
+def apply_issue_label_gates(
+    validation_policy: dict[str, Any],
+    labels: list[str],
+) -> dict[str, Any]:
+    normalized = {label.strip().lower() for label in labels}
+    blocking = sorted(normalized & QUEUE_BLOCKING_LABELS)
+    if not blocking:
+        return dict(validation_policy)
+
+    if validation_policy.get("execution_mode") in {"validate-and-propose-only", "needs-human-design-review"}:
+        updated = dict(validation_policy)
+    else:
+        updated = apply_execution_mode_override(validation_policy, "validate-and-propose-only")
+    updated["fix_allowed"] = False
+    updated["human_review_required"] = True
+    updated["stop_conditions"] = unique_lines(
+        list(updated.get("stop_conditions", []))
+        + [f"issue label `{label}` requires human resolution before fix or dispatch" for label in blocking]
+    )
     return updated
 
 
@@ -1425,6 +1453,10 @@ def init_run(args: argparse.Namespace) -> int:
     execution_mode_field = project_control_plane().get("execution_mode_field") if project_control_plane() else None
     if execution_mode_field and project_fields.get(execution_mode_field):
         validation_policy = apply_execution_mode_override(validation_policy, project_fields[execution_mode_field])
+    validation_policy = apply_issue_label_gates(
+        validation_policy,
+        issue_payload.get("labels", []) if issue_payload else [],
+    )
     portability = portability_preflight(
         issue_payload or {"title": args.target, "body": ""},
         project_fields=project_fields,

--- a/.agents/skills/_functional-qa/scripts/qa_runtime.py
+++ b/.agents/skills/_functional-qa/scripts/qa_runtime.py
@@ -511,9 +511,19 @@ def collect_issue_notes(issue_ref: str | None) -> list[str]:
         return []
     notes: list[str] = []
     for item in REPO_ADAPTER.get("issue_notes", []):
-        if item["match"] in issue_ref:
+        if issue_ref_matches(issue_ref, item["match"]):
             notes.extend(item["notes"])
     return notes
+
+
+def issue_ref_matches(issue_ref: str | None, selector: object) -> bool:
+    normalized_ref = str(issue_ref or "").strip()
+    normalized_selector = str(selector or "").strip()
+    if not normalized_ref or not normalized_selector:
+        return False
+    if re.fullmatch(r"#\d+", normalized_selector):
+        return bool(re.fullmatch(rf"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+{re.escape(normalized_selector)}", normalized_ref))
+    return normalized_ref == normalized_selector
 
 
 def issue_fallback_labels(issue_ref: str | None) -> list[str]:
@@ -521,7 +531,7 @@ def issue_fallback_labels(issue_ref: str | None) -> list[str]:
         return []
     labels: list[str] = []
     for item in REPO_ADAPTER.get("issue_notes", []):
-        if item["match"] in issue_ref:
+        if issue_ref_matches(issue_ref, item["match"]):
             labels.extend(str(label) for label in item.get("fallback_labels", []))
     return unique_lines(labels)
 
@@ -530,7 +540,7 @@ def issue_playbook(issue_ref: str | None) -> dict[str, Any] | None:
     if not issue_ref:
         return None
     for item in REPO_ADAPTER.get("issue_playbooks", []):
-        if item["match"] in issue_ref:
+        if issue_ref_matches(issue_ref, item["match"]):
             return item
     return None
 
@@ -539,7 +549,7 @@ def classification_override(issue_ref: str | None) -> str | None:
     if not issue_ref:
         return None
     for item in REPO_ADAPTER.get("issue_notes", []):
-        if item["match"] in issue_ref:
+        if issue_ref_matches(issue_ref, item["match"]):
             return item.get("issue_class_override")
     return None
 

--- a/.agents/skills/_functional-qa/scripts/remote_agent_providers.py
+++ b/.agents/skills/_functional-qa/scripts/remote_agent_providers.py
@@ -85,6 +85,13 @@ class ProviderAdapter:
         return dict(self.config.get("capabilities") or {})
 
     def dispatch_eligibility(self, issue: dict[str, Any]) -> tuple[bool, str]:
+        validation_policy = issue.get("validation_policy") or {}
+        if validation_policy.get("fix_allowed") is False:
+            execution_mode = validation_policy.get("execution_mode", "validation-only")
+            return (
+                False,
+                f"validation policy '{execution_mode}' blocks remote dispatch until the human gate is resolved",
+            )
         if self.supports_dispatch():
             return (True, "")
         reason = self.placeholder_reason() or f"provider `{self.provider_id}` does not have a configured dispatch workflow yet"

--- a/.agents/skills/_functional-qa/scripts/remote_agent_providers.py
+++ b/.agents/skills/_functional-qa/scripts/remote_agent_providers.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from qa_runtime import CONFIG_ROOT, TEMPLATE_ROOT, load_json, run_command, slugify
+from qa_runtime import CONFIG_ROOT, TEMPLATE_ROOT, issue_ref_matches, load_json, run_command, slugify
 
 
 PROVIDER_REGISTRY = load_json(CONFIG_ROOT / "remote-agent-providers.json")
@@ -201,7 +201,7 @@ def select_provider_for_issue(
     for override in active_policy.get("issue_overrides", []):
         match = str(override.get("match") or "").strip()
         provider_id = str(override.get("provider") or "").strip().lower()
-        if match and issue_ref and match in issue_ref and provider_id:
+        if issue_ref_matches(issue_ref, match) and provider_id:
             normalize_requested_provider(provider_id)
             return ProviderSelection(provider_id, f"issue override `{match}`", "issue-override")
 

--- a/.agents/skills/_functional-qa/scripts/remote_agent_queue.py
+++ b/.agents/skills/_functional-qa/scripts/remote_agent_queue.py
@@ -13,6 +13,7 @@ from qa_runtime import (
     CONFIG_ROOT,
     artifact_root,
     format_portability_summary,
+    issue_ref_matches,
     load_json,
     render_portability_lines,
     repo_name_with_owner,
@@ -43,7 +44,7 @@ def override_for(issue_ref: str | None) -> dict[str, Any] | None:
     if not issue_ref:
         return None
     for item in CLOUD_CONFIG.get("issue_overrides", []):
-        if item["match"] in issue_ref:
+        if issue_ref_matches(issue_ref, item["match"]):
             return item
     return None
 
@@ -133,7 +134,7 @@ def configured_batch_for(issue_ref: str | None) -> str:
         return "unassigned"
     for batch in CLOUD_CONFIG.get("current_batches", []):
         for item in batch.get("issues", []):
-            if item in issue_ref:
+            if issue_ref_matches(issue_ref, item):
                 return batch["id"]
     return "unassigned"
 
@@ -143,7 +144,7 @@ def issue_order_value(issue_ref: str | None, batch_id: str) -> int:
         if batch["id"] != batch_id:
             continue
         for index, item in enumerate(batch.get("issues", [])):
-            if issue_ref and item in issue_ref:
+            if issue_ref_matches(issue_ref, item):
                 return index
         return 999
     return 999

--- a/.agents/skills/_functional-qa/scripts/remote_agent_queue.py
+++ b/.agents/skills/_functional-qa/scripts/remote_agent_queue.py
@@ -158,14 +158,14 @@ def queue_action_for(issue: dict[str, Any]) -> str:
     provider_name = issue.get("provider_display_name") or issue.get("provider") or "provider"
     if issue["cloud_mode"] == "local-only":
         return "skip remote execution for now"
-    if issue["batch_id"] == "unassigned":
-        return "hold for manual batching or split before dispatch"
-    if issue["depends_on"]:
-        return "launch after listed dependencies merge or are rebased into the task branch"
     if not issue["provider_dispatch_supported"]:
         if issue.get("provider_dispatch_reason"):
             return f"hold: {issue['provider_dispatch_reason']}"
         return f"hold until the `{provider_name}` adapter is configured for remote dispatch"
+    if issue["batch_id"] == "unassigned":
+        return "hold for manual batching or split before dispatch"
+    if issue["depends_on"]:
+        return "launch after listed dependencies merge or are rebased into the task branch"
     return f"launch a direct {provider_name} task and create a PR from the task result"
 
 
@@ -487,10 +487,10 @@ def build_launch_instructions(plan: dict[str, Any]) -> str:
         lines.append(f"# {issue['issue_ref'] or issue['title']}")
         if not is_dispatchable(issue):
             reason = issue["readiness_reason"]
-            if issue["batch_id"] == "unassigned":
-                reason = f"{reason} Keep this item out of the launch queue until it is explicitly batched or split into narrower tasks."
-            elif not issue["provider_dispatch_supported"]:
+            if not issue["provider_dispatch_supported"]:
                 reason = issue["provider_dispatch_reason"] or reason
+            elif issue["batch_id"] == "unassigned":
+                reason = f"{reason} Keep this item out of the launch queue until it is explicitly batched or split into narrower tasks."
             lines.append(f"1. Skip remote dispatch for `{issue['provider_display_name']}` for now.")
             lines.append(f"2. Reason: {reason}")
             lines.append("")

--- a/.agents/skills/_functional-qa/scripts/remote_agent_queue.py
+++ b/.agents/skills/_functional-qa/scripts/remote_agent_queue.py
@@ -162,6 +162,8 @@ def queue_action_for(issue: dict[str, Any]) -> str:
     if issue["depends_on"]:
         return "launch after listed dependencies merge or are rebased into the task branch"
     if not issue["provider_dispatch_supported"]:
+        if issue.get("provider_dispatch_reason"):
+            return f"hold: {issue['provider_dispatch_reason']}"
         return f"hold until the `{provider_name}` adapter is configured for remote dispatch"
     return f"launch a direct {provider_name} task and create a PR from the task result"
 
@@ -285,6 +287,7 @@ def build_queue_issue(raw_issue: dict[str, Any], queue_dir: Path, *, requested_p
 
     selection = select_provider_for_issue(issue_entry, requested_provider=requested_provider)
     adapter = get_provider_adapter(selection.provider)
+    dispatch_ready, dispatch_reason = adapter.dispatch_eligibility(issue_entry)
 
     issue_number = issue_entry.get("number")
     effective_title = issue_entry["title"]
@@ -326,7 +329,8 @@ def build_queue_issue(raw_issue: dict[str, Any], queue_dir: Path, *, requested_p
                 "depends_on": depends_on,
                 "provider": adapter.provider_id,
                 "provider_display_name": adapter.display_name,
-                "provider_dispatch_supported": adapter.supports_dispatch(),
+                "provider_dispatch_supported": dispatch_ready,
+                "provider_dispatch_reason": dispatch_reason,
             }
         ),
         "{{verification_instruction}}": verification_instruction_for(issue_entry),
@@ -365,7 +369,6 @@ def build_queue_issue(raw_issue: dict[str, Any], queue_dir: Path, *, requested_p
         encoding="utf-8",
     )
 
-    ready, provider_reason = adapter.dispatch_eligibility(issue_entry)
     return {
         **issue_entry,
         "cloud_mode": cloud_mode,
@@ -379,8 +382,8 @@ def build_queue_issue(raw_issue: dict[str, Any], queue_dir: Path, *, requested_p
         "provider_selection_reason": selection.reason,
         "provider_selection_source": selection.source,
         "provider_capabilities": adapter.capabilities(),
-        "provider_dispatch_supported": ready,
-        "provider_dispatch_reason": provider_reason,
+        "provider_dispatch_supported": dispatch_ready,
+        "provider_dispatch_reason": dispatch_reason,
         "branch_name": branch_name,
         "draft_pr_title": pr_title,
         "generated_files": {

--- a/.agents/skills/_functional-qa/scripts/test_issue_router.py
+++ b/.agents/skills/_functional-qa/scripts/test_issue_router.py
@@ -140,6 +140,34 @@ class IssueRouterLabelTests(unittest.TestCase):
         lanes = issue_router.build_parallel_lanes([entry])
         self.assertEqual(lanes[0]["lane_id"], "serialized-cross-boundary")
 
+    def test_hidden_qa_path_cannot_be_lost_to_stale_lane_label(self) -> None:
+        issue = {
+            "number": 361,
+            "title": "Repair functional QA routing",
+            "body": "Change .agents/skills/_functional-qa/scripts/issue_router.py.",
+            "url": "https://github.com/erniesg/tong/issues/361",
+            "labels": ["lane:server-api"],
+            "issue_ref": "erniesg/tong#361",
+        }
+        with (
+            mock.patch.object(issue_router, "fetch_project_overrides", return_value={}),
+            mock.patch.object(issue_router, "find_previous_run", return_value=None),
+        ):
+            entry = issue_router.build_issue_entry(issue)
+
+        self.assertIn(".agents/skills/_functional-qa/scripts/issue_router.py", entry["explicit_paths"])
+        self.assertEqual(entry["recommended_worktree"]["id"], "qa-platform")
+        self.assertEqual(entry["explicit_worktree_candidates"], ["qa-platform"])
+        self.assertTrue(entry["spans_multiple_worktrees"])
+        self.assertIn("conflicts with explicit path ownership", " ".join(entry["routing_reasons"]))
+        self.assertEqual(issue_router.build_parallel_lanes([entry])[0]["lane_id"], "serialized-cross-boundary")
+
+    def test_hidden_github_paths_are_extracted(self) -> None:
+        self.assertEqual(
+            issue_router.extract_paths("Update .github/ISSUE_TEMPLATE/bug.yml."),
+            [".github/ISSUE_TEMPLATE/bug.yml"],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.agents/skills/_functional-qa/scripts/test_issue_router.py
+++ b/.agents/skills/_functional-qa/scripts/test_issue_router.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import issue_router
+import qa_runtime
+
+
+def blocked_issue() -> dict[str, object]:
+    return {
+        "number": 359,
+        "title": "Archive API fixture backlog before automation resumes",
+        "body": "Compare API fixture PRs before any replacement is dispatched.",
+        "url": "https://github.com/erniesg/tong/issues/359",
+        "labels": ["blocked-on-human", "lane:qa-platform", "needs-consolidation"],
+        "issue_ref": "erniesg/tong#359",
+    }
+
+
+class IssueLabelGateTests(unittest.TestCase):
+    def test_blocked_on_human_is_a_non_weakenable_validation_floor(self) -> None:
+        policy = {
+            "execution_mode": "safe-unattended",
+            "fix_allowed": True,
+            "human_review_required": False,
+            "stop_conditions": [],
+        }
+
+        gated = qa_runtime.apply_issue_label_gates(policy, ["blocked-on-human"])
+
+        self.assertEqual(gated["execution_mode"], "validate-and-propose-only")
+        self.assertFalse(gated["fix_allowed"])
+        self.assertTrue(gated["human_review_required"])
+        self.assertIn("blocked-on-human", " ".join(gated["stop_conditions"]))
+
+    def test_all_documented_queue_skip_labels_disable_unattended_fixes(self) -> None:
+        for label in ("blocked-on-human", "do-not-merge", "pm:portability-gap", "self-heal:exhausted"):
+            with self.subTest(label=label):
+                gated = qa_runtime.apply_issue_label_gates(
+                    {
+                        "execution_mode": "safe-unattended",
+                        "fix_allowed": True,
+                        "human_review_required": False,
+                        "stop_conditions": [],
+                    },
+                    [label],
+                )
+
+                self.assertEqual(gated["execution_mode"], "validate-and-propose-only")
+                self.assertFalse(gated["fix_allowed"])
+                self.assertTrue(gated["human_review_required"])
+                self.assertIn(label, " ".join(gated["stop_conditions"]))
+
+
+class IssueRouterLabelTests(unittest.TestCase):
+    def test_blocking_and_lane_labels_override_keyword_fallbacks(self) -> None:
+        with (
+            mock.patch.object(issue_router, "fetch_project_overrides", return_value={}),
+            mock.patch.object(issue_router, "find_previous_run", return_value=None),
+        ):
+            entry = issue_router.build_issue_entry(blocked_issue())
+
+        self.assertEqual(entry["classification"]["issue_class"], "functional-logic")
+        self.assertEqual(entry["validation_policy"]["execution_mode"], "validate-and-propose-only")
+        self.assertFalse(entry["validation_policy"]["fix_allowed"])
+        self.assertTrue(entry["validation_policy"]["human_review_required"])
+        self.assertEqual(entry["recommended_worktree"]["id"], "qa-platform")
+        self.assertIn("label `lane:qa-platform`", " ".join(entry["routing_reasons"]))
+        self.assertNotIn("validate-issue --verify-fix", entry["follow_up_skills"])
+
+    def test_project_lane_remains_authoritative_over_lane_label(self) -> None:
+        issue = blocked_issue()
+        issue_ref = str(issue["issue_ref"])
+        with (
+            mock.patch.object(
+                issue_router,
+                "fetch_project_overrides",
+                return_value={issue_ref: {"Lane": "server-api"}},
+            ),
+            mock.patch.object(issue_router, "find_previous_run", return_value=None),
+        ):
+            entry = issue_router.build_issue_entry(issue)
+
+        self.assertEqual(entry["recommended_worktree"]["id"], "server-api")
+        self.assertIn("project field `Lane`", " ".join(entry["routing_reasons"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/skills/_functional-qa/scripts/test_issue_router.py
+++ b/.agents/skills/_functional-qa/scripts/test_issue_router.py
@@ -140,6 +140,16 @@ class IssueRouterLabelTests(unittest.TestCase):
         self.assertFalse(entry["validation_policy"]["fix_allowed"])
         self.assertEqual(entry["recommended_worktree"]["id"], "qa-platform")
 
+    def test_missing_gh_uses_repo_fallback_labels(self) -> None:
+        with mock.patch.object(qa_runtime, "run_command", side_effect=FileNotFoundError("gh")):
+            payload = qa_runtime.fetch_issue("erniesg/tong#359")
+
+        self.assertIsNotNone(payload)
+        self.assertEqual(payload["metadata_resolution"], "repo-adapter-fallback")
+        self.assertIn("blocked-on-human", payload["labels"])
+        self.assertIn("lane:qa-platform", payload["labels"])
+        self.assertIn("rucksack-blocked", payload["labels"])
+
     def test_blocking_and_lane_labels_override_keyword_fallbacks(self) -> None:
         with (
             mock.patch.object(issue_router, "fetch_project_overrides", return_value={}),

--- a/.agents/skills/_functional-qa/scripts/test_issue_router.py
+++ b/.agents/skills/_functional-qa/scripts/test_issue_router.py
@@ -213,6 +213,18 @@ class IssueRouterLabelTests(unittest.TestCase):
             [".github/ISSUE_TEMPLATE/bug.yml"],
         )
 
+    def test_hidden_paths_are_normalized_from_github_urls(self) -> None:
+        self.assertEqual(
+            issue_router.extract_paths(
+                "Review https://github.com/erniesg/tong/blob/main/.agents/skills/_functional-qa/scripts/issue_router.py "
+                "and https://github.com/erniesg/tong/blob/main/.github/workflows/issue-queue-orchestrator.yml."
+            ),
+            [
+                ".agents/skills/_functional-qa/scripts/issue_router.py",
+                ".github/workflows/issue-queue-orchestrator.yml",
+            ],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.agents/skills/_functional-qa/scripts/test_issue_router.py
+++ b/.agents/skills/_functional-qa/scripts/test_issue_router.py
@@ -29,6 +29,13 @@ def blocked_issue() -> dict[str, object]:
 
 
 class IssueLabelGateTests(unittest.TestCase):
+    def test_issue_ref_selectors_do_not_match_longer_issue_numbers(self) -> None:
+        self.assertTrue(qa_runtime.issue_ref_matches("erniesg/tong#359", "#359"))
+        self.assertTrue(qa_runtime.issue_ref_matches("erniesg/tong#359", "erniesg/tong#359"))
+        self.assertFalse(qa_runtime.issue_ref_matches("erniesg/tong#3590", "#359"))
+        self.assertFalse(qa_runtime.issue_ref_matches("erniesg/other#359", "erniesg/tong#359"))
+        self.assertEqual(qa_runtime.issue_fallback_labels("erniesg/tong#3590"), [])
+
     def test_blocked_on_human_is_a_non_weakenable_validation_floor(self) -> None:
         policy = {
             "execution_mode": "safe-unattended",

--- a/.agents/skills/_functional-qa/scripts/test_issue_router.py
+++ b/.agents/skills/_functional-qa/scripts/test_issue_router.py
@@ -61,6 +61,31 @@ class IssueLabelGateTests(unittest.TestCase):
                 self.assertTrue(gated["human_review_required"])
                 self.assertIn(label, " ".join(gated["stop_conditions"]))
 
+    def test_human_review_gate_blocks_fixed_claims_not_validation_updates(self) -> None:
+        run = {
+            "classification": {"issue_class": "functional-logic"},
+            "validation_policy": {
+                "execution_mode": "validate-and-propose-only",
+                "human_review_required": True,
+                "requires_direct_issue_evidence": False,
+                "ui_acceptance_required": False,
+                "required_runtime_modes_for_fixed": [],
+                "requires_live_model_for_fixed": False,
+            },
+        }
+        evidence = {
+            "validation": {
+                "human_review_completed": False,
+                "missing_requirements": [],
+            }
+        }
+
+        validation_failures = qa_runtime.validation_gate_failures(run, evidence, for_fixed_claim=False)
+        fixed_failures = qa_runtime.validation_gate_failures(run, evidence, for_fixed_claim=True)
+
+        self.assertNotIn("human review is not marked complete", validation_failures)
+        self.assertIn("human review is not marked complete", fixed_failures)
+
 
 class IssueRouterLabelTests(unittest.TestCase):
     def test_blocking_and_lane_labels_override_keyword_fallbacks(self) -> None:

--- a/.agents/skills/_functional-qa/scripts/test_issue_router.py
+++ b/.agents/skills/_functional-qa/scripts/test_issue_router.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sys
+import subprocess
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -44,7 +45,16 @@ class IssueLabelGateTests(unittest.TestCase):
         self.assertIn("blocked-on-human", " ".join(gated["stop_conditions"]))
 
     def test_all_documented_queue_skip_labels_disable_unattended_fixes(self) -> None:
-        for label in ("blocked-on-human", "do-not-merge", "pm:portability-gap", "self-heal:exhausted"):
+        for label in (
+            "blocked-on-human",
+            "do-not-merge",
+            "pm:portability-gap",
+            "rucksack-blocked",
+            "rucksack-needs-decision",
+            "rucksack-needs-human",
+            "rucksack-provider-limited",
+            "self-heal:exhausted",
+        ):
             with self.subTest(label=label):
                 gated = qa_runtime.apply_issue_label_gates(
                     {
@@ -60,6 +70,21 @@ class IssueLabelGateTests(unittest.TestCase):
                 self.assertFalse(gated["fix_allowed"])
                 self.assertTrue(gated["human_review_required"])
                 self.assertIn(label, " ".join(gated["stop_conditions"]))
+
+    def test_missing_github_metadata_without_repo_fallback_fails_closed(self) -> None:
+        policy = {
+            "execution_mode": "safe-unattended",
+            "fix_allowed": True,
+            "human_review_required": False,
+            "stop_conditions": [],
+        }
+
+        gated = qa_runtime.apply_issue_metadata_gate(policy, "fallback-no-gh")
+
+        self.assertEqual(gated["execution_mode"], "validate-and-propose-only")
+        self.assertFalse(gated["fix_allowed"])
+        self.assertTrue(gated["human_review_required"])
+        self.assertIn("metadata is unavailable", " ".join(gated["stop_conditions"]))
 
     def test_human_review_gate_blocks_fixed_claims_not_validation_updates(self) -> None:
         run = {
@@ -88,6 +113,26 @@ class IssueLabelGateTests(unittest.TestCase):
 
 
 class IssueRouterLabelTests(unittest.TestCase):
+    def test_offline_issue_resolution_uses_repo_fallback_labels(self) -> None:
+        unavailable = subprocess.CompletedProcess(args=["gh"], returncode=1, stdout="", stderr="offline")
+        with (
+            mock.patch.object(qa_runtime, "run_command", return_value=unavailable),
+            mock.patch.object(issue_router, "fetch_project_overrides", return_value={}),
+            mock.patch.object(issue_router, "find_previous_run", return_value=None),
+        ):
+            source, issues = issue_router.resolve_targets(["erniesg/tong#359"], limit=1)
+            entry = issue_router.build_issue_entry(issues[0])
+
+        self.assertEqual(source, "explicit-targets")
+        self.assertEqual(issues[0]["metadata_resolution"], "repo-adapter-fallback")
+        self.assertEqual(entry["metadata_resolution"], "repo-adapter-fallback")
+        self.assertIn("blocked-on-human", entry["labels"])
+        self.assertIn("lane:qa-platform", entry["labels"])
+        self.assertIn("rucksack-blocked", entry["labels"])
+        self.assertEqual(entry["validation_policy"]["execution_mode"], "validate-and-propose-only")
+        self.assertFalse(entry["validation_policy"]["fix_allowed"])
+        self.assertEqual(entry["recommended_worktree"]["id"], "qa-platform")
+
     def test_blocking_and_lane_labels_override_keyword_fallbacks(self) -> None:
         with (
             mock.patch.object(issue_router, "fetch_project_overrides", return_value={}),

--- a/.agents/skills/_functional-qa/scripts/test_issue_router.py
+++ b/.agents/skills/_functional-qa/scripts/test_issue_router.py
@@ -119,6 +119,27 @@ class IssueRouterLabelTests(unittest.TestCase):
         self.assertEqual(entry["recommended_worktree"]["id"], "server-api")
         self.assertIn("project field `Lane`", " ".join(entry["routing_reasons"]))
 
+    def test_lane_label_cannot_override_explicit_path_ownership(self) -> None:
+        issue = {
+            "number": 358,
+            "title": "Update API route",
+            "body": "Change apps/server/api/profile.ts.",
+            "url": "https://github.com/erniesg/tong/issues/358",
+            "labels": ["lane:qa-platform"],
+            "issue_ref": "erniesg/tong#358",
+        }
+        with (
+            mock.patch.object(issue_router, "fetch_project_overrides", return_value={}),
+            mock.patch.object(issue_router, "find_previous_run", return_value=None),
+        ):
+            entry = issue_router.build_issue_entry(issue)
+
+        self.assertEqual(entry["recommended_worktree"]["id"], "server-api")
+        self.assertTrue(entry["spans_multiple_worktrees"])
+        self.assertIn("conflicts with explicit path ownership", " ".join(entry["routing_reasons"]))
+        lanes = issue_router.build_parallel_lanes([entry])
+        self.assertEqual(lanes[0]["lane_id"], "serialized-cross-boundary")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.agents/skills/_functional-qa/scripts/test_remote_agent_orchestration.py
+++ b/.agents/skills/_functional-qa/scripts/test_remote_agent_orchestration.py
@@ -27,6 +27,11 @@ def sample_issue(*, lane: str = "qa-platform", execution_mode: str = "safe-unatt
 
 
 class ProviderSelectionTests(unittest.TestCase):
+    def test_current_batch_ids_are_unique(self) -> None:
+        batch_ids = [batch["id"] for batch in remote_agent_queue.CLOUD_CONFIG["current_batches"]]
+
+        self.assertEqual(len(batch_ids), len(set(batch_ids)))
+
     def test_select_provider_uses_default_policy(self) -> None:
         selection = remote_agent_providers.select_provider_for_issue(
             sample_issue(),

--- a/.agents/skills/_functional-qa/scripts/test_remote_agent_orchestration.py
+++ b/.agents/skills/_functional-qa/scripts/test_remote_agent_orchestration.py
@@ -148,6 +148,32 @@ class DispatchSummaryTests(unittest.TestCase):
         self.assertFalse(remote_agent_queue.is_dispatchable(issue))
         self.assertIn("blocks remote dispatch", remote_agent_queue.queue_action_for(issue))
 
+    def test_validation_gate_precedes_batching_guidance(self) -> None:
+        gate_reason = "issue label `blocked-on-human` requires human resolution before remote dispatch"
+        issue = {
+            "issue_ref": "erniesg/tong#359",
+            "title": "Archive and consolidate the open PR backlog before automation resumes",
+            "cloud_mode": "cloud-ready",
+            "batch_id": "unassigned",
+            "depends_on": [],
+            "provider": "codex",
+            "provider_display_name": "Codex",
+            "provider_dispatch_supported": False,
+            "provider_dispatch_reason": gate_reason,
+            "readiness_reason": "Repo context is portable.",
+        }
+
+        self.assertEqual(remote_agent_queue.queue_action_for(issue), f"hold: {gate_reason}")
+        launch = remote_agent_queue.build_launch_instructions(
+            {
+                "default_provider": "codex",
+                "requested_provider": "codex",
+                "issues": [issue],
+            }
+        )
+        self.assertIn(gate_reason, launch)
+        self.assertNotIn("explicitly batched", launch)
+
     def test_dispatcher_skips_validation_only_issue(self) -> None:
         issue = {
             "issue_ref": "erniesg/tong#359",

--- a/.agents/skills/_functional-qa/scripts/test_remote_agent_orchestration.py
+++ b/.agents/skills/_functional-qa/scripts/test_remote_agent_orchestration.py
@@ -75,6 +75,20 @@ class ProviderSelectionTests(unittest.TestCase):
         self.assertEqual(selection.provider, "claude")
         self.assertEqual(selection.source, "request")
 
+    def test_issue_provider_override_does_not_match_longer_issue_number(self) -> None:
+        selection = remote_agent_providers.select_provider_for_issue(
+            {**sample_issue(), "issue_ref": "erniesg/tong#2920"},
+            policy={
+                "default_provider": "codex",
+                "lane_overrides": {},
+                "execution_mode_overrides": {},
+                "issue_overrides": [{"match": "#292", "provider": "claude"}],
+            },
+        )
+
+        self.assertEqual(selection.provider, "codex")
+        self.assertEqual(selection.source, "policy")
+
 
 class CommentParsingTests(unittest.TestCase):
     def test_parse_comment_command_accepts_repo_native_prefix(self) -> None:
@@ -106,6 +120,12 @@ class CommentParsingTests(unittest.TestCase):
 
 
 class DispatchSummaryTests(unittest.TestCase):
+    def test_cloud_overrides_and_batches_use_exact_issue_numbers(self) -> None:
+        self.assertIsNotNone(remote_agent_queue.override_for("erniesg/tong#11"))
+        self.assertIsNone(remote_agent_queue.override_for("erniesg/tong#110"))
+        self.assertEqual(remote_agent_queue.configured_batch_for("erniesg/tong#11"), "batch-2")
+        self.assertEqual(remote_agent_queue.configured_batch_for("erniesg/tong#110"), "unassigned")
+
     def test_validation_only_issue_is_not_remotely_dispatchable(self) -> None:
         issue = {
             "cloud_mode": "cloud-ready",

--- a/.agents/skills/_functional-qa/scripts/test_remote_agent_orchestration.py
+++ b/.agents/skills/_functional-qa/scripts/test_remote_agent_orchestration.py
@@ -129,7 +129,7 @@ class DispatchSummaryTests(unittest.TestCase):
     def test_validation_only_issue_is_not_remotely_dispatchable(self) -> None:
         issue = {
             "cloud_mode": "cloud-ready",
-            "batch_id": "batch-1",
+            "batch_id": "unassigned",
             "depends_on": [],
             "provider": "codex",
             "provider_display_name": "Codex",

--- a/.agents/skills/_functional-qa/scripts/test_remote_agent_orchestration.py
+++ b/.agents/skills/_functional-qa/scripts/test_remote_agent_orchestration.py
@@ -13,6 +13,7 @@ if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
 
 import dispatch_issue_queue
+import remote_agent_queue
 import remote_agent_providers
 import resolve_issue_queue_request
 
@@ -100,6 +101,58 @@ class CommentParsingTests(unittest.TestCase):
 
 
 class DispatchSummaryTests(unittest.TestCase):
+    def test_validation_only_issue_is_not_remotely_dispatchable(self) -> None:
+        issue = {
+            "cloud_mode": "cloud-ready",
+            "batch_id": "batch-1",
+            "depends_on": [],
+            "provider": "codex",
+            "provider_display_name": "Codex",
+            "provider_dispatch_supported": False,
+            "provider_dispatch_reason": "validation policy 'validate-and-propose-only' blocks remote dispatch",
+            "validation_policy": {
+                "execution_mode": "validate-and-propose-only",
+                "fix_allowed": False,
+            },
+        }
+
+        ready, reason = remote_agent_providers.get_provider_adapter("codex").dispatch_eligibility(issue)
+
+        self.assertFalse(ready)
+        self.assertIn("blocks remote dispatch", reason)
+        self.assertFalse(remote_agent_queue.is_dispatchable(issue))
+        self.assertIn("blocks remote dispatch", remote_agent_queue.queue_action_for(issue))
+
+    def test_dispatcher_skips_validation_only_issue(self) -> None:
+        issue = {
+            "issue_ref": "erniesg/tong#359",
+            "title": "Archive API fixture backlog before automation resumes",
+            "cloud_mode": "cloud-ready",
+            "batch_id": "batch-1",
+            "depends_on": [],
+            "provider": "codex",
+            "branch_name": "codex/issue-359-planner-gates",
+            "validation_policy": {
+                "execution_mode": "validate-and-propose-only",
+                "fix_allowed": False,
+            },
+        }
+        plan = {"repository": "erniesg/tong", "default_provider": "codex", "issues": [issue]}
+
+        with mock.patch.object(dispatch_issue_queue, "list_open_prs", return_value={}):
+            summary = dispatch_issue_queue.build_dispatch_summary(
+                plan,
+                Path("/tmp/queue"),
+                plan_path=Path("/tmp/queue/queue-plan.json"),
+                action="queue",
+                issue_ref="",
+                max_dispatches=1,
+                dry_run=True,
+            )
+
+        self.assertEqual(summary["counts"], {"considered": 1, "dispatched": 0, "skipped": 1})
+        self.assertIn("blocks remote dispatch", summary["skipped"][0]["reason"])
+
     def test_build_summary_markdown_lists_provider_per_issue(self) -> None:
         markdown = dispatch_issue_queue.build_summary_markdown(
             {


### PR DESCRIPTION
## Summary

- treat `blocked-on-human`, `do-not-merge`, `pm:portability-gap`, and `self-heal:exhausted` as a non-weakenable validation-only floor
- block validation-only and human-gated issues at provider eligibility, generated launch instructions, and final dispatch
- honor one valid `lane:*` label as the worktree fallback when the GitHub Project `Lane` field is absent
- preserve `.agents/...`, `.github/...`, and other safe hidden top-level paths as explicit ownership evidence
- keep explicit path ownership ahead of conflicting lane labels and serialize the mismatch
- keep Project `Lane` authoritative while serializing conflicts with explicit ownership
- classify #359 as archival/control-plane `functional-logic` instead of API fixture work
- allow evidence-only updates for blocked issues while still requiring human review before any fixed claim
- cover policy, ownership, precedence, conflict serialization, publication, planning, and dispatch gates with deterministic unit tests

## How to test

```bash
python -m unittest discover -s .agents/skills/_functional-qa/scripts -p "test_*.py"
python -m compileall -q .agents/skills/_functional-qa/scripts
python -m json.tool .agents/skills/_functional-qa/config/repo-adapter.json >/dev/null
python .agents/skills/_functional-qa/scripts/issue_router.py plan 359 --json
python .agents/skills/_functional-qa/scripts/remote_agent_queue.py plan 359 --provider codex --json
```

Expected live route for #359: `functional-logic`, `validate-and-propose-only`, `fix_allowed=false`, `human_review_required=true`, and `qa-platform`. Expected remote plan: `provider_dispatch_supported=false` with a human-gate reason and “Skip remote dispatch” launch instructions.

## Evidence and caveats

- 18 functional-QA Python tests pass.
- The pre-fix live plan reproduced `safe-unattended` plus `server-api`; the post-fix live plan no longer does.
- Codex path-conflict review finding is repaired in `a03165d` with an explicit serialization regression.
- Codex remote-dispatch review finding is repaired in `7a2f901` with planning and dispatcher regressions.
- Codex hidden-path ownership review finding is repaired in `82bc2dd` with `.agents/...` and `.github/...` regressions.
- Structured validation update: https://github.com/erniesg/tong/issues/359#issuecomment-4952876739
- `npm run demo:smoke` still fails on current `main` because `/assets/app/tong_opening.mp4` is absent. This patch does not touch runtime assets or smoke validation; closed issue #38 remains correctly enforced.
- Functional-QA run bundles remain gitignored local staging artifacts; no secrets or generated media are committed.
- This is a partial control-plane repair. It does not complete or close #359, approve consolidation groupings, delete branches, close PRs, or resume automation.

Refs #359
