### PR TITLE
fix(autofix): check HTTP response status before reporting success

### DIFF
--- a/apps/client/app/api/ai/translate/route.ts
+++ b/apps/client/app/api/ai/translate/route.ts
@@ -30,7 +30,12 @@ async function googleTranslate(text: string, from: string, to: string): Promise<
 }
 
 export async function POST(req: Request) {
-  const body = await req.json();
+  let body: Record<string, unknown>;
+  try {
+    body = await req.json();
+  } catch {
+    return Response.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
   const { words, from, to } = body as {
     words: string[];
     from: string;
@@ -57,6 +62,6 @@ export async function POST(req: Request) {
     return Response.json({ translations: result });
   } catch (e) {
     console.error('[translate] error:', e);
-    return Response.json({ translations: {} }, { status: 200 });
+    return Response.json({ error: 'Translation failed', translations: {} }, { status: 502 });
   }
 }

--- a/apps/client/app/backstage/director/page.tsx
+++ b/apps/client/app/backstage/director/page.tsx
@@ -153,15 +153,18 @@ export default function BackstagePage() {
     if (!exported) return;
     try {
       const serverUrl = process.env.NEXT_PUBLIC_TONG_SERVER_URL || 'http://localhost:8787';
-      await fetch(`${serverUrl}/api/v1/director/publish`, {
+      const res = await fetch(`${serverUrl}/api/v1/director/publish`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ pipelineId: activePipeline.id, ...exported }),
       });
+      if (!res.ok) {
+        console.error('Publish failed:', res.status);
+        return;
+      }
       markPublished(activePipeline.id);
     } catch (err) {
       console.error('Publish failed:', err);
-      markPublished(activePipeline.id);
     }
   }, [activePipeline]);
 

--- a/apps/client/app/page.tsx
+++ b/apps/client/app/page.tsx
@@ -149,7 +149,7 @@ function LandingPage() {
     clearTimeout(saveTimer.current);
     saveTimer.current = setTimeout(async () => {
       try {
-        await fetch(`${API_BASE}/api/v1/signup/preferences`, {
+        const res = await fetch(`${API_BASE}/api/v1/signup/preferences`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
@@ -158,6 +158,10 @@ function LandingPage() {
             explainIn: { ...ex },
           }),
         });
+        if (!res.ok) {
+          showToast('Could not save — try again');
+          return;
+        }
         setPrefsWereSaved(true);
         showToast('Saved');
       } catch {

--- a/apps/client/components/playtest/PlaytestWrapper.tsx
+++ b/apps/client/components/playtest/PlaytestWrapper.tsx
@@ -55,10 +55,16 @@ export function PlaytestWrapper({ children }: { children: React.ReactNode }) {
 
       try {
         setUploading(true);
-        await fetch(`${API_BASE}/api/v1/playtest/sessions/${sessionId}/upload`, {
+        const res = await fetch(`${API_BASE}/api/v1/playtest/sessions/${sessionId}/upload`, {
           method: 'POST',
           body: formData,
         });
+
+        if (!res.ok) {
+          console.error('Playtest upload failed:', res.status, await res.text().catch(() => ''));
+          setUploading(false);
+          return;
+        }
 
         sessionStorage.removeItem('tong_playtest_session');
         setUploading(false);


### PR DESCRIPTION
## Summary

- **translate/route.ts**: Add try/catch on `req.json()` for malformed input (returns 400 instead of unhandled exception); return 502 instead of 200 when translation fails so callers can distinguish errors from empty results
- **PlaytestWrapper.tsx**: Check `res.ok` before clearing sessionStorage and showing "submitted" — prevents silent data loss when upload returns a server error
- **director/page.tsx**: Remove `markPublished()` call from the catch block — previously marked pipelines as published even when the publish request failed
- **page.tsx**: Check `res.ok` before showing "Saved" toast for preferences — previously showed success even on server errors

## Test plan

- [ ] Verify `npx tsc --noEmit` passes (confirmed in pipeline)
- [ ] Manually test playtest upload with a failing endpoint to confirm error is surfaced
- [ ] Verify preferences save shows error toast on non-200 response
- [ ] Confirm director publish does not mark as published on failure

Auto-fix from daily pipeline run 2026-07-16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011hHi8AkCspEwN4EpYwxgEg

---
_Generated by [Claude Code](https://claude.ai/code/session_011hHi8AkCspEwN4EpYwxgEg)_